### PR TITLE
Fixed default literal example

### DIFF
--- a/snippets/csharp/programming-guide/statements-expressions-operators/default-literal.cs
+++ b/snippets/csharp/programming-guide/statements-expressions-operators/default-literal.cs
@@ -1,4 +1,4 @@
-public class Point
+public struct Point
 {
     public double X { get; }
     public double Y { get; }


### PR DESCRIPTION
[Default literal example](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/default-value-expressions#default-literal-and-type-inference) is not correct:
- `Point` is a class, a reference type
- The call `FindClosestLocation(sequence, default)` where the second argument is of the `Point` type should then be equivalent to `FindClosestLocation(sequence, null)`
