### PR TITLE
Fix HttpClientHandler sample spacing

### DIFF
--- a/snippets/csharp/VS_Snippets_Misc/system.net.http.httpclienthandler/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_Misc/system.net.http.httpclienthandler/cs/source.cs
@@ -7,7 +7,7 @@ class HttpClientHandler_Example
 {
 // <Snippet1>
    static async void Main()
-	 {
+   {
       // Create an HttpClientHandler object and set to use default credentials
       HttpClientHandler handler = new HttpClientHandler();
       handler.UseDefaultCredentials = true;
@@ -24,17 +24,17 @@ class HttpClientHandler_Example
 
          string responseBody = await response.Content.ReadAsStringAsync();
          Console.WriteLine(responseBody);
-       }  
-       catch(HttpRequestException e)
-       {
+      }  
+      catch(HttpRequestException e)
+      {
           Console.WriteLine("\nException Caught!");	
           Console.WriteLine("Message :{0} ",e.Message);
-       }
+      }
 
-       // Need to call dispose on the HttpClient and HttpClientHandler objects 
-       // when done using them, so the app doesn't leak resources
-       handler.Dispose(true);
-       client.Dispose(true);
+      // Need to call dispose on the HttpClient and HttpClientHandler objects 
+      // when done using them, so the app doesn't leak resources
+      handler.Dispose(true);
+      client.Dispose(true);
    }
 // </Snippet1>			
 }


### PR DESCRIPTION
Fix HttpClientHandler sample spacing

Primary reason: Attempt to fix weird 'space' before `static async void Main()` in the [HttpClientHandler sample](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclienthandler?view=netcore-2.0).
Not sure if it is going to help though.