### PR TITLE
Correct a typo in comment (comment says "decrypt" but s/be "encrypt")

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/RijndaelManaged Example/CS/class1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/RijndaelManaged Example/CS/class1.cs
@@ -57,7 +57,7 @@ namespace RijndaelManaged_Example
                 rijAlg.Key = Key;
                 rijAlg.IV = IV;
 
-                // Create a decrytor to perform the stream transform.
+                // Create an encryptor to perform the stream transform.
                 ICryptoTransform encryptor = rijAlg.CreateEncryptor(rijAlg.Key, rijAlg.IV);
 
                 // Create the streams used for encryption.


### PR DESCRIPTION
The following line of code at line 61 performs an ENcrypt (as opposed to DEcrypt) 
    ICryptoTransform encryptor = rijAlg.CreateEncryptor(rijAlg.Key, rijAlg.IV);

however the preceeding comment at line 60 says 
   // Create a decrytor to perform the stream transform.

This PR alters the comment to 
   // Create an encryptor to perform the stream transform.

FWIW this PR also adds a missing letter 'p' within the '..crypt' word of the comment

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
