### PR TITLE
Dispose enumerators in custom sequence (LINQ) sample

### DIFF
--- a/core/linq/csharp/customsequence/CustomSequence-Sample-1.cs
+++ b/core/linq/csharp/customsequence/CustomSequence-Sample-1.cs
@@ -8,12 +8,13 @@ namespace CustomSequence
     {
         private static IEnumerable<T> Combine<T>(this IEnumerable<T> first, IEnumerable<T> second, Func<T, T, T> func)
         {
-            var e1 = first.GetEnumerator();
-            var e2 = second.GetEnumerator();
-
-            while (e1.MoveNext() && e2.MoveNext())
+            using (IEnumerator<T> e1 = first.GetEnumerator(),
+                                  e2 = second.GetEnumerator())
             {
-                yield return func(e1.Current, e2.Current);
+                while (e1.MoveNext() && e2.MoveNext())
+                {
+                    yield return func(e1.Current, e2.Current);
+                }
             }
         }
 


### PR DESCRIPTION
I think it's worthwhile to follow the best practice of disposing the enumerators. It doesn't complicate the sample much or distract from anything and will make a newcomer do the right thing if they use the sample as a starting point for further learning or development.