### PR TITLE
Fixes for 2 snippet samples in Deconstructing tuples and other types

### DIFF
--- a/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-ambiguous.cs
+++ b/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-ambiguous.cs
@@ -21,7 +21,7 @@ public class Person
          age--;
    }
 
-   public void Deconstruct(out string lname, out string fname, out string mname, decimal income)
+   public void Deconstruct(out string lname, out string fname, out string mname, out decimal income)
    {
       fname = FirstName;
       mname = MiddleName;

--- a/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-class1.cs
+++ b/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-class1.cs
@@ -6,16 +6,15 @@ public class Person
    public string MiddleName { get; set; }
    public string LastName { get; set; }
 
-   // <Snippet1>
    public Person(string fname, string mname, string lname)
-   // </Snippet1>
    {
       FirstName = fname;
       MiddleName = mname;
       LastName = lname;
    }   
-   
+   // <Snippet1>
    public void Deconstruct(out string fname, out string mname, out string lname)
+   // </Snippet1>
    {
       fname = FirstName;
       mname = MiddleName;


### PR DESCRIPTION
In the [Deconstructing tuples and other types](https://docs.microsoft.com/en-us/dotnet/csharp/deconstruct) documentation the first snippet for the section on **Deconstructing user-defined types** was showing the constructor method instead of the deconstruct method. (Credit goes to  @vishaalkal for point this out in comments.)

In the same page the snippet right before the **Deconstructing a user-defined type with discards** section there is a missing `out` from the last parameter `decimal income` in the second Deconstruct method.