### PR TITLE
Remove incorrect comment from Dispose pattern

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base1.cs
@@ -29,8 +29,6 @@ class BaseClass : IDisposable
          //
       }
       
-      // Free any unmanaged objects here.
-      //
       disposed = true;
    }
 }

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/base1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/base1.vb
@@ -28,8 +28,6 @@ Class BaseClass : Implements IDisposable
          '
       End If
       
-      ' Free any unmanaged objects here.
-      '
       disposed = True
    End Sub
 End Class


### PR DESCRIPTION
In the Dispose pattern, if the base class doesn't have a finalizer, it shouldn't have any unmanaged objects, so it shouldn't have a comment showing where the non-existent unmanaged objects would be freed.