### PR TITLE
Renamed sumOfSquares() to squaresOfOdds() in f# unittest samples ...

### DIFF
--- a/core/getting-started/unit-testing-with-fsharp-mstest/MathService.Tests/Tests.fs
+++ b/core/getting-started/unit-testing-with-fsharp-mstest/MathService.Tests/Tests.fs
@@ -17,17 +17,17 @@ type TestClass () =
     [<TestMethod>]
     member this.TestEvenSequence() = 
         let expected = Seq.empty<int> |> Seq.toList
-        let actual = MyMath.sumOfSquares [2; 4; 6; 8; 10]
+        let actual = MyMath.squaresOfOdds [2; 4; 6; 8; 10]
         Assert.AreEqual(expected, actual)
 
     [<TestMethod>]
-    member public this.SumOnesAndEvens() =
+    member public this.TestOnesAndEvens() =
         let expected = [1; 1; 1; 1]
-        let actual = MyMath.sumOfSquares [2; 1; 4; 1; 6; 1; 8; 1; 10]
+        let actual = MyMath.squaresOfOdds [2; 1; 4; 1; 6; 1; 8; 1; 10]
         Assert.AreEqual(expected, actual)
 
     [<TestMethod>]
     member public this.TestSquaresOfOdds() =
         let expected = [1; 9; 25; 49; 81]
-        let actual = MyMath.sumOfSquares [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
+        let actual = MyMath.squaresOfOdds [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
         Assert.AreEqual(expected, actual)

--- a/core/getting-started/unit-testing-with-fsharp-mstest/MathService/Library.fs
+++ b/core/getting-started/unit-testing-with-fsharp-mstest/MathService/Library.fs
@@ -4,7 +4,7 @@ module MyMath =
     let private square x = x * x
     let private isOdd x = x % 2 <> 0
 
-    let sumOfSquares xs = 
+    let squaresOfOdds xs = 
         xs 
         |> Seq.filter isOdd 
         |> Seq.map square

--- a/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/Tests.fs
+++ b/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/Tests.fs
@@ -14,19 +14,19 @@ let ``My test`` () =
 
 
 [<Test>]
-let ``Sum of evens returns empty collection`` () =
+let ``Sequence of Evens returns empty collection`` () =
     let expected = Seq.empty<int>
-    let actual = MyMath.sumOfSquares [2; 4; 6; 8; 10]
+    let actual = MyMath.squaresOfOdds [2; 4; 6; 8; 10]
     Assert.That(actual, Is.EqualTo(expected))
 
 [<Test>]
-let ``Sum of sequences of Ones and Evens`` () =
+let ``Sequence of Ones and Evens return Ones`` () =
     let expected = [1; 1; 1; 1]
-    let actual = MyMath.sumOfSquares [2; 1; 4; 1; 6; 1; 8; 1; 10]
+    let actual = MyMath.squaresOfOdds [2; 1; 4; 1; 6; 1; 8; 1; 10]
     Assert.That(actual, Is.EqualTo(expected))
 
 [<Test>]
 let ``SquaresOfOdds works`` () =
     let expected = [1; 9; 25; 49; 81]
-    let actual = MyMath.sumOfSquares [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
+    let actual = MyMath.squaresOfOdds [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
     Assert.That(actual, Is.EqualTo(expected))

--- a/core/getting-started/unit-testing-with-fsharp-nunit/MathService/Library.fs
+++ b/core/getting-started/unit-testing-with-fsharp-nunit/MathService/Library.fs
@@ -4,7 +4,7 @@ module MyMath =
     let private square x = x * x
     let private isOdd x = x % 2 <> 0
 
-    let sumOfSquares xs = 
+    let squaresOfOdds xs = 
         xs 
         |> Seq.filter isOdd 
         |> Seq.map square

--- a/core/getting-started/unit-testing-with-fsharp/MathService.Tests/Tests.fs
+++ b/core/getting-started/unit-testing-with-fsharp/MathService.Tests/Tests.fs
@@ -14,19 +14,19 @@ let ``My test`` () =
 
 
 [<Fact>]
-let ``Sum of evens returns empty collection`` () =
+let ``Sequence of Evens returns empty collection`` () =
     let expected = Seq.empty<int>
-    let actual = MyMath.sumOfSquares [2; 4; 6; 8; 10]
+    let actual = MyMath.squaresOfOdds [2; 4; 6; 8; 10]
     Assert.Equal<Collections.Generic.IEnumerable<int>>(expected, actual)
 
 [<Fact>]
-let ``Sum of sequences of Ones and Evens`` () =
+let ``Sequence of Ones and Evens returns Ones`` () =
     let expected = [1; 1; 1; 1]
-    let actual = MyMath.sumOfSquares [2; 1; 4; 1; 6; 1; 8; 1; 10]
+    let actual = MyMath.squaresOfOdds [2; 1; 4; 1; 6; 1; 8; 1; 10]
     Assert.Equal<Collections.Generic.IEnumerable<int>>(expected, actual)
 
 [<Fact>]
 let ``SquaresOfOdds works`` () =
     let expected = [1; 9; 25; 49; 81]
-    let actual = MyMath.sumOfSquares [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
+    let actual = MyMath.squaresOfOdds [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]
     Assert.Equal(expected, actual)

--- a/core/getting-started/unit-testing-with-fsharp/MathService/Library.fs
+++ b/core/getting-started/unit-testing-with-fsharp/MathService/Library.fs
@@ -4,7 +4,7 @@ module MyMath =
     let private square x = x * x
     let private isOdd x = x % 2 <> 0
 
-    let sumOfSquares xs = 
+    let squaresOfOdds xs = 
         xs 
         |> Seq.filter isOdd 
         |> Seq.map square


### PR DESCRIPTION
... to match updates in dotnet/docs PR#4904.

I have also renamed test names to be more appropriate (by removing _sum_)

Fixes dotnet/docs#4902