### PR TITLE
Closing parenthesis placed incorrectly.

### DIFF
--- a/core/hosting/host.cpp
+++ b/core/hosting/host.cpp
@@ -59,7 +59,7 @@ int wmain(int argc, wchar_t* argv[])
 	// at the last path delimiter (\)
 	wchar_t targetAppPath[MAX_PATH];
 	wcscpy_s(targetAppPath, targetApp);
-	size_t i = wcslen(targetAppPath - 1);
+	size_t i = wcslen(targetAppPath) - 1;
 	while (i >= 0 && targetAppPath[i] != L'\\') i--;
 	targetAppPath[i] = L'\0';
 


### PR DESCRIPTION
## Summary

SampleHost.exe was crashing on line 63 with a stack overflow in debug x64 build because i was getting assigned to a large number.  This change seems to let SampleHost.exe run correctly.