### PR TITLE
Fixed example of IEnumerable.Union<T>() method

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/CsLINQEncapsulatedComparer/CS/EncapsulatedComparer.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/CsLINQEncapsulatedComparer/CS/EncapsulatedComparer.cs
@@ -89,7 +89,7 @@ class Program
         //excluding duplicates.
 
         IEnumerable<ProductA> union =
-          store1.Union(store2);
+          store1.Union(store2, new ProductComparer());
 
         foreach (var product in union)
             Console.WriteLine(product.Name + " " + product.Code);


### PR DESCRIPTION
## Summary  
Fixing the Snipped 4 (CSLINQEncapsulatedComparer#4) adding the comparer class to show correct results

## Documentation Link  
[docs.microsoft.com IEnumerable.Union](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.union)

Focus on the last snipped of first overload, the comparer is missing
```c#
    IEnumerable<ProductA> union =
         store1.Union(store2);
```




