### PR TITLE
Update VB nullable values example

### DIFF
--- a/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrNullableValue/VB/Class1.vb
+++ b/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrNullableValue/VB/Class1.vb
@@ -55,14 +55,14 @@ Module Module1
         Dim m As Integer = 3
         Dim n? As Integer = 2
 
-        ' The comparison evaluated is 3>2, but compare1 is inferred to be of 
+        ' The comparison evaluated is 3 > 2, but compare1 is inferred to be of 
         ' type Boolean?.
         Dim compare1 = m > n
         ' The values summed are 3 and 2, but sum1 is inferred to be of type Integer?.
         Dim sum1 = m + n
 
         ' The following line displays: 3 * 2 * 5 * True
-        Console.WriteLine(m & " * " & n & " * " & sum1 & " * " & compare1)
+        Console.WriteLine($"{m} * {n} * {sum1} * {compare1}")
         '</Snippet7>
 
         '<Snippet8>
@@ -73,8 +73,8 @@ Module Module1
         Dim sum2 = m + n
 
         ' Because the values of n, compare2, and sum2 are all Nothing, the
-        ' following line displays 3 * * *
-        Console.WriteLine(m & " * " & n & " * " & sum2 & " * " & compare2)
+        ' following line displays: 3 * <null> * <null> * <null>
+        Console.WriteLine($"{m} * {If(n, "<null>")} * {If(sum2, "<null>")} * {If(compare2, "<null>")}")
         '</Snippet8>
     End Sub
 End Module


### PR DESCRIPTION
## Update VB nullable values example

This PR addresses the issue of confusing output raised in [dotnet/docs#5007](https://github.com/dotnet/docs/pull/5007). The problem here is that, because a nullable type whose value is null generates no output, the output from the example is confusing. 

//cc @d-dizhevsky
 