### PR TITLE
Remove reserved words from VB sample

### DIFF
--- a/snippets/visualbasic/VS_Snippets_Remoting/NclMailASync/vb/mailasync.vb
+++ b/snippets/visualbasic/VS_Snippets_Remoting/NclMailASync/vb/mailasync.vb
@@ -32,13 +32,13 @@ Namespace Examples.SmtpExamples.Async
             '<snippet2>
             ' Create a mailing address that includes a UTF8 character
             ' in the display name.
-            Dim [from] As New MailAddress("jane@contoso.com", "Jane " & ChrW(&HD8) & " Clayton", System.Text.Encoding.UTF8)
+            Dim mailFrom As New MailAddress("jane@contoso.com", "Jane " & ChrW(&HD8) & " Clayton", System.Text.Encoding.UTF8)
             '</snippet2>
             ' Set destinations for the email message.
-            Dim [to] As New MailAddress("ben@contoso.com")
+            Dim mailTo As New MailAddress("ben@contoso.com")
             ' Specify the message content.
             '<snippet3>
-            Dim message As New MailMessage([from], [to])
+            Dim message As New MailMessage(mailFrom, mailTo)
             message.Body = "This is a test email message sent by an application. "
             ' Include some non-ASCII characters in body and subject.
             Dim someArrows As New String(New Char() {ChrW(&H2190), ChrW(&H2191), ChrW(&H2192), ChrW(&H2193)})


### PR DESCRIPTION
## Summary

As noted in the issue, using non-recommended strategy in sample code could lead to it being used when there is not good reason for it to be. Therefore, I've renamed the variables in this sample. (It appears most of the mail samples I looked at are C# only, so just the one seems to be floating around for VB right now.) If I spot any more instances of this, I'll submit a correction for those later.

Fixes dotnet/docs#6129
