### PR TITLE
Update the binding for WCF client

### DIFF
--- a/snippets/csharp/VS_Snippets_CFX/c_securityscenarios/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_securityscenarios/cs/source.cs
@@ -714,7 +714,7 @@ namespace SecuredUsingMessageWithWindowsClient
         {
             //<snippet18>
             // Create the binding.
-            WSHttpBinding myBinding = new WSHttpBinding();
+            NetTcpBinding myBinding = new NetTcpBinding();
             myBinding.Security.Mode = SecurityMode.Message;
             myBinding.Security.Message.ClientCredentialType =
                 MessageCredentialType.Windows;

--- a/snippets/visualbasic/VS_Snippets_CFX/c_securityscenarios/vb/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CFX/c_securityscenarios/vb/source.vb
@@ -592,7 +592,7 @@ Namespace SecuredUsingMessageWithWindowsClient
             binding.Security.Message.ClientCredentialType = MessageCredentialType.Windows
             
             ' Create the URI for the endpoint.
-            Dim netTcpUri As New Uri("net.tcp://localhost:8006/Calculator")
+            Dim netTcpUri As New Uri("net.tcp://localhost:8008/Calculator")
             
             ' Crate the service host and add an endpoint.
             Dim myServiceHost As New ServiceHost(GetType(ServiceModel.Calculator), netTcpUri)
@@ -613,12 +613,12 @@ Namespace SecuredUsingMessageWithWindowsClient
         Private Sub ClientRun() 
             '<snippet18>
             ' Create the binding.
-            Dim myBinding As New WSHttpBinding()
+            Dim myBinding As New NetTcpBinding()
             myBinding.Security.Mode = SecurityMode.Message
             myBinding.Security.Message.ClientCredentialType = MessageCredentialType.Windows
             
             ' Create the endpoint address. 
-            Dim ea As New EndpointAddress("http://localhost:90/Calculator")
+            Dim ea As New EndpointAddress("net.tcp://machineName:8008/Calculator")
             
             ' Create the client. 
             Dim cc As New CalculatorClient(myBinding, ea)


### PR DESCRIPTION
## Summary
- Corrected the binding as `NetTcpBinding` instead of `WSHttpBinding` in the WCF client for charp and visual basic code sample.
- Corrected the endpoint for WCF service and client in the visual basic code sample.

Fixes https://github.com/dotnet/docs/issues/5494
