### PR TITLE
Fixed the spellling of Northwind.mdf to fix 5673.

### DIFF
--- a/snippets/csharp/VS_Snippets_Data/DLinqCommunicatingWithDatabase/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_Data/DLinqCommunicatingWithDatabase/cs/Program.cs
@@ -22,7 +22,7 @@ namespace cs_test20730build
 
             // <Snippet1>
 // DataContext takes a connection string. 
-DataContext db = new DataContext(@"c:\Northwnd.mdf");
+DataContext db = new DataContext(@"c:\Northwind.mdf");
 
 // Get a typed table to run queries.
 Table<Customer> Customers = db.GetTable<Customer>();

--- a/snippets/visualbasic/VS_Snippets_Data/DLinqCommunicatingWithDatabase/vb/Module1.vb
+++ b/snippets/visualbasic/VS_Snippets_Data/DLinqCommunicatingWithDatabase/vb/Module1.vb
@@ -13,7 +13,7 @@ Module Module1
         '        Dim db As New Northwnd("c:\northwnd.mdf")
         ' <Snippet1>
         ' DataContext takes a connection string.
-        Dim db As New DataContext("…\Northwnd.mdf")
+        Dim db As New DataContext("…\Northwind.mdf")
 
         ' Get a typed table to run queries.
         Dim Customers As Table(Of Customer) = db.GetTable(Of Customer)()


### PR DESCRIPTION
## Summary

Corrected the spelling of the .MDF filename for the Northwind sample database.

Fixes https://github.com/dotnet/docs/issues/5673