### PR TITLE
Updated ML taxi fare tutorial source code

### DIFF
--- a/machine-learning/tutorials/TaxiFarePrediction/Program.cs
+++ b/machine-learning/tutorials/TaxiFarePrediction/Program.cs
@@ -34,7 +34,7 @@ namespace TaxiFarePrediction
             // </Snippet10>
 
             // <Snippet16>
-            var prediction = model.Predict(TestTrips.Trip1);
+            TaxiTripFarePrediction prediction = model.Predict(TestTrips.Trip1);
             Console.WriteLine("Predicted fare: {0}, actual fare: 29.5", prediction.FareAmount);
             // </Snippet16>
         }
@@ -48,11 +48,12 @@ namespace TaxiFarePrediction
             {
                 new TextLoader(_datapath).CreateFrom<TaxiTrip>(separator: ','),
                 new ColumnCopier(("FareAmount", "Label")),
-                
-                new CategoricalOneHotVectorizer("VendorId",
+                new CategoricalOneHotVectorizer(
+                    "VendorId",
                     "RateCode",
                     "PaymentType"),
-                new ColumnConcatenator("Features",
+                new ColumnConcatenator(
+                    "Features",
                     "VendorId",
                     "RateCode",
                     "PassengerCount",
@@ -74,7 +75,7 @@ namespace TaxiFarePrediction
         private static void Evaluate(PredictionModel<TaxiTrip, TaxiTripFarePrediction> model)
         {
             // <Snippet12>
-            var testData = new TextLoader(_datapath).CreateFrom<TaxiTrip>(useHeader: true, separator: ',');
+            var testData = new TextLoader(_testdatapath).CreateFrom<TaxiTrip>(useHeader: true, separator: ',');
             // </Snippet12>
 
             // <Snippet13>
@@ -83,11 +84,10 @@ namespace TaxiFarePrediction
             // </Snippet13>
 
             // <Snippet14>
-            // Rms should be around 2.795276
-            Console.WriteLine("Rms=" + metrics.Rms);
+            Console.WriteLine($"Rms = {metrics.Rms}");
             // </Snippet14>
             // <Snippet15>
-            Console.WriteLine("RSquared = " + metrics.RSquared);
+            Console.WriteLine($"RSquared = {metrics.RSquared}");
             // </Snippet15>
         }
     }

--- a/machine-learning/tutorials/TaxiFarePrediction/Program.cs
+++ b/machine-learning/tutorials/TaxiFarePrediction/Program.cs
@@ -46,7 +46,7 @@ namespace TaxiFarePrediction
             // <Snippet3>
             var pipeline = new LearningPipeline
             {
-                new TextLoader(_datapath).CreateFrom<TaxiTrip>(separator: ','),
+                new TextLoader(_datapath).CreateFrom<TaxiTrip>(useHeader: true, separator: ','),
                 new ColumnCopier(("FareAmount", "Label")),
                 new CategoricalOneHotVectorizer(
                     "VendorId",


### PR DESCRIPTION
Updates the taxi fare tutorial source code:
- The file with the train data contains header, so `useHeader` argument of `TextLoader.CreateFrom` should be `true`
- Use string interpolation to display metrics values
- Minor style updates
- Load data from the file with the test data for the model evaluation.

Fixes dotnet/docs#5841
