### PR TITLE
Update samples for Csharp73 new generic constraints

### DIFF
--- a/snippets/csharp/keywords/GenericWhereConstraints.cs
+++ b/snippets/csharp/keywords/GenericWhereConstraints.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace keywords
+{
+    // <Snippet1>
+    class MyClass<T, U>
+        where T : class
+        where U : struct
+    { }
+    // </Snippet1>
+
+    // <Snippet2>
+    public class MyGenericClass<T> where T : IComparable, new()
+    {
+        // The following line is not possible without new() constraint:
+        T item = new T();
+    }
+    // </Snippet2
+
+    // <Snippet3>
+    interface IMyInterface
+    {
+    }
+
+    class Dictionary<TKey, TVal>
+        where TKey : IComparable, IEnumerable
+        where TVal : IMyInterface
+    {
+        public void Add(TKey key, TVal val)
+        {
+        }
+    }
+    // </Snippet3>
+
+    // <Snippet4>
+    public class Employee
+    {
+        public Employee(string s, int i) => (Name, ID) = (s, i);
+        public string Name { get; set; }
+        public int ID { get; set; }
+    }
+
+    public class GenericList<T> where T : Employee
+    {
+        private class Node
+        {
+            public Node(T t) => (Next, Data) = (null, t);
+
+            public Node Next { get; set; }
+            public T Data { get; set; }
+        }
+
+        private Node head;
+
+        public void AddHead(T t)
+        {
+            Node n = new Node(t) { Next = head };
+            head = n;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            Node current = head;
+
+            while (current != null)
+            {
+                yield return current.Data;
+                current = current.Next;
+            }
+        }
+
+        public T FindFirstOccurrence(string s)
+        {
+            Node current = head;
+            T t = null;
+
+            while (current != null)
+            {
+                //The constraint enables access to the Name property.
+                if (current.Data.Name == s)
+                {
+                    t = current.Data;
+                    break;
+                }
+                else
+                {
+                    current = current.Next;
+                }
+            }
+            return t;
+        }
+    }
+    // <Snippet4>
+
+    public interface IEmployee
+    {
+
+    }
+
+    // <Snippet5>
+    class EmployeeList<T> where T : Employee, IEmployee, System.IComparable<T>, new()
+    {
+        // ...
+    }
+    // </Snippet5>
+
+    // <Snippet7>
+    class Base { }
+    class Test<T, U>
+        where U : struct
+        where T : Base, new()
+    { }
+    // </Snippet7>
+
+    // <Snippet8>
+    public class List<T>
+    {
+        public void Add<U>(List<U> items) where U : T {/*...*/}
+    }
+    // </Snippet8>
+
+    // <Snippet9>
+    //Type parameter V is used as a type constraint.
+    public class SampleClass<T, U, V> where T : V { }
+    // </Snippet9>
+
+    public static class GenericWhereConstraints
+    {
+        public static void Examples()
+        {
+            TestStringEquality();
+        }
+
+        // <Snippet6>
+        public static void OpEqualsTest<T>(T s, T t) where T : class
+        {
+            System.Console.WriteLine(s == t);
+        }
+        private static void TestStringEquality()
+        {
+            string s1 = "target";
+            System.Text.StringBuilder sb = new System.Text.StringBuilder("target");
+            string s2 = sb.ToString();
+            OpEqualsTest<string>(s1, s2);
+        }
+        // </Snippet6>
+
+    }
+}

--- a/snippets/csharp/keywords/GenericWhereConstraints.cs
+++ b/snippets/csharp/keywords/GenericWhereConstraints.cs
@@ -41,9 +41,7 @@ namespace keywords
     // </Snippet5>
 
     // <Snippet6>
-    public interface IMyInterface
-    {
-    }
+    public interface IMyInterface { }
 
     namespace CodeExample
     {

--- a/snippets/csharp/keywords/Program.cs
+++ b/snippets/csharp/keywords/Program.cs
@@ -7,6 +7,7 @@ namespace keywords
         static void Main(string[] args)
         {
             StackAllocExamples.Examples();
+            GenericWhereConstraints.Examples();
         }
     }
 }


### PR DESCRIPTION
This PR has the following changes:

1. Pull the existing inline samples from the language reference on [where generic constraint](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) and the programming guide for [constraints on type parameters](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters) into the samples repo.
1. Add new samples for `unmanaged`, `System.Delegate` and `System.Enum`.

These samples will be part of the work to address dotnet/docs#3964

/cc @OmarTawfik @jcouv 
