### PR TITLE
GenericWhereConstraints.cs: fix minor inconsistencies

### DIFF
--- a/snippets/csharp/keywords/GenericWhereConstraints.cs
+++ b/snippets/csharp/keywords/GenericWhereConstraints.cs
@@ -8,7 +8,7 @@ using static keywords.UnmanagedExtensions;
 namespace keywords
 {
     // <Snippet1>
-    public class AGenericClass<T> where T : IComparable { }
+    public class AGenericClass<T> where T : IComparable<T> { }
     // </Snippet1>
 
     // <SNippet2>
@@ -33,7 +33,7 @@ namespace keywords
     // </Snippet4>
 
     // <Snippet5>
-    public class MyGenericClass<T> where T : IComparable, new()
+    public class MyGenericClass<T> where T : IComparable<T>, new()
     {
         // The following line is not possible without new() constraint:
         T item = new T();
@@ -46,15 +46,13 @@ namespace keywords
     namespace CodeExample
     {
         class Dictionary<TKey, TVal>
-            where TKey : IComparable, IEnumerable
+            where TKey : IComparable<TKey>
             where TVal : IMyInterface
         {
-            public void Add(TKey key, TVal val)
-            {
-            }
+            public void Add(TKey key, TVal val) { }
         }
-        // </Snippet6>
     }
+    // </Snippet6>
     public class Container
     {
         // <Snippet7>


### PR DESCRIPTION
The [topic on where keyword](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) says:
>For example, you can declare a generic class, `MyGenericClass`, such that the type parameter `T` implements the `IComparable<T>` interface:

I've fixed the code snippet to match that description. After that, I've also checked other places where generic interfaces might be used.
