### PR TITLE
Update source.cs

### DIFF
--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks DataTable.CreateDataReader/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks DataTable.CreateDataReader/CS/source.cs
@@ -5,13 +5,14 @@ using System.Data;
 
 class Program
 {
+    // <Snippet1>
     static void Main()
     {
         TestCreateDataReader(GetCustomers());
         Console.WriteLine("Press any key to continue.");
         Console.ReadKey();
     }
-    // <Snippet1>
+    
     private static void TestCreateDataReader(DataTable dt)
     {
         // Given a DataTable, retrieve a DataTableReader


### PR DESCRIPTION
Moved the `<Snippet1>` marker to include the `Main` method. Without it, `TestCreateDataReader(DataTable dt)` is never called and the sample is incomplete, or doesn't do anything. (I'm assuming that `<Snippet1>` marks the start of what appears on the page.)

Another option would be to call `TestCreateDataReader(DataTable dt)` at the end of `GetCustomers()`, passing in the new table but that's not as clean.