### PR TITLE
update links to new samples repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ with `http://docs.microsoft.com/dotnet/articles`.
 
 Your topic will also contain links to the sample. Link directly to the sample's folder on GitHub.
 
-For more information, see the [Samples Readme](https://github.com/dotnet/docs/blob/master/samples/README.md).
+For more information, see the [Samples Readme](https://github.com/dotnet/samples/blob/master/samples/README.md).
 
 ## DOs and DON'Ts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ with `http://docs.microsoft.com/dotnet/articles`.
 
 Your topic will also contain links to the sample. Link directly to the sample's folder on GitHub.
 
-For more information, see the [Samples Readme](https://github.com/dotnet/samples/blob/master/samples/README.md).
+For more information, see the [Samples Readme](https://github.com/dotnet/samples/blob/master/README.md).
 
 ## DOs and DON'Ts
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We will have a CI system in place to build these projects shortly.
 
 To create a sample:
 
-1. File an [issue](https://github.com/dotnet/docs/issues) or add a comment to an existing one that you are working on it.
+1. File an [issue](https://github.com/dotnet/samples/issues) or add a comment to an existing one that you are working on it.
 2. Write the topic that explains the concepts demonstrated in your sample (example: `docs/standard/linq/where-clause.md`) 
 3. Write your sample (example: `WhereClause-Sample1.cs`)
 4. Create a Program.cs with a Main entry point that calls your samples. If there is already one there, add the call to your sample:

--- a/framework/libraries/README.md
+++ b/framework/libraries/README.md
@@ -39,7 +39,7 @@ And that's it!
 
 The project under `/new-library` targets **only** .NET Core. For that reason,
 this project is stored under the core project directory, so our build server builds it on
-all platforms. Look under https://github.com/dotnet/docs/tree/master/samples/core/libraries/new-library/.
+all platforms. Look under https://github.com/dotnet/samples/tree/master/samples/core/libraries/new-library/.
 
 It demonstrates two other things: how to use multiple projects, and how to test.
 

--- a/framework/libraries/README.md
+++ b/framework/libraries/README.md
@@ -39,7 +39,7 @@ And that's it!
 
 The project under `/new-library` targets **only** .NET Core. For that reason,
 this project is stored under the core project directory, so our build server builds it on
-all platforms. Look under https://github.com/dotnet/samples/tree/master/samples/core/libraries/new-library/.
+all platforms. Look under https://github.com/dotnet/samples/tree/master/core/libraries/new-library/.
 
 It demonstrates two other things: how to use multiple projects, and how to test.
 


### PR DESCRIPTION
Links that pointed to source on GitHub in the docs repo have been updated to the samples repo, where appropriate.

First of three PRs to fix dotnet/docs#4821

