### PR TITLE
Changed datasets for SentimentAnalysis Sample

### DIFF
--- a/machine-learning/tutorials/SentimentAnalysis/Program.cs
+++ b/machine-learning/tutorials/SentimentAnalysis/Program.cs
@@ -15,8 +15,8 @@ namespace SentimentAnalysis
     class Program
     {
         // <Snippet2>
-        const string _dataPath = @".\Data\imdb_labelled.txt";
-        const string _testDataPath = @".\Data\yelp_labelled.txt";
+        const string _dataPath = @".\Data\wikipedia-detox-250-line-data.tsv";
+        const string _testDataPath = @".\Data\wikipedia-detox-250-line-test.tsv";
         // </Snippet2>
 
         static void Main(string[] args)
@@ -41,7 +41,7 @@ namespace SentimentAnalysis
             // When you create a loader, you specify the schema by passing a class to the loader containing
             // all the column names and their types. This is used to create the model, and train it. 
             // <Snippet6>
-            pipeline.Add(new TextLoader<SentimentData>(_dataPath, useHeader: false, separator: "tab"));
+            pipeline.Add(new TextLoader<SentimentData>(_dataPath, useHeader: true, separator: "tab"));
             // </Snippet6>
 
             // TextFeaturizer is a transform that is used to featurize an input column. 
@@ -65,21 +65,14 @@ namespace SentimentAnalysis
             // Adds some comments to test the trained model's predictions.
             // <Snippet10>
             IEnumerable<SentimentData> sentiments = new[]
-             {
+            {
                 new SentimentData
                 {
-                    SentimentText = "Contoso's 11 is a wonderful experience",
-                    Sentiment = 0
+                    SentimentText = "Please refrain from adding nonsense to Wikipedia."
                 },
                 new SentimentData
                 {
-                    SentimentText = "The acting in this movie is very bad",
-                    Sentiment = 0
-                },
-                new SentimentData
-                {
-                    SentimentText = "Joe versus the Volcano Coffee Company is a great film.",
-                    Sentiment = 0
+                    SentimentText = "He is the best, and the article should say that."
                 }
             };
             // </Snippet10>
@@ -119,7 +112,7 @@ namespace SentimentAnalysis
         {
             // Evaluates.
             // <Snippet18>
-            var testData = new TextLoader<SentimentData>(_testDataPath, useHeader: false, separator: "tab");
+            var testData = new TextLoader<SentimentData>(_testDataPath, useHeader: true, separator: "tab");
             // </Snippet18>
 
             // BinaryClassificationEvaluator computes the quality metrics for the PredictionModel

--- a/machine-learning/tutorials/SentimentAnalysis/SentimentAnalysis.csproj
+++ b/machine-learning/tutorials/SentimentAnalysis/SentimentAnalysis.csproj
@@ -18,10 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Data\imdb_labelled.txt">
+    <None Update="Data\wikipedia-detox-250-line-data.tsv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Data\yelp_labelled.txt">
+    <None Update="Data\wikipedia-detox-250-line-test.tsv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/machine-learning/tutorials/SentimentAnalysis/SentimentData.cs
+++ b/machine-learning/tutorials/SentimentAnalysis/SentimentData.cs
@@ -7,10 +7,10 @@ namespace SentimentAnalysis
     // <Snippet2>
     public class SentimentData
     {
-        [Column(ordinal: "0")]
-        public string SentimentText;
-        [Column(ordinal: "1", name: "Label")]
+        [Column(ordinal: "0", name: "Label")]
         public float Sentiment;
+        [Column(ordinal: "1")]
+        public string SentimentText;
     }
 
     public class SentimentPrediction


### PR DESCRIPTION
# Changed test and train datasets for ML.NET SentimentAnalysis Sample

Change log: 

**Program.cs**
* Line 18: Train dataset (_dataPath variable) to wikipedia-detox-250-line-data.tsv
* Line 19: Test dataset (_testDataPath variable) to wikipedia-detox-250-line-test.tsv
* Line 44:  Changed the useHeader parameter to true.
* Lines 73 - 83:  Changed SentimentData items from three to two.
  * Line 77: Changed SentimentText value to "Please refrain from adding nonsense to Wikipedia."
  * Line 81: Changed SentimentText value to "He is the best, and the article should say that."
* Line 126:  Changed the useHeader parameter to true.

**SentimentData.cs**
* Lines 10 - 13: Reversed the SentimentText and Sentiment columns.

**SentimentAnalysis.csproj**
* Line 21: Changed Update attribute to "Data\wikipedia-detox-250-line-data.tsv".
* Line 24: Changed Update attribute to  Update="Data\wikipedia-detox-250-line-test.tsv".

Note: New datasets may be found [here](https://github.com/dotnet/machinelearning/tree/master/test/data). 

