### PR TITLE
Change VB, C# compiler switch in dotnet/samples

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs
@@ -2,7 +2,7 @@
 namespace Wrap1
 {
     //<Snippet1>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// text for class TestClass
     public class TestClass
@@ -33,7 +33,7 @@ namespace Wrap1
 namespace Wrap2
 {
     //<Snippet2>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// text for class TestClass
     public class TestClass
@@ -57,7 +57,7 @@ namespace Wrap2
 //-----------------------------------------------------------------------------
 //<Snippet3>
 // Save this file as CRefTest.cs
-// Compile with: csc CRefTest.cs /doc:Results.xml 
+// Compile with: csc CRefTest.cs -doc:Results.xml 
 
 namespace TestNamespace
 {
@@ -136,7 +136,7 @@ namespace TestNamespace
 
 namespace Wrap3
 {
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// text for class TestClass
     public class TestClass
@@ -172,7 +172,7 @@ namespace Wrap3
 namespace Wrap4
 {
     //<Snippet4>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// Comment for class
     public class EClass : System.Exception
@@ -202,7 +202,7 @@ namespace Wrap4
 namespace Wrap5
 {
     //<Snippet5>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// <include file='xml_include_tag.doc' path='MyDocs/MyMembers[@name="test"]/*' />
     class Test
@@ -229,7 +229,7 @@ namespace Wrap5
 namespace Wrap6
 {
     //<Snippet6>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// text for class TestClass
     public class TestClass
@@ -256,7 +256,7 @@ namespace Wrap6
 namespace Wrap7
 {
     //<Snippet7>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// text for class TestClass
     public class TestClass
@@ -281,7 +281,7 @@ namespace Wrap7
 namespace Wrap8
 {
     //<Snippet8>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     class TestClass
     {
@@ -302,7 +302,7 @@ namespace Wrap8
 namespace Wrap9
 {
     //<Snippet9>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// <summary>
     /// You may have some primary information about this class.
@@ -325,7 +325,7 @@ namespace Wrap9
 namespace Wrap10
 {
     //<Snippet10>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// text for class TestClass
     public class TestClass
@@ -349,7 +349,7 @@ namespace Wrap10
 namespace Wrap11
 {
     //<Snippet11>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     // the following cref shows how to specify the reference, such that,
     // the compiler will resolve the reference
@@ -378,7 +378,7 @@ namespace Wrap11
 namespace Wrap12
 {
     //<Snippet12>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// text for class TestClass
     public class TestClass
@@ -404,7 +404,7 @@ namespace Wrap12
 namespace Wrap13
 {
     //<Snippet13>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// comment for class
     public class TestClass
@@ -426,7 +426,7 @@ namespace Wrap13
 namespace Wrap14
 {
     //<Snippet14>
-    // compile with: /doc:DocFileName.xml 
+    // compile with: -doc:DocFileName.xml 
 
     /// text for class Employee
     public class Employee
@@ -465,7 +465,7 @@ namespace Wrap14
 namespace Wrap15
 {
     //<Snippet15>
-    // If compiling from the command line, compile with: /doc:YourFileName.xml
+    // If compiling from the command line, compile with: -doc:YourFileName.xml
 
     /// <summary>
     /// Class level summary documentation goes here.

--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideInheritance/CS/Inheritance.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideInheritance/CS/Inheritance.cs
@@ -39,7 +39,7 @@ class TestPaint : System.Windows.Forms.Form
 
 
 //<Snippet1>
-// compile with: csc /target:library abstractshape.cs
+// compile with: csc -target:library abstractshape.cs
 public abstract class Shape
 {
     private string name;
@@ -78,7 +78,7 @@ public abstract class Shape
 
 
 //<Snippet2>
-// compile with: csc /target:library /reference:abstractshape.dll shapes.cs
+// compile with: csc -target:library -reference:abstractshape.dll shapes.cs
 public class Square : Shape
 {
     private int side;
@@ -144,7 +144,7 @@ public class Rectangle : Shape
 
 
 //<Snippet3>
-// compile with: csc /reference:abstractshape.dll;shapes.dll shapetest.cs
+// compile with: csc -reference:abstractshape.dll;shapes.dll shapetest.cs
 class TestClass
 {
     static void Main()
@@ -490,7 +490,7 @@ public abstract class A
 namespace WrapD
 {
     //<Snippet15>
-    // compile with: /target:library
+    // compile with: -target:library
     public class D
     {
         public virtual void DoWork(int i)

--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuidePointers/CS/Pointers2.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuidePointers/CS/Pointers2.cs
@@ -1,5 +1,5 @@
 //<Snippet1>
-// compile with: /unsafe
+// compile with: -unsafe
 // arguments: readfile.cs
 // Use the program to read and display a text file.
 //</Snippet1>
@@ -7,35 +7,35 @@
 
 //USED BY MULTIPLE TOPICS
 //<Snippet3>
-// compile with: /unsafe
+// compile with: -unsafe
 //</Snippet3>
 
 
 //<Snippet5>
-// compile with: /unsafe
+// compile with: -unsafe
 //</Snippet5>
 
 
 //<Snippet7>
-// compile with: /unsafe
+// compile with: -unsafe
 //</Snippet7>
 
 
 //<Snippet9>
-// compile with: /unsafe
+// compile with: -unsafe
 //</Snippet9>
 
 
 //<Snippet11>
-// compile with: /unsafe
+// compile with: -unsafe
 //</Snippet11>
 
 
 //<Snippet14>
-// compile with: /unsafe
+// compile with: -unsafe
 //</Snippet14>
 
 
 //<Snippet16>
-// compile with: /unsafe
+// compile with: -unsafe
 //</Snippet16>

--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -647,7 +647,7 @@ class MainClass : Employee4
 //</snippet21>
 
     //<snippet22>
-    // compile with: /unsafe
+    // compile with: -unsafe
 
     class UnsafeTest
     {

--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefOperators/CS/csrefOperators.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefOperators/CS/csrefOperators.cs
@@ -265,7 +265,7 @@ namespace ConsoleApplication1
     //</snippet14>
 
     //<snippet15>
-    // compile with: /unsafe
+    // compile with: -unsafe
 
     struct Point
     {

--- a/snippets/csharp/VS_Snippets_Winforms/DateTimePicker.CalendarFont/CS/calendarfont.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/DateTimePicker.CalendarFont/CS/calendarfont.cs
@@ -1,5 +1,5 @@
 
-// compile with: /r:system.dll /r:system.windows.forms.dll /r:system.drawing.dll
+// compile with: -r:system.dll -r:system.windows.forms.dll -r:system.drawing.dll
 using System.Windows.Forms;
 using System;
 using System.Drawing;

--- a/snippets/csharp/VS_Snippets_Winforms/DateTimePicker.CalendarForeColor/CS/calendarforecolor.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/DateTimePicker.CalendarForeColor/CS/calendarforecolor.cs
@@ -1,5 +1,5 @@
 
-// compile with: /r:system.dll /r:system.windows.forms.dll /r:system.drawing.dll
+// compile with: -r:system.dll -r:system.windows.forms.dll -r:system.drawing.dll
 using System.Windows.Forms;
 using System;
 using System.Drawing;

--- a/snippets/csharp/VS_Snippets_Winforms/DateTimePicker.CalendarMonthBackground/CS/calendarmonthbackground.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/DateTimePicker.CalendarMonthBackground/CS/calendarmonthbackground.cs
@@ -1,5 +1,5 @@
 
-// compile with: /r:system.dll /r:system.windows.forms.dll /r:system.drawing.dll
+// compile with: -r:system.dll -r:system.windows.forms.dll -r:system.drawing.dll
 using System.Windows.Forms;
 using System;
 using System.Drawing;

--- a/snippets/csharp/VS_Snippets_Winforms/DateTimePicker.Value/CS/value.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/DateTimePicker.Value/CS/value.cs
@@ -1,5 +1,5 @@
 
-// compile with: /r:system.dll /r:system.windows.forms.dll
+// compile with: -r:system.dll -r:system.windows.forms.dll
 using System.Windows.Forms;
 using System;
 

--- a/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrCompiler/VB/OptionStrictOff.vb
+++ b/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrCompiler/VB/OptionStrictOff.vb
@@ -4,7 +4,7 @@ Option Explicit On
 
 ' <snippet48>
 ' t2.vb
-' Compile with vbc /addmodule:t1.netmodule t2.vb.
+' Compile with vbc -addmodule:t1.netmodule t2.vb.
 Option Strict Off
 
 Namespace NetmoduleTest
@@ -21,7 +21,7 @@ End Namespace
 
 ' <snippet47>
 ' t1.vb
-' Compile with vbc /target:module t1.vb.
+' Compile with vbc -target:module t1.vb.
 ' Outputs t1.netmodule.
 
 Public Class TestClass
@@ -84,7 +84,7 @@ Namespace Classdb7cfa59c315401ca59b0daf355343d6
 
     Namespace namespace36
         ' <snippet36>
-        ' compile with: /target:library
+        ' compile with: -target:library
         Module Module1
             ' valid with or without /netcf
             Declare Sub DllSub Lib "SomeLib.dll" ()

--- a/snippets/visualbasic/VS_Snippets_Winforms/DateTimePicker.CalendarFont/VB/calendarfont.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/DateTimePicker.CalendarFont/VB/calendarfont.vb
@@ -1,5 +1,5 @@
 
-' compile with: /r:system.dll /r:system.windows.forms.dll /r:system.drawing.dll
+' compile with: -r:system.dll -r:system.windows.forms.dll -r:system.drawing.dll
 Imports System.Windows.Forms
 Imports System
 Imports System.Drawing

--- a/snippets/visualbasic/VS_Snippets_Winforms/DateTimePicker.CalendarForeColor/VB/calendarforecolor.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/DateTimePicker.CalendarForeColor/VB/calendarforecolor.vb
@@ -1,5 +1,5 @@
 
-' compile with: /r:system.dll /r:system.windows.forms.dll /r:system.drawing.dll
+' compile with: -r:system.dll -r:system.windows.forms.dll -r:system.drawing.dll
 Imports System.Windows.Forms
 Imports System
 Imports System.Drawing

--- a/snippets/visualbasic/VS_Snippets_Winforms/DateTimePicker.CalendarMonthBackground/VB/calendarmonthbackground.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/DateTimePicker.CalendarMonthBackground/VB/calendarmonthbackground.vb
@@ -1,5 +1,5 @@
 
-' compile with: /r:system.dll /r:system.windows.forms.dll /r:system.drawing.dll
+' compile with: -r:system.dll -r:system.windows.forms.dll -r:system.drawing.dll
 Imports System.Windows.Forms
 Imports System
 Imports System.Drawing

--- a/snippets/visualbasic/VS_Snippets_Winforms/DateTimePicker.Value/VB/value.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/DateTimePicker.Value/VB/value.vb
@@ -1,5 +1,5 @@
 
-' compile with: /r:system.dll /r:system.windows.forms.dll
+' compile with: -r:system.dll -r:system.windows.forms.dll
 Imports System.Windows.Forms
 Imports System
 


### PR DESCRIPTION
## Summary

Updated compiler switch from ( / ) to ( - ) in the dotnet/**samples** code (files *.cs and *.vb).  

Fixes dotnet/**docs**#4785