### PR TITLE
Update source.vb

### DIFF
--- a/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks DataTable.CreateDataReader/VB/source.vb
+++ b/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks DataTable.CreateDataReader/VB/source.vb
@@ -6,13 +6,13 @@ Imports System.Data
 
 Module Module1
 
+' <Snippet1>
   Sub Main()
     TestCreateDataReader(GetCustomers())
     Console.WriteLine("Press any key to continue.")
     Console.ReadKey()
   End Sub
 
-' <Snippet1>
   Private Sub TestCreateDataReader(ByVal dt As DataTable)
     ' Given a DataTable, retrieve a DataTableReader
     ' allowing access to all the tables's data:


### PR DESCRIPTION
Moved the `<Snippet1>` marker to include the `Main` method. Without it, `TestCreateDataReader(DataTable dt)` is never called and the sample is incomplete, or doesn't do anything. (I'm assuming that `<Snippet1>` marks the start of what appears on the page.)

Another option would be to call `TestCreateDataReader(DataTable dt)` at the end of `GetCustomers()`, passing in the new table but that's not as clean.