### PR TITLE
added Path.Combine() to How to: Write Text to a File

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source.cs
@@ -40,7 +40,7 @@ class WriteTextFiles
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the string array to a new file named "WriteLines.txt".
-        using (StreamWriter outputFile = new StreamWriter(mydocpath + @"\WriteLines.txt")) {
+        using (StreamWriter outputFile = new StreamWriter(System.IO.Path.Combine(mydocpath,@"\WriteLines.txt"))) {
             foreach (string line in lines)
                 outputFile.WriteLine(line);
         }
@@ -55,7 +55,7 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Append text to an existing file named "WriteLines.txt".
-        using (StreamWriter outputFile = new StreamWriter(mydocpath + @"\WriteLines.txt", true)) {
+        using (StreamWriter outputFile = new StreamWriter(System.IO.Path.Combine(mydocpath,@"\WriteLines.txt"), true)) {
             outputFile.WriteLine("Fourth Line");
         }
         // </SnippetAppendText>
@@ -69,7 +69,7 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the text asynchronously to a new file named "WriteTextAsync.txt".
-        using (StreamWriter outputFile = new StreamWriter(mydocpath + @"\WriteTextAsync.txt")) {
+        using (StreamWriter outputFile = new StreamWriter(System.IO.Path.Combine(mydocpath,@"\WriteTextAsync.txt"))) {
             await outputFile.WriteAsync(text);
         }
     }
@@ -85,13 +85,13 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the text to a new file named "WriteFile.txt".
-        File.WriteAllText(mydocpath + @"\WriteFile.txt", text);
+        File.WriteAllText(System.IO.Path.Combine(mydocpath,@"\WriteFile.txt"), text);
 
         // Create a string array with the additional lines of text
         string[] lines = { "New line 1", "New line 2" };
 
         // Append new lines of text to the file
-        File.AppendAllLines(mydocpath + @"\WriteFile.txt", lines);
+        File.AppendAllLines(System.IO.Path.Combine(mydocpath,@"\WriteFile.txt"), lines);
         // </SnippetWriteFile>
 
     }

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source.cs
@@ -40,7 +40,7 @@ class WriteTextFiles
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the string array to a new file named "WriteLines.txt".
-        using (StreamWriter outputFile = new StreamWriter(System.IO.Path.Combine(mydocpath,@"\WriteLines.txt"))) {
+        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,@"\WriteLines.txt"))) {
             foreach (string line in lines)
                 outputFile.WriteLine(line);
         }
@@ -55,7 +55,7 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Append text to an existing file named "WriteLines.txt".
-        using (StreamWriter outputFile = new StreamWriter(System.IO.Path.Combine(mydocpath,@"\WriteLines.txt"), true)) {
+        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,@"\WriteLines.txt"), true)) {
             outputFile.WriteLine("Fourth Line");
         }
         // </SnippetAppendText>
@@ -69,7 +69,7 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the text asynchronously to a new file named "WriteTextAsync.txt".
-        using (StreamWriter outputFile = new StreamWriter(System.IO.Path.Combine(mydocpath,@"\WriteTextAsync.txt"))) {
+        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,@"\WriteTextAsync.txt"))) {
             await outputFile.WriteAsync(text);
         }
     }
@@ -85,13 +85,13 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the text to a new file named "WriteFile.txt".
-        File.WriteAllText(System.IO.Path.Combine(mydocpath,@"\WriteFile.txt"), text);
+        File.WriteAllText(Path.Combine(mydocpath,@"\WriteFile.txt"), text);
 
         // Create a string array with the additional lines of text
         string[] lines = { "New line 1", "New line 2" };
 
         // Append new lines of text to the file
-        File.AppendAllLines(System.IO.Path.Combine(mydocpath,@"\WriteFile.txt"), lines);
+        File.AppendAllLines(Path.Combine(mydocpath,@"\WriteFile.txt"), lines);
         // </SnippetWriteFile>
 
     }

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source.cs
@@ -40,7 +40,7 @@ class WriteTextFiles
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the string array to a new file named "WriteLines.txt".
-        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,@"\WriteLines.txt"))) {
+        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,"WriteLines.txt"))) {
             foreach (string line in lines)
                 outputFile.WriteLine(line);
         }
@@ -55,7 +55,7 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Append text to an existing file named "WriteLines.txt".
-        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,@"\WriteLines.txt"), true)) {
+        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,"WriteLines.txt"), true)) {
             outputFile.WriteLine("Fourth Line");
         }
         // </SnippetAppendText>
@@ -69,7 +69,7 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the text asynchronously to a new file named "WriteTextAsync.txt".
-        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,@"\WriteTextAsync.txt"))) {
+        using (StreamWriter outputFile = new StreamWriter(Path.Combine(mydocpath,"WriteTextAsync.txt"))) {
             await outputFile.WriteAsync(text);
         }
     }
@@ -85,13 +85,13 @@ class WriteTextFiles
         string mydocpath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Write the text to a new file named "WriteFile.txt".
-        File.WriteAllText(Path.Combine(mydocpath,@"\WriteFile.txt"), text);
+        File.WriteAllText(Path.Combine(mydocpath,"WriteFile.txt"), text);
 
         // Create a string array with the additional lines of text
         string[] lines = { "New line 1", "New line 2" };
 
         // Append new lines of text to the file
-        File.AppendAllLines(Path.Combine(mydocpath,@"\WriteFile.txt"), lines);
+        File.AppendAllLines(Path.Combine(mydocpath,"WriteFile.txt"), lines);
         // </SnippetWriteFile>
 
     }

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source5.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source5.cs
@@ -29,7 +29,7 @@ namespace WpfApplication
 
             // Open a streamwriter to a new text file named "UserInputFile.txt"and write the contents of 
             // the stringbuilder to it.
-            using (StreamWriter outfile = new StreamWriter(mydocpath + @"\UserInputFile.txt", true))
+            using (StreamWriter outfile = new StreamWriter(Path.Combine(mydocpath,@"\UserInputFile.txt"), true))
             {
                 await outfile.WriteAsync(sb.ToString());
             }

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source5.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.basicio.textfiles/cs/source5.cs
@@ -29,7 +29,7 @@ namespace WpfApplication
 
             // Open a streamwriter to a new text file named "UserInputFile.txt"and write the contents of 
             // the stringbuilder to it.
-            using (StreamWriter outfile = new StreamWriter(Path.Combine(mydocpath,@"\UserInputFile.txt"), true))
+            using (StreamWriter outfile = new StreamWriter(Path.Combine(mydocpath,"UserInputFile.txt"), true))
             {
                 await outfile.WriteAsync(sb.ToString());
             }

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.basicio.textfiles/vb/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.basicio.textfiles/vb/source.vb
@@ -38,7 +38,7 @@ Class WriteTextFiles
         Dim mydocpath As String = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
 
         ' Write the string array to a new file named "WriteLines.txt".
-        Using outputFile As New StreamWriter(Path.Combine(mydocpath,Convert.ToString("\WriteLines.txt")))
+        Using outputFile As New StreamWriter(Path.Combine(mydocpath,Convert.ToString("WriteLines.txt")))
             For Each line As String In lines
                 outputFile.WriteLine(line)
             Next
@@ -54,7 +54,7 @@ Class WriteTextFiles
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
 
         ' Append text to an existing file named "WriteLines.txt".
-Using outputFile As New StreamWriter(Path.Combine(mydocpath,Convert.ToString("\WriteLines.txt")), True)
+Using outputFile As New StreamWriter(Path.Combine(mydocpath,Convert.ToString("WriteLines.txt")), True)
             outputFile.WriteLine("Fourth Line")
         End Using
         ' </SnippetAppendText>
@@ -67,7 +67,7 @@ Using outputFile As New StreamWriter(Path.Combine(mydocpath,Convert.ToString("\W
         Dim mydocpath As String = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
 
         ' Write the text asynchronously to a new file named "WriteTextAsync.txt".
-Using outputFile As New StreamWriter(Path.Combine(mydocpath,Convert.ToString("\WriteTextAsync.txt")))
+Using outputFile As New StreamWriter(Path.Combine(mydocpath,Convert.ToString("WriteTextAsync.txt")))
             Await outputFile.WriteAsync(text)
         End Using
     End Sub
@@ -82,13 +82,13 @@ Using outputFile As New StreamWriter(Path.Combine(mydocpath,Convert.ToString("\W
         Dim mydocpath As String = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
 
         ' Write the text to a new file named "WriteFile.txt".
-File.WriteAllText(Path.Combine(mydocpath,Convert.ToString("\WriteFile.txt")), text)
+File.WriteAllText(Path.Combine(mydocpath,Convert.ToString("WriteFile.txt")), text)
 
         ' Create a string array with the additional lines of text
         Dim lines() As String = {"New line 1", "New line 2"}
 
         ' Append new lines of text to the file
-File.AppendAllLines(Path.Combine(mydocpath,Convert.ToString("\WriteFile.txt")), lines)
+File.AppendAllLines(Path.Combine(mydocpath,Convert.ToString("WriteFile.txt")), lines)
         ' </SnippetWriteFile>
 
     End Sub

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.basicio.textfiles/vb/source5.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.basicio.textfiles/vb/source5.vb
@@ -18,7 +18,7 @@ Class MainWindow
 
         ' Open a stream writer to a new text file named "UserInputFile.txt" and write the contents 
         ' of the stringbuilder to it.
-        Using outfile As StreamWriter = New StreamWriter(Path.Combine(mydocpath,"\UserInputFile.txt"), True)
+        Using outfile As StreamWriter = New StreamWriter(Path.Combine(mydocpath,"UserInputFile.txt"), True)
             Await outfile.WriteAsync(sb.ToString())
         End Using
     End Sub


### PR DESCRIPTION
## Summary

Added `Path.Combine()` call to file constructors

Fixes dotnet/docs#4754 (if available)
