### PR TITLE
Correct spelling of "SmtpExamples" namespace

### DIFF
--- a/snippets/csharp/VS_Snippets_Remoting/NCLMailSync/CS/mail.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/NCLMailSync/CS/mail.cs
@@ -8,7 +8,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.IO;
 using System.Text;
-namespace Examples.SmptExamples.Sync
+namespace Examples.SmtpExamples.Sync
 {
 
 	public class CtorExamples

--- a/snippets/csharp/VS_Snippets_Remoting/NclMailASync/CS/mailasync.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/NclMailASync/CS/mailasync.cs
@@ -8,7 +8,7 @@ using System.Net.Mail;
 using System.Net.Mime;
 using System.Threading;
 using System.ComponentModel;
-namespace Examples.SmptExamples.Async
+namespace Examples.SmtpExamples.Async
 {
     public class SimpleAsynchronousExample
     {

--- a/snippets/csharp/VS_Snippets_Remoting/NclMailPerms/CS/mailpermissions.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/NclMailPerms/CS/mailpermissions.cs
@@ -7,7 +7,7 @@ using System.Net.Mail;
 using System.Net.Mime;
 
 
-namespace Examples.SmptExamples.Permissions
+namespace Examples.SmtpExamples.Permissions
 {
 
     public class Test

--- a/snippets/csharp/VS_Snippets_Remoting/NclSSLMailSync/CS/mail.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/NclSSLMailSync/CS/mail.cs
@@ -8,7 +8,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.IO;
 using System.Text;
-namespace Examples.SmptExamples.Sync
+namespace Examples.SmtpExamples.Sync
 {
 
 	public class CtorExamples

--- a/snippets/visualbasic/VS_Snippets_Remoting/NclMailASync/vb/mailasync.vb
+++ b/snippets/visualbasic/VS_Snippets_Remoting/NclMailASync/vb/mailasync.vb
@@ -8,7 +8,7 @@ Imports System.Net.Mail
 Imports System.Net.Mime
 Imports System.Threading
 Imports System.ComponentModel
-Namespace Examples.SmptExamples.Async
+Namespace Examples.SmtpExamples.Async
     Public Class SimpleAsynchronousExample
         Private Shared mailSent As Boolean = False
         Private Shared Sub SendCompletedCallback(ByVal sender As Object, ByVal e As AsyncCompletedEventArgs)


### PR DESCRIPTION
## Summary

Found this on SendAsync. Did a search and realized it happened a few more times so I changed those too.
