### PR TITLE
Add clarity to the pattern matching section of the F# Tour

### DIFF
--- a/snippets/fsharp/tour.fs
+++ b/snippets/fsharp/tour.fs
@@ -717,14 +717,17 @@ module PatternMatching =
         | Executive of executive: Person * reports: List<Employee> * assistant: Employee
 
     /// Count everyone underneath the employee in the management hierarchy,
-    /// including the employee.
+    /// including the employee. The matches bind names to the properties 
+    /// of the cases so that those names can be used inside the match branches.
+    /// Note that the names used for binding do not need to be the same as the 
+    /// names given in the DU definition above.
     let rec countReports(emp : Employee) =
         1 + match emp with
-            | Engineer(id) ->
+            | Engineer(person) ->
                 0
-            | Manager(id, reports) ->
+            | Manager(person, reports) ->
                 reports |> List.sumBy countReports
-            | Executive(id, reports, assistant) ->
+            | Executive(person, reports, assistant) ->
                 (reports |> List.sumBy countReports) + countReports assistant
 
 


### PR DESCRIPTION
On @csharpfritz's stream today there was some confusion around `id` in this section because there wasn't a clear link between a Person record and `id` in any way. I added some docs and renamed the parameter to hopefully highlight the links.
