### PR TITLE
Several uneccessary catch(Exception) were removed in c# examples.

### DIFF
--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks ConnectionStrings.Encrypt/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks ConnectionStrings.Encrypt/CS/source.cs
@@ -12,8 +12,6 @@ class Program
     {
         // Takes the executable file name without the
         // .config extension.
-        try
-        {
             // Open the configuration file and retrieve 
             // the connectionStrings section.
             Configuration config = ConfigurationManager.
@@ -39,11 +37,6 @@ class Program
 
             Console.WriteLine("Protected={0}",
                 section.SectionInformation.IsProtected);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
     }
     // </Snippet1>
 }

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks DataTableLoad.IDataReader/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks DataTableLoad.IDataReader/CS/source.cs
@@ -32,14 +32,8 @@ class Program
         // by the particular incompatibility:
         table = GetIntegerTable();
         reader = new DataTableReader(GetStringTable());
-        try 
-        {
-            table.Load(reader);
-        } 
-        catch (Exception ex) 
-        { 
-            Console.WriteLine(ex.GetType().Name + ":" + ex.Message);
-        }
+        
+        table.Load(reader);
 
         Console.WriteLine(" ============================= ");
         Console.WriteLine(

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks DataTableLoad.LoadOption/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks DataTableLoad.LoadOption/CS/source.cs
@@ -33,15 +33,9 @@ class Program
         // by the particular incompatibility:
         table = GetIntegerTable();
         reader = new DataTableReader(GetStringTable());
-        try
-        {
-            table.Load(reader);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.GetType().Name + ":" + ex.Message);
-        }
 
+        table.Load(reader);
+        
         Console.WriteLine(" ============================= ");
         Console.WriteLine(
             "Load a DataTable with an IDataReader that has extra columns:");

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks DataTableLoad/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks DataTableLoad/CS/source.cs
@@ -31,14 +31,8 @@ class Program
         // by the particular incompatibility:
         table = GetIntegerTable();
         reader = new DataTableReader(GetStringTable());
-        try
-        {
-            table.Load(reader);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.GetType().Name + ":" + ex.Message);
-        }
+
+        table.Load(reader);
 
         Console.WriteLine(" ============================= ");
         Console.WriteLine(

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks OracleConnectionStringBuilder.IntegratedSecurity/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks OracleConnectionStringBuilder.IntegratedSecurity/CS/source.cs
@@ -9,34 +9,26 @@ class Program
 {
     static void Main()
     {
-        try
-        {
-            string connectString =
-                "Data Source=OracleSample;User ID=Mary;Password=*****;";
+        string connectString =
+            "Data Source=OracleSample;User ID=Mary;Password=*****;";
 
-            OracleConnectionStringBuilder builder =
-                new OracleConnectionStringBuilder(connectString);
-            Console.WriteLine("Original: " + builder.ConnectionString);
+        OracleConnectionStringBuilder builder =
+            new OracleConnectionStringBuilder(connectString);
+        Console.WriteLine("Original: " + builder.ConnectionString);
 
-            // Use the Remove method
-            // in order to reset the user ID and password back to their
-            // default (empty string) values. Simply setting the 
-            // associated property values to an empty string will not
-            // remove them from the connection string; you must
-            // call the Remove method.
-            builder.Remove("User ID");
-            builder.Remove("Password");
+        // Use the Remove method
+        // in order to reset the user ID and password back to their
+        // default (empty string) values. Simply setting the 
+        // associated property values to an empty string will not
+        // remove them from the connection string; you must
+        // call the Remove method.
+        builder.Remove("User ID");
+        builder.Remove("Password");
 
-            // Turn on integrated security.
-            builder.IntegratedSecurity = true;
+        // Turn on integrated security.
+        builder.IntegratedSecurity = true;
 
-            Console.WriteLine("Modified: " + builder.ConnectionString);
-
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
+        Console.WriteLine("Modified: " + builder.ConnectionString);
 
         Console.WriteLine("Press any key to finish.");
         Console.ReadLine();

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks OracleConnectionStringBuilder.Remove/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks OracleConnectionStringBuilder.Remove/CS/source.cs
@@ -9,30 +9,23 @@ class Program
 {
     static void Main()
     {
-        try
-        {
-            string connectString =
-                "Data Source=OracleDemo;User ID=Mary;Password=*****";
+        string connectString =
+            "Data Source=OracleDemo;User ID=Mary;Password=*****";
 
-            OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder(connectString);
-            Console.WriteLine("Original: " + builder.ConnectionString);
+        OracleConnectionStringBuilder builder = new OracleConnectionStringBuilder(connectString);
+        Console.WriteLine("Original: " + builder.ConnectionString);
 
-            // Use the Remove method
-            // in order to reset the user ID and password back to their
-            // default (empty string) values. 
-            builder.Remove("User ID");
-            builder.Remove("Password");
+        // Use the Remove method
+        // in order to reset the user ID and password back to their
+        // default (empty string) values. 
+        builder.Remove("User ID");
+        builder.Remove("Password");
 
-            // Turn on integrated security.
-            builder.IntegratedSecurity = true;
+        // Turn on integrated security.
+        builder.IntegratedSecurity = true;
 
-            Console.WriteLine("Modified: " + builder.ConnectionString);
+        Console.WriteLine("Modified: " + builder.ConnectionString);
 
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
         Console.WriteLine("Press any key to finish.");
         Console.ReadLine();
     }

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.Oracle/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.Oracle/CS/source.cs
@@ -12,28 +12,22 @@ class Program
         string queryString =
             "SELECT CUSTOMER_ID, NAME FROM DEMO.CUSTOMER";
         using (OracleConnection connection =
-                   new OracleConnection(connectionString))
+            new OracleConnection(connectionString))
         {
             OracleCommand command = connection.CreateCommand();
             command.CommandText = queryString;
+            
+            connection.Open();
 
-            try
+            OracleDataReader reader = command.ExecuteReader();
+
+            while (reader.Read())
             {
-                connection.Open();
-
-                OracleDataReader reader = command.ExecuteReader();
-
-                while (reader.Read())
-                {
-                    Console.WriteLine("\t{0}\t{1}",
-                        reader[0], reader[1]);
-                }
-                reader.Close();
+                Console.WriteLine("\t{0}\t{1}",
+                    reader[0], reader[1]);
             }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-            }
+
+            reader.Close();
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlCommand.BeginExecuteNonQuery/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlCommand.BeginExecuteNonQuery/CS/source.cs
@@ -61,12 +61,6 @@ class Class1
             {
                 Console.WriteLine("Error: {0}", ex.Message);
             }
-            catch (Exception ex)
-            {
-                // You might want to pass these errors
-                // back out to the caller.
-                Console.WriteLine("Error: {0}", ex.Message);
-            }
         }
     }
 

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlCommand.BeginExecuteReader/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlCommand.BeginExecuteReader/CS/source.cs
@@ -66,12 +66,6 @@ class Class1
             {
                 Console.WriteLine("Error: {0}", ex.Message);
             }
-            catch (Exception ex)
-            {
-                // You might want to pass these errors
-                // back out to the caller.
-                Console.WriteLine("Error: {0}", ex.Message);
-            }
         }
     }
 

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlCommand.BeginExecuteReaderAsyncSimple/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlCommand.BeginExecuteReaderAsyncSimple/CS/source.cs
@@ -65,12 +65,6 @@ class Class1
         {
             Console.WriteLine("Error: {0}", ex.Message);
         }
-        catch (Exception ex)
-        {
-            // You might want to pass these errors
-            // back out to the caller.
-            Console.WriteLine("Error: {0}", ex.Message);
-        }
     }
 
     private static void DisplayResults(SqlDataReader reader)

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnection.ChangePassword/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnection.ChangePassword/CS/source.cs
@@ -7,14 +7,8 @@ class Program
 {
     static void Main()
     {
-        try
-        {
-            DemonstrateChangePassword();
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Error: " + ex.Message);
-        }
+        DemonstrateChangePassword();
+        
         Console.WriteLine("Press ENTER to continue...");
         Console.ReadLine();
     }

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.ApplicationName/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.ApplicationName/CS/source.cs
@@ -7,8 +7,6 @@ class Program
 {
     static void Main()
     {
-        try
-        {
             string connectString = "Server=(local);Initial Catalog=AdventureWorks;" + 
                 "Integrated Security=true";
             SqlConnectionStringBuilder builder = 
@@ -22,12 +20,6 @@ class Program
 
             Console.WriteLine("Press any key to finish.");
             Console.ReadLine();
-
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.Async/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.Async/CS/source.cs
@@ -76,12 +76,6 @@ class Program
             {
                 Console.WriteLine("Error: {0}", ex.Message);
             }
-            catch (Exception ex)
-            {
-                // You might want to pass these errors
-                // back out to the caller.
-                Console.WriteLine("Error: {0}", ex.Message);
-            }
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.AttachDBFilename/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.AttachDBFilename/CS/source.cs
@@ -7,8 +7,6 @@ class Program
 {
     static void Main()
     {
-        try
-        {
             string connectString =
                 "Server=(local);" +
                 "Integrated Security=true";
@@ -28,11 +26,6 @@ class Program
             }
             Console.WriteLine("Press any key to finish.");
             Console.ReadLine();
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.ConnectTimeout/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.ConnectTimeout/CS/source.cs
@@ -7,8 +7,6 @@ class Program
 {
     static void Main()
     {
-        try
-        {
             string connectString =
                 "Server=(local);Initial Catalog=AdventureWorks;" +
                 "Integrated Security=true";
@@ -22,12 +20,6 @@ class Program
 
             Console.WriteLine("Press any key to finish.");
             Console.ReadLine();
-
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.InitialCatalog/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.InitialCatalog/CS/source.cs
@@ -7,8 +7,6 @@ class Program
 {
     static void Main()
     {
-        try
-        {
             string connectString = "Data Source=(local);" +
                 "Integrated Security=true";
 
@@ -34,13 +32,7 @@ class Program
                 // Now use the open connection.
                 Console.WriteLine("Database = " + connection.Database);
             }
-
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
-
+        
         Console.WriteLine("Press any key to finish.");
         Console.ReadLine();
     }

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.IntegratedSecurity/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.IntegratedSecurity/CS/source.cs
@@ -7,8 +7,6 @@ class Program
 {
     static void Main()
     {
-        try
-        {
             string connectString =
                 "Data Source=(local);User ID=ab;Password=MyPassword;" +
                 "Initial Catalog=AdventureWorks";
@@ -38,13 +36,7 @@ class Program
                 // Now use the open connection.
                 Console.WriteLine("Database = " + connection.Database);
             }
-
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
-
+        
         Console.WriteLine("Press any key to finish.");
         Console.ReadLine();
     }

--- a/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.Remove/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SqlConnectionStringBuilder.Remove/CS/source.cs
@@ -7,8 +7,6 @@ class Program
 {
     static void Main()
     {
-        try
-        {
             string connectString =
                 "Data Source=(local);User ID=ab;Password= a1Pass@@11;" +
                 "Initial Catalog=AdventureWorks";
@@ -34,12 +32,7 @@ class Program
                 // Now use the open connection.
                 Console.WriteLine("Database = " + connection.Database);
             }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-        }
-
+        
         Console.WriteLine("Press any key to finish.");
         Console.ReadLine();
     }

--- a/snippets/csharp/VS_Snippets_CFX/c_certificatevalidationdifferences/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_certificatevalidationdifferences/cs/source.cs
@@ -16,21 +16,11 @@ public class Test
 {
     public static void Main()
     {
-        try
-        {
-            Test t = new Test();
-            t.Run();
-        }
-        catch (Exception exc)
-        {
-            Console.WriteLine("Message: {0}", exc.Message);
-            Console.ReadLine();
-        }
-        finally
-        {
-            Console.WriteLine("\n \n Done");
-            Console.ReadLine();
-        }
+        Test t = new Test();
+        t.Run();
+        
+        Console.WriteLine("\n \n Done");
+        Console.ReadLine();
     }
     private void Run()
     {

--- a/snippets/csharp/VS_Snippets_CFX/c_replaydetection/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_replaydetection/cs/source.cs
@@ -16,14 +16,7 @@ namespace Replay
 
         static void Main()
         {
-            try
-            {
-                Test t = new Test();
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-            }
+            Test t = new Test();
         }
 
         //<snippet1>

--- a/snippets/csharp/VS_Snippets_CFX/c_securityscenarios/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_securityscenarios/cs/source.cs
@@ -11,18 +11,7 @@ namespace BasicAuthentication
     {
         static void Main()
         {
-            try
-            {
-
-                MessageSecuritWithKerberosAuth.MyService.Run();
-            }
-            catch (System.Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-                //Console.WriteLine(ex.InnerException.Message);
-                Console.ReadLine();
-            }
-
+            MessageSecuritWithKerberosAuth.MyService.Run();
         }
 
         private void ClientConstructor()

--- a/snippets/csharp/VS_Snippets_CFX/c_settingsecuritymode/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_settingsecuritymode/cs/source.cs
@@ -9,18 +9,9 @@ namespace Samples
     {
         public static void Main()
         {
-            try
-            {
-                Test t = new Test();
-                //t.TcpMessageWithCredentialWindows();
-                t.AllConfig();
-            }
-            catch (System.Exception exc)
-            {
-                Console.WriteLine(exc.Message);
-                Console.ReadLine();
-            }
-            
+            Test t = new Test();
+            //t.TcpMessageWithCredentialWindows();
+            t.AllConfig();
         }
         private void AllConfig()
         {

--- a/snippets/csharp/VS_Snippets_CFX/c_supportingcredential/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_supportingcredential/cs/source.cs
@@ -20,16 +20,8 @@ namespace Samples
     {
         static void Main()
         {
-            try
-            {
-                Test t = new Test();
-                t.CreateSecurityBindingElement();
-            }
-            catch (System.Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-                Console.ReadLine();
-            }
+            Test t = new Test();
+            t.CreateSecurityBindingElement();
         }
 
         private SecurityBindingElement CreateSecurityBindingElement()

--- a/snippets/csharp/VS_Snippets_CFX/c_syncasyncclient/cs/client.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_syncasyncclient/cs/client.cs
@@ -82,10 +82,6 @@ public class Client
     {
       Console.WriteLine("There was a communication problem. " + commProblem.Message);
     }
-    catch (Exception e)
-    {
-      Console.WriteLine("There was an exception: " + e.Message);
-    }
   }
 
   public static void Main()

--- a/snippets/csharp/VS_Snippets_CFX/c_tcpclient/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_tcpclient/cs/source.cs
@@ -31,13 +31,6 @@ namespace Microsoft.Security.Samples
             {
                 Console.WriteLine("Message: {0}", exc.Message);
             }
-            catch (Exception exc)
-            {
-                Console.WriteLine(exc.Message);
-                Console.WriteLine(exc.InnerException.Message);
-                Console.ReadLine();
-            }
-
         }
 
         private void NetTcpSecurityWindows()

--- a/snippets/csharp/VS_Snippets_CFX/c_tcpservice/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_tcpservice/cs/source.cs
@@ -21,11 +21,6 @@ namespace TcpService
                 Console.WriteLine(iexc.Message);
                 Console.ReadLine();
             }
-            catch (System.Exception exc)
-            {
-                Console.WriteLine(exc.Message);
-                Console.ReadLine();
-            }
         }
 
         private void TcpTransportCert()
@@ -80,11 +75,6 @@ namespace TcpService
             {
                 Console.WriteLine("A commmunication error occurred: {0}", ce.Message);
                 Console.WriteLine();
-            }
-            catch (System.Exception exc)
-            {
-                Console.WriteLine("An unforseen error occurred: {0}", exc.Message);
-                Console.ReadLine();
             }
             //</snippet1>
         }
@@ -145,12 +135,6 @@ namespace TcpService
                 Console.WriteLine("A commmunication error occurred: {0}", ce.Message);
                 Console.WriteLine();
             }
-            catch (System.Exception exc)
-            {
-                Console.WriteLine("An unforseen error occurred: {0}", exc.Message);
-                Console.ReadLine();
-            }
-
             //</snippet2>
         }
 
@@ -188,11 +172,6 @@ namespace TcpService
                 Console.WriteLine("A commmunication error occurred: {0}", ce.Message);
                 Console.WriteLine();
             }
-            catch (System.Exception exc)
-            {
-                Console.WriteLine("An unforseen error occurred: {0}", exc.Message);
-                Console.ReadLine();
-            }
             //</snippet3>
         }
         private void RunClient()
@@ -229,11 +208,6 @@ namespace TcpService
                 Console.WriteLine(adExc.Message);
                 Console.ReadLine();
             }
-            catch (System.Exception exc)
-            {
-                Console.WriteLine(exc.Message);
-                Console.ReadLine();
-            }          
             //</snippet4>
         }
 

--- a/snippets/csharp/VS_Snippets_CFX/datacontractserializer/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/datacontractserializer/cs/source.cs
@@ -71,13 +71,6 @@ namespace DataContractSerializerExample
                 Console.WriteLine("Serialization Failed");
                 Console.WriteLine(serExc.Message);
             }
-            catch (Exception exc)
-            {
-                Console.WriteLine(
-                "The serialization operation failed: {0} StackTrace: {1}",
-                exc.Message, exc.StackTrace);
-            }
-
             finally
             {
                 Console.WriteLine("Press <Enter> to exit....");

--- a/snippets/csharp/VS_Snippets_CFX/datacontractserializeroperationbehavior/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/datacontractserializeroperationbehavior/cs/source.cs
@@ -112,18 +112,11 @@ namespace Example
 
         static void Main()
         {
-            try
-            {
-                Test t = new Test();
-                t.DataContractBehavior();
-            }
-            catch (System.Exception exc)
-            {
-                Console.WriteLine(exc.Message);
-                Console.ReadLine();
-            }
+            Test t = new Test();
+            t.DataContractBehavior();
         }
     }
+    
     [ServiceContract]
     interface ICalculator
     {

--- a/snippets/csharp/VS_Snippets_CFX/datamemberattribute/cs/overview.cs
+++ b/snippets/csharp/VS_Snippets_CFX/datamemberattribute/cs/overview.cs
@@ -68,12 +68,6 @@ public class Test
             WriteObject(@"DataMemberAttributeExample.xml");
             ReadObject(@"DataMemberAttributeExample.xml");
         }
-        catch (Exception exc)
-        {
-            Console.WriteLine(
-            "The serialization operation failed: {0} StackTrace: {1}",
-            exc.Message, exc.StackTrace);
-        }
         finally
         {
             Console.WriteLine("Press <Enter> to exit....");

--- a/snippets/csharp/VS_Snippets_CFX/invaliddatacontractexception/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/invaliddatacontractexception/cs/source.cs
@@ -30,12 +30,6 @@ namespace Example
                 Console.ReadLine();
                 
             }
-              catch (Exception exc)
-            {
-                Console.WriteLine(exc.Message);
-                Console.WriteLine(exc.ToString() );
-                Console.ReadLine();
-            }
         }
 
         private void Run()

--- a/snippets/csharp/VS_Snippets_CFX/lockdownvalidation/cs/hostapplication.cs
+++ b/snippets/csharp/VS_Snippets_CFX/lockdownvalidation/cs/hostapplication.cs
@@ -15,15 +15,8 @@ namespace Microsoft.WCF.Documentation
     static void Main()
     {
       HostApplication app = new HostApplication();
-      try
-      {
+      
       app.Run();
-      }
-      catch(Exception ex)
-      {
-        Console.WriteLine(ex);
-        Console.Read();
-      }
     }
 
     private void Run()

--- a/snippets/csharp/VS_Snippets_CFX/netdatacontractserializer/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/netdatacontractserializer/cs/source.cs
@@ -72,13 +72,7 @@ namespace DataContractSerializerExample
                 Console.WriteLine("Serialization Failed");
                 Console.WriteLine(serExc.Message);
             }
-            catch (Exception exc)
-            {
-                Console.WriteLine(
-                "The serialization operation failed: {0} StackTrace: {1}",
-                exc.Message, exc.StackTrace);
-            }
-
+            
             finally
             {
                 Console.WriteLine("Press <Enter> to exit....");

--- a/snippets/csharp/VS_Snippets_CFX/principalpermissionmode/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/principalpermissionmode/cs/source.cs
@@ -193,17 +193,8 @@ namespace CustomMode
     {
         public static void Main()
         {
-            try
-            {
-                ShowPrincipalPermissionModeCustom ppwm = new ShowPrincipalPermissionModeCustom();
-                ppwm.Run();
-
-            }
-            catch (Exception exc)
-            {
-                Console.WriteLine("Error: {0}", exc.Message);
-                Console.ReadLine();
-            }
+            ShowPrincipalPermissionModeCustom ppwm = new ShowPrincipalPermissionModeCustom();
+            ppwm.Run();
         }
     }
 

--- a/snippets/csharp/VS_Snippets_CFX/resumebookmarkendpoint/cs/program.cs
+++ b/snippets/csharp/VS_Snippets_CFX/resumebookmarkendpoint/cs/program.cs
@@ -32,10 +32,6 @@ namespace Microsoft.Samples.WF.ResumeBookmarkEndpoint
                 Console.WriteLine("Press return to exit ...");
                 Console.ReadLine();
             }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-            }
             finally
             {
                 if (host != null)

--- a/snippets/csharp/VS_Snippets_CFX/sendreceiveparameters/cs/echoworkflowclient/program.cs
+++ b/snippets/csharp/VS_Snippets_CFX/sendreceiveparameters/cs/echoworkflowclient/program.cs
@@ -19,15 +19,10 @@ namespace Microsoft.Samples.WorkflowServicesSamples.EchoWorkflowClient
         static void Main(string[] args)
         {
             CreateClientWorkflow();
-            try
-            {
-                WorkflowInvoker.Invoke(workflow);
-                Console.WriteLine("Workflow completed successfully.");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Workflow completed with {0}: {1}.", e.GetType().FullName, e.Message);
-            }
+            
+            WorkflowInvoker.Invoke(workflow);
+            Console.WriteLine("Workflow completed successfully.");
+            
             Console.WriteLine("To exit press ENTER.");
             Console.ReadLine();
         }

--- a/snippets/csharp/VS_Snippets_CFX/sendreceiveparameters/cs/echoworkflowservice/program.cs
+++ b/snippets/csharp/VS_Snippets_CFX/sendreceiveparameters/cs/echoworkflowservice/program.cs
@@ -101,10 +101,6 @@ namespace Microsoft.Samples.WorkflowServicesSamples.EchoWorkflowService
                 Console.WriteLine("To terminate press ENTER");
                 Console.ReadLine();
             }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Service terminated with exception {0}", ex.ToString());
-            }
             finally
             {
                 host.Close();

--- a/snippets/csharp/VS_Snippets_CFX/wf_samples/cs/snippets24.cs
+++ b/snippets/csharp/VS_Snippets_CFX/wf_samples/cs/snippets24.cs
@@ -1230,10 +1230,6 @@ namespace WF_Snippets
 
                     waitHandle.WaitOne();
                 }
-                catch (Exception e)
-                {
-                    Console.WriteLine("Exception \n\t Source: {0} \n\t Message: {1}", e.Source, e.Message);
-                }
                 finally
                 {
                     workflowRuntime.StopRuntime();

--- a/snippets/csharp/VS_Snippets_CFX/wfs_formatter/cs/program.cs
+++ b/snippets/csharp/VS_Snippets_CFX/wfs_formatter/cs/program.cs
@@ -20,16 +20,10 @@ namespace Microsoft.Samples.WorkflowServicesSamples.EchoWorkflowClient
         static void Main(string[] args)
         {
             CreateClientWorkflow();
-            try
-            {
-                WorkflowInvoker.Invoke(workflow);
-                Console.WriteLine("Workflow completed successfully.");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Workflow completed with {0}: {1}.", e.GetType().FullName, e.Message);
-            }
-
+            
+            WorkflowInvoker.Invoke(workflow);
+            Console.WriteLine("Workflow completed successfully.");
+            
             Console.WriteLine("To exit press ENTER.");
             Console.ReadLine();
         }

--- a/snippets/csharp/VS_Snippets_CFX/x509accessible/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/x509accessible/cs/source.cs
@@ -11,17 +11,7 @@ namespace BasicAuthentication
     {
         static void Main()
         {
-            try
-            {
-
-                MessageSecuritWithKerberosAuth.MyService.Run();
-            }
-            catch (System.Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-                //Console.WriteLine(ex.InnerException.Message);
-                Console.ReadLine();
-            }
+            MessageSecuritWithKerberosAuth.MyService.Run();
         }
 
         public static void Run()

--- a/snippets/csharp/VS_Snippets_CFX/xmlobjectserializer/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/xmlobjectserializer/cs/source.cs
@@ -80,12 +80,6 @@ namespace Example
                 Console.WriteLine(qExc.Message);
                 Console.ReadLine();
             }
-            catch (Exception exc)
-            {
-                Console.WriteLine(exc.Message);
-                Console.WriteLine(exc.ToString());
-                Console.ReadLine();
-            }
         }
         //</snippet1>
     }

--- a/snippets/csharp/VS_Snippets_CFX/xmlserializeroperationbehavior/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/xmlserializeroperationbehavior/cs/source.cs
@@ -54,16 +54,8 @@ namespace Example
 
         static void Main()
         {
-            try
-            {
-                Test t = new Test();
-                t.Run();
-            }
-            catch (System.Exception exc)
-            {
-                Console.WriteLine(exc.Message);
-                Console.ReadLine();
-            }
+            Test t = new Test();
+            t.Run();
         }
     }
     [ServiceContract]

--- a/snippets/csharp/VS_Snippets_CFX/xsddatacontractexporter/cs/overview.cs
+++ b/snippets/csharp/VS_Snippets_CFX/xsddatacontractexporter/cs/overview.cs
@@ -12,10 +12,6 @@ public class Program
         {
             ExportXSD();
         }
-        catch (Exception exc)
-        {
-            Console.WriteLine("Message: {0} StackTrace:{1}", exc.Message, exc.StackTrace);
-        }
         finally
         {
             Console.ReadLine();

--- a/snippets/csharp/VS_Snippets_CFX/xsddatacontractimporter/cs/xsddatacontractimporterexample.cs
+++ b/snippets/csharp/VS_Snippets_CFX/xsddatacontractimporter/cs/xsddatacontractimporterexample.cs
@@ -21,10 +21,6 @@ namespace XsdContractImporterExample
                 CompileCode(ccu, "Person.cs");
                 CompileCode(ccu, "Person.vb");
             }
-            catch (Exception exc)
-            {
-                Console.WriteLine("{0}: {1}", exc.Message, exc.StackTrace);
-            }
             finally
             {
                 Console.WriteLine("Press <Enter> to end....");

--- a/snippets/csharp/VS_Snippets_CLR/AccessControl.FileSystemAuditRule/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/AccessControl.FileSystemAuditRule/cs/sample.cs
@@ -9,8 +9,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 string FileName = "test.xml";
 
                 Console.WriteLine("Adding access control entry for " + FileName);
@@ -24,13 +22,8 @@ namespace FileSystemExample
                 RemoveFileAuditRule(FileName, @"MYDOMAIN\MyAccount", FileSystemRights.ReadData, AuditFlags.Failure);
 
                 Console.WriteLine("Done.");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-
-            Console.ReadLine();
+            
+                Console.ReadLine();
         }
 
         // Adds an ACL entry on the specified file for the specified account.

--- a/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller/CS/assemblyinstaller.cs
+++ b/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller/CS/assemblyinstaller.cs
@@ -40,10 +40,6 @@ class AssemblyInstaller_Example
       catch (ArgumentException)
       {
       }
-      catch (Exception e)
-      {
-         Console.WriteLine( e.Message );
-      }
    }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_CheckIfInstallable/CS/assemblyinstaller_checkifinstallable.cs
+++ b/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_CheckIfInstallable/CS/assemblyinstaller_checkifinstallable.cs
@@ -16,10 +16,6 @@ class MyCheckIfInstallableClass:Installer
 {
    static void Main()
    {
-
-
-      try
-      {
          // Determine whether the assembly 'MyAssembly' is installable.
          AssemblyInstaller.CheckIfInstallable( "MyAssembly_CheckIfInstallable.exe" );
 
@@ -27,12 +23,6 @@ class MyCheckIfInstallableClass:Installer
 
          // Determine whether the assembly 'NonExistant' is installable.
          AssemblyInstaller.CheckIfInstallable( "NonExistant" );
-      }
-      catch( Exception )
-      {
-      }
-
-
    }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_HelpText/CS/assemblyinstaller_helptext.cs
+++ b/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_HelpText/CS/assemblyinstaller_helptext.cs
@@ -48,10 +48,5 @@ class AssemblyInstaller_Example
       catch( ArgumentException )
       {
       }
-      catch( Exception e )
-      {
-         Console.WriteLine( e.Message );
-      }
-
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_Install/CS/assemblyinstaller_install.cs
+++ b/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_Install/CS/assemblyinstaller_install.cs
@@ -23,8 +23,6 @@ class MyInstallClass
 
       Console.WriteLine( "" );
 
-      try
-      {
          // Set the commandline argument array for 'logfile'.
          string[] myString = new string[ 1 ];
          myString[ 0 ] = "/logFile=example.log";
@@ -47,12 +45,7 @@ class MyInstallClass
 
          // Commit the 'MyAssembly_Install' assembly.
          myAssemblyInstaller.Commit( mySavedState );
-      }
-      catch( Exception )
-      {
-      }
-
-
+      
    }
 }
 // </Snippet2>

--- a/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_Rollback/CS/assemblyinstaller_rollback.cs
+++ b/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_Rollback/CS/assemblyinstaller_rollback.cs
@@ -23,8 +23,6 @@ class AssemblyInstaller_Example
 
       Console.WriteLine( "" );
 
-      try
-      {
 // <Snippet2>
          // Create an object of the 'AssemblyInstaller' class.
          AssemblyInstaller myAssemblyInstaller = new AssemblyInstaller();
@@ -54,10 +52,5 @@ class AssemblyInstaller_Example
       catch( ArgumentException )
       {
       }
-      catch( Exception e )
-      {
-         Console.WriteLine( e.Message );
-      }
-
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_Uninstall/CS/assemblyinstaller_uninstall.cs
+++ b/snippets/csharp/VS_Snippets_CLR/AssemblyInstaller_Uninstall/CS/assemblyinstaller_uninstall.cs
@@ -54,9 +54,5 @@ class MyInstallClass
       catch( ArgumentException )
       {
       }
-      catch( Exception myException )
-      {
-         Console.WriteLine( myException.Message );
-      }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception.cs
+++ b/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception.cs
@@ -14,10 +14,6 @@ class ExceptionTestClass
          {
             Console.WriteLine("ArithmeticException Handler: {0}", e.ToString());
          }
-         catch (Exception e) 
-         {
-            Console.WriteLine("Generic Exception Handler: {0}", e.ToString());
-         }
    }	
 }
 /*

--- a/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception2.cs
@@ -6,15 +6,9 @@ public class ProcessFile
 {
     public static void Main()
     {
-        try
+        using (StreamReader sr = File.OpenText("data.txt"))
         {
-            StreamReader sr = File.OpenText("data.txt");
             Console.WriteLine("The first line of this file is {0}", sr.ReadLine());
-	    sr.Close();
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("An error occurred: '{0}'", e);
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception3.cs
+++ b/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception3.cs
@@ -17,10 +17,6 @@ public class ProcessFile
             Console.WriteLine("[Data File Missing] {0}", e);
         }
         //</snippet5>
-        catch (Exception e)
-        {
-            Console.WriteLine("An error occurred: '{0}'", e);
-        }
     }
 }
 //</snippet4>

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.3DES.Create.File/CS/fileexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.3DES.Create.File/CS/fileexample.cs
@@ -9,8 +9,6 @@ class TripleDESSample
 
     static void Main()
     {
-        try
-        {
             // Create a new TripleDES object to generate a key
             // and an initialization vector (IV).
             using (TripleDES TripleDESalg = TripleDES.Create())
@@ -28,12 +26,6 @@ class TripleDESSample
                 // Display the decrypted string to the console.
                 Console.WriteLine(Final);
             }
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-
     }
 
     public static void EncryptTextToFile(String Data, String FileName, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.3DES.Create.Memory/CS/memoryexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.3DES.Create.Memory/CS/memoryexample.cs
@@ -8,9 +8,6 @@ namespace AesManaged_Examples
     {
         public static void Main()
         {
-            try
-            {
-
                 string original = "Here is some data to encrypt!";
 
                 // Create a new instance of the AesCryptoServiceProvider
@@ -29,12 +26,6 @@ namespace AesManaged_Examples
                     Console.WriteLine("Original:   {0}", original);
                     Console.WriteLine("Round Trip: {0}", roundtrip);
                 }
-
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Error: {0}", e.Message);
-            }
         }
 
         static byte[] encryptStringToBytes_AesManaged(string plainText, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.3DES.Createstring.File/CS/fileexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.3DES.Createstring.File/CS/fileexample.cs
@@ -9,8 +9,6 @@ class TripleDESSample
 
     static void Main()
     {
-        try
-        {
             // Create a new TripleDES object to generate a key 
             // and initialization vector (IV).  Specify one 
             // of the recognized simple names for this 
@@ -29,12 +27,6 @@ class TripleDESSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static void EncryptTextToFile(String Data, String FileName, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.3DES.Createstring.Memory/CS/memoryexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.3DES.Createstring.Memory/CS/memoryexample.cs
@@ -8,8 +8,6 @@ class TripleDESSample
 {
     static void Main()
     {
-        try
-        {
             // Create a new TripleDES object to generate a key 
             // and initialization vector (IV).  Specify one 
             // of the recognized simple names for this 
@@ -27,12 +25,6 @@ class TripleDESSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static byte[] EncryptTextToMemory(string Data,  byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.3DESCSP.CreateEncryptor.File/CS/fileexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.3DESCSP.CreateEncryptor.File/CS/fileexample.cs
@@ -9,8 +9,6 @@ class TrippleDESCSPSample
 
     static void Main()
     {
-        try
-        {
             // Create a new TripleDESCryptoServiceProvider object
             // to generate a key and initialization vector (IV).
             TripleDESCryptoServiceProvider tDESalg = new TripleDESCryptoServiceProvider();
@@ -27,12 +25,6 @@ class TrippleDESCSPSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static void EncryptTextToFile(String Data, String FileName, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.3DESCSP.CreateEncryptor.Memory/CS/memoryexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.3DESCSP.CreateEncryptor.Memory/CS/memoryexample.cs
@@ -9,8 +9,6 @@ class TrippleDESCSPSample
 
     static void Main()
     {
-        try
-        {
             // Create a new TripleDESCryptoServiceProvider object
             // to generate a key and initialization vector (IV).
             TripleDESCryptoServiceProvider tDESalg = new TripleDESCryptoServiceProvider();
@@ -26,12 +24,6 @@ class TrippleDESCSPSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static byte[] EncryptTextToMemory(string Data,  byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.DES.Create.File/CS/fileexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.DES.Create.File/CS/fileexample.cs
@@ -9,8 +9,6 @@ class DESSample
 
     static void Main()
     {
-        try
-        {
             // Create a new DES object to generate a key
             // and initialization vector (IV).
             DES DESalg = DES.Create();
@@ -27,12 +25,6 @@ class DESSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static void EncryptTextToFile(String Data, String FileName, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.DES.Create.Memory/CS/memoryexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.DES.Create.Memory/CS/memoryexample.cs
@@ -8,8 +8,6 @@ class DESSample
 {
     static void Main()
     {
-        try
-        {
             // Create a new DES object to generate a key
             // and initialization vector (IV).
             DES DESalg = DES.Create();
@@ -25,12 +23,6 @@ class DESSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static byte[] EncryptTextToMemory(string Data,  byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.DES.Createstring.File/CS/fileexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.DES.Createstring.File/CS/fileexample.cs
@@ -9,8 +9,6 @@ class DESSample
 
     static void Main()
     {
-        try
-        {
             // Create a new DES object to generate a key 
             // and initialization vector (IV).  Specify one 
             // of the recognized simple names for this 
@@ -29,11 +27,6 @@ class DESSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
        
     }
 

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.DES.Createstring.Memory/CS/memoryexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.DES.Createstring.Memory/CS/memoryexample.cs
@@ -8,8 +8,6 @@ class DESSample
 {
     static void Main()
     {
-        try
-        {
             // Create a new DES object to generate a key 
             // and initialization vector (IV).  Specify one 
             // of the recognized simple names for this 
@@ -27,12 +25,6 @@ class DESSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static byte[] EncryptTextToMemory(string Data,  byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.DESCSP.CreateEncryptor.File/CS/fileexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.DESCSP.CreateEncryptor.File/CS/fileexample.cs
@@ -9,8 +9,6 @@ class DESCSPSample
 
     static void Main()
     {
-        try
-        {
             // Create a new DESCryptoServiceProvider object
             // to generate a key and initialization vector (IV).
             DESCryptoServiceProvider DESalg = new DESCryptoServiceProvider();
@@ -27,12 +25,6 @@ class DESCSPSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static void EncryptTextToFile(String Data, String FileName, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.DESCSP.CreateEncryptor.Memory/CS/memoryexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.DESCSP.CreateEncryptor.Memory/CS/memoryexample.cs
@@ -8,8 +8,6 @@ class DESCSPSample
 {
     static void Main()
     {
-        try
-        {
             // Create a new DESCryptoServiceProvider object
             // to generate a key and initialization vector (IV).
             DESCryptoServiceProvider DESalg = new DESCryptoServiceProvider();
@@ -25,12 +23,6 @@ class DESCSPSample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static byte[] EncryptTextToMemory(string Data,  byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.PasswordDerivedbytes/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.PasswordDerivedbytes/CS/sample.cs
@@ -37,10 +37,6 @@ public class PasswordDerivedBytesExample
 
             Console.WriteLine("Operation complete.");
         }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
         finally
         {
             // Clear the buffers

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.RC2.Create.File/CS/fileexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.RC2.Create.File/CS/fileexample.cs
@@ -9,8 +9,6 @@ class RC2Sample
 
     static void Main()
     {
-        try
-        {
             // Create a new RC2 object to generate a key
             // and initialization vector (IV).
             RC2 RC2alg = RC2.Create();
@@ -27,12 +25,6 @@ class RC2Sample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static void EncryptTextToFile(String Data, String FileName, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.RC2.Create.Memory/CS/memoryexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.RC2.Create.Memory/CS/memoryexample.cs
@@ -8,8 +8,6 @@ class RC2Sample
 {
     static void Main()
     {
-        try
-        {
             // Create a new RC2 object to generate a key
             // and initialization vector (IV).
             RC2 RC2alg = RC2.Create();
@@ -25,12 +23,6 @@ class RC2Sample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static byte[] EncryptTextToMemory(string Data,  byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.RC2.Createstring.File/CS/fileexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.RC2.Createstring.File/CS/fileexample.cs
@@ -9,8 +9,6 @@ class RC2Sample
 
     static void Main()
     {
-        try
-        {
             // Create a new RC2 object to generate a key 
             // and initialization vector (IV).  Specify one 
             // of the recognized simple names for this 
@@ -29,12 +27,6 @@ class RC2Sample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static void EncryptTextToFile(String Data, String FileName, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.RC2.Createstring.Memory/CS/memoryexample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.RC2.Createstring.Memory/CS/memoryexample.cs
@@ -8,8 +8,6 @@ class RC2Sample
 {
     static void Main()
     {
-        try
-        {
             // Create a new RC2 object to generate a key 
             // and initialization vector (IV).  Specify one 
             // of the recognized simple names for this 
@@ -27,12 +25,6 @@ class RC2Sample
             
             // Display the decrypted string to the console.
             Console.WriteLine(Final);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-       
     }
 
     public static byte[] EncryptTextToMemory(string Data,  byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.RsaCryptoServiceProvider.CspKeyContainerInfo/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.RsaCryptoServiceProvider.CspKeyContainerInfo/CS/sample.cs
@@ -71,10 +71,6 @@ public class CspKeyContainerInfoExample
 
 
         }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.ToString());
-        }
         finally
         {
             // Clear the key.

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML-EncryptedData - EncryptedType/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML-EncryptedData - EncryptedType/cs/sample.cs
@@ -13,15 +13,11 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
+        
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
+        
+        
 
         // Create a new TripleDES key. 
         TripleDESCryptoServiceProvider tDESkey = new TripleDESCryptoServiceProvider();
@@ -45,10 +41,6 @@ class Program
             Console.WriteLine("Decrypted XML:");
             Console.WriteLine();
             Console.WriteLine(xmlDoc.OuterXml);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
         }
         finally
         {

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.DataReference/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.DataReference/cs/sample.cs
@@ -14,16 +14,9 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
+        
         // Create a new RSA key.  This key will encrypt a symmetric key,
         // which will then be imbedded in the XML document.  
         RSA rsaKey = new RSACryptoServiceProvider();

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.EncryptedData/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.EncryptedData/cs/sample.cs
@@ -13,16 +13,9 @@ class Program
 		XmlDocument xmlDoc = new XmlDocument();
 
 		// Load an XML file into the XmlDocument object.
-		try
-		{
-			xmlDoc.PreserveWhitespace = true;
-			xmlDoc.Load("test.xml");
-		}
-		catch (Exception e)
-		{
-			Console.WriteLine(e.Message);
-		}
-
+		xmlDoc.PreserveWhitespace = true;
+		xmlDoc.Load("test.xml");
+		
 		// Create a new RSA key.  This key will encrypt a symmetric key,
 		// which will then be imbedded in the XML document.  
 		RSA rsaKey = new RSACryptoServiceProvider();
@@ -39,10 +32,6 @@ class Program
 			// Decrypt the "creditcard" element.
 			Decrypt(xmlDoc, rsaKey, "rsaKey");
 
-		}
-		catch (Exception e)
-		{
-			Console.WriteLine(e.Message);
 		}
 		finally
 		{

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.EncryptedKey/cs/example.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.EncryptedKey/cs/example.cs
@@ -13,16 +13,10 @@ class Program
 		XmlDocument xmlDoc = new XmlDocument();
 
 		// Load an XML file into the XmlDocument object.
-		try
-		{
-			xmlDoc.PreserveWhitespace = true;
-			xmlDoc.Load("test.xml");
-		}
-		catch (Exception e)
-		{
-			Console.WriteLine(e.Message);
-		}
-
+		
+		xmlDoc.PreserveWhitespace = true;
+		xmlDoc.Load("test.xml");
+		
 		// Create a new RSA key.  This key will encrypt a symmetric key,
 		// which will then be imbedded in the XML document.  
 		RSA rsaKey = new RSACryptoServiceProvider();

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.EncryptionProperty/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.EncryptionProperty/cs/sample.cs
@@ -13,16 +13,9 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
+        
         // Create a new RSA key.  This key will encrypt a symmetric key,
         // which will then be imbedded in the XML document.  
         RSA rsaKey = new RSACryptoServiceProvider();

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.MainXMLEncDecryptDataOOP/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.MainXMLEncDecryptDataOOP/CS/sample.cs
@@ -13,17 +13,9 @@ using System.Security.Cryptography.Xml;
 			XmlDocument xmlDoc = new XmlDocument();
 
 			// Load an XML file into the XmlDocument object.
-			try
-			{
-				xmlDoc.PreserveWhitespace = true;
-				xmlDoc.Load("test.xml");
-			}
-			catch (Exception e)
-			{
-				Console.WriteLine(e.Message);
-				return;
-			}
-
+			xmlDoc.PreserveWhitespace = true;
+			xmlDoc.Load("test.xml");
+			
 			// Create a new TripleDES key. 
 			TripleDESCryptoServiceProvider tDESkey = new TripleDESCryptoServiceProvider();
 

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncImbedKey/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncImbedKey/CS/sample.cs
@@ -13,16 +13,8 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-            return;
-        }
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
 
         // Create a new RSA key.  This key will encrypt a symmetric key,
         // which will then be imbedded in the XML document.  
@@ -49,10 +41,6 @@ class Program
             Console.WriteLine("Decrypted XML:");
             Console.WriteLine();
             Console.WriteLine(xmlDoc.OuterXml);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
         }
         finally
         {

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncMapKey/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncMapKey/CS/sample.cs
@@ -13,16 +13,8 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-            return;
-        }
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
 
         // Create a new TripleDES key. 
         TripleDESCryptoServiceProvider tDESkey = new TripleDESCryptoServiceProvider();

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncMapKeyX509/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncMapKeyX509/CS/sample.cs
@@ -14,17 +14,9 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-            return;
-        }
-
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
+        
         // Create a new X509Certificate2 object by loading
         // an X.509 certificate file.  To use XML encryption 
         // with an X.509 certificate, use an X509Certificate2 

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncMinimalDecrypt/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncMinimalDecrypt/CS/sample.cs
@@ -13,16 +13,9 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
+        
         // Create a new TripleDES key. 
         TripleDESCryptoServiceProvider tDESkey = new TripleDESCryptoServiceProvider();
 

--- a/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncMinimalDecryptData/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Cryptography.XML.XMLEncMinimalDecryptData/CS/sample.cs
@@ -13,17 +13,9 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-            return;
-        }
-
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
+        
         // Create a new TripleDES key. 
         TripleDESCryptoServiceProvider tDESkey = new TripleDESCryptoServiceProvider();
 

--- a/snippets/csharp/VS_Snippets_CLR/DPAPI-HowTO/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DPAPI-HowTO/cs/sample.cs
@@ -13,9 +13,6 @@ public class MemoryProtectionSample
 
     public static void Run()
     {
-        try
-        {
-
             ///////////////////////////////
             //
             // Memory Encryption - ProtectedMemory
@@ -75,14 +72,6 @@ public class MemoryProtectionSample
             fStream.Close();
 
             Console.WriteLine("Decrypted data: " + UnicodeEncoding.ASCII.GetString(decryptData));
-
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("ERROR: " + e.Message);
-        }
-
     }
 
 

--- a/snippets/csharp/VS_Snippets_CLR/DateTime.FromFileTime/CS/class1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DateTime.FromFileTime/CS/class1.cs
@@ -9,14 +9,7 @@ namespace FromFileTime
 		{			
 			System.Console.WriteLine("Enter a file's path");
 			string filePath = System.Console.ReadLine();
-			System.IO.FileInfo fInfo;
-			try {
-				fInfo = new System.IO.FileInfo(filePath);
-			}
-			catch {
-				System.Console.WriteLine("Error opening {0}", filePath);
-				return;
-			}
+		    System.IO.FileInfo fInfo = new System.IO.FileInfo(filePath);
 			long fileTime = System.Convert.ToInt64(fInfo.CreationTime.ToFileTime());
 			Class1 theApp = new Class1();
 			System.TimeSpan fileAge = theApp.FileAge(fileTime);

--- a/snippets/csharp/VS_Snippets_CLR/DirInfo Class Example/CS/dirinfo class example.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DirInfo Class Example/CS/dirinfo class example.cs
@@ -8,8 +8,7 @@ class Test
     {
         // Specify the directories you want to manipulate.
         DirectoryInfo di = new DirectoryInfo(@"c:\MyDir");
-        try 
-        {
+        
             // Determine whether the directory exists.
             if (di.Exists) 
             {
@@ -25,13 +24,6 @@ class Test
             // Delete the directory.
             di.Delete();
             Console.WriteLine("The directory was deleted successfully.");
-
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        } 
-        finally {}
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/DirInfo Create/CS/dirinfo create.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DirInfo Create/CS/dirinfo create.cs
@@ -9,8 +9,6 @@ class Test
         // Specify the directories you want to manipulate.
         DirectoryInfo di = new DirectoryInfo(@"c:\MyDir");
 
-        try 
-        {
             // Determine whether the directory exists.
             if (di.Exists) 
             {
@@ -26,13 +24,6 @@ class Test
             // Delete the directory.
             di.Delete();
             Console.WriteLine("The directory was deleted successfully.");
-
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        } 
-        finally {}
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/DirInfo Ctor/CS/dirinfo ctor.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DirInfo Ctor/CS/dirinfo ctor.cs
@@ -10,8 +10,6 @@ class Test
         DirectoryInfo di1 = new DirectoryInfo(@"c:\MyDir");
         DirectoryInfo di2 = new DirectoryInfo(@"c:\MyDir\temp");
 
-        try 
-        {
             // Create the directories.
             di1.Create();
             di2.Create();
@@ -20,12 +18,6 @@ class Test
             Console.WriteLine("I am about to attempt to delete {0}.", di1.Name);
             di1.Delete();
             Console.WriteLine("The Delete operation was successful, which was unexpected.");
-        } 
-        catch (Exception) 
-        {
-            Console.WriteLine("The Delete operation failed as expected.");
-        } 
-        finally {}
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/DirInfo Delete1/CS/dirinfo delete1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DirInfo Delete1/CS/dirinfo delete1.cs
@@ -9,8 +9,6 @@ class Test
         // Specify the directories you want to manipulate.
         DirectoryInfo di1 = new DirectoryInfo(@"c:\MyDir");
 
-        try 
-        {
             // Create the directories.
             di1.Create();
             di1.CreateSubdirectory("temp");
@@ -19,12 +17,6 @@ class Test
             Console.WriteLine("I am about to attempt to delete {0}", di1.Name);
             di1.Delete();
             Console.WriteLine("The Delete operation was successful, which was unexpected.");
-        } 
-        catch (Exception) 
-        {
-            Console.WriteLine("The Delete operation failed as expected.");
-        } 
-        finally {}
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/DirInfo GetDirs2/CS/dirinfo getdirs2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DirInfo GetDirs2/CS/dirinfo getdirs2.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             DirectoryInfo di = new DirectoryInfo(@"c:\");
 
             // Get only subdirectories that contain the letter "p."
@@ -19,11 +17,6 @@ class Test
                 Console.WriteLine("The number of files in {0} is {1}", diNext, 
                     diNext.GetFiles().Length);
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/DirInfo GetFileSysInfos2/CS/dirinfo getfilesysinfos2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DirInfo GetFileSysInfos2/CS/dirinfo getfilesysinfos2.cs
@@ -11,8 +11,7 @@ class DirectoryFileCount
 
     static void Main()
     {
-        try
-        {
+        
             Console.WriteLine("Enter the path to a directory:");
 
             string directory = Console.ReadLine();
@@ -41,17 +40,6 @@ class DirectoryFileCount
             // Display the results to the console. 
             Console.WriteLine("Directories: {0}", directories);
             Console.WriteLine("Files: {0}", files);
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-        finally
-        {
-
-            Console.ReadLine();
-        }
     }
 
     static void ListDirectoriesAndFiles(FileSystemInfo[] FSInfo, string SearchString)

--- a/snippets/csharp/VS_Snippets_CLR/Dir_CreateDir/CS/dir_createdir.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_CreateDir/CS/dir_createdir.cs
@@ -9,8 +9,6 @@ class Test
         // Specify the directory you want to manipulate.
         string path = @"c:\MyDir";
 
-        try 
-        {
             // Determine whether the directory exists.
             if (Directory.Exists(path)) 
             {
@@ -25,12 +23,6 @@ class Test
             // Delete the directory.
             di.Delete();
             Console.WriteLine("The directory was deleted successfully.");
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        } 
-        finally {}
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_GetCreation/CS/dir_getcreation.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_GetCreation/CS/dir_getcreation.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             // Get the creation time of a well-known directory.
             DateTime dt = Directory.GetCreationTime(Environment.CurrentDirectory);
 
@@ -28,11 +26,6 @@ class Test
             {
                 Console.WriteLine("This directory was created on {0}", dt);
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_GetCurDir/CS/dir_getcurdir.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_GetCurDir/CS/dir_getcurdir.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             // Get the current directory.
             string path = Directory.GetCurrentDirectory();
             string target = @"c:\temp";
@@ -27,11 +25,6 @@ class Test
             {
                 Console.WriteLine("You are not in the temp directory.");
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_GetDirs2/CS/dir_getdirs2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_GetDirs2/CS/dir_getdirs2.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             // Only get subdirectories that begin with the letter "p."
             string[] dirs = Directory.GetDirectories(@"c:\", "p*");
             Console.WriteLine("The number of directories starting with p is {0}.", dirs.Length);
@@ -15,11 +13,6 @@ class Test
             {
                 Console.WriteLine(dir);
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_GetDirs2/CS/dir_getdirs3.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_GetDirs2/CS/dir_getdirs3.cs
@@ -6,19 +6,12 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string[] dirs = Directory.GetDirectories(@"c:\", "p*", SearchOption.TopDirectoryOnly);
             Console.WriteLine("The number of directories starting with p is {0}.", dirs.Length);
             foreach (string dir in dirs) 
             {
                 Console.WriteLine(dir);
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet2>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_GetFiles2/CS/dir_getfiles2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_GetFiles2/CS/dir_getfiles2.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             // Only get files that begin with the letter "c."
             string[] dirs = Directory.GetFiles(@"c:\", "c*");
             Console.WriteLine("The number of files starting with c is {0}.", dirs.Length);
@@ -15,11 +13,6 @@ class Test
             {
                 Console.WriteLine(dir);
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_GetLastAccess/CS/dir_getlastaccess.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_GetLastAccess/CS/dir_getlastaccess.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string path = @"c:\MyDir";
             if (!Directory.Exists(path)) 
             {
@@ -23,12 +21,6 @@ class Test
             Directory.SetLastAccessTime(path, DateTime.Now);
             dt = Directory.GetLastAccessTime(path);
             Console.WriteLine("The last access time for this directory was {0}", dt);
-        } 
-
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_GetLastWrite/CS/dir_getlastwrite.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_GetLastWrite/CS/dir_getlastwrite.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string path = @"c:\MyDir";
             if (!Directory.Exists(path)) 
             {
@@ -27,12 +25,6 @@ class Test
             Directory.SetLastWriteTime(path, DateTime.Now);
             dt = Directory.GetLastWriteTime(path);
             Console.WriteLine("The last write time for this directory was {0}", dt);
-        } 
-
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_SetLastAccess/CS/dir_setlastaccess.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_SetLastAccess/CS/dir_setlastaccess.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string path = @"c:\MyDir";
             if (!Directory.Exists(path)) 
             {
@@ -23,12 +21,6 @@ class Test
             Directory.SetLastAccessTime(path, DateTime.Now);
             dt = Directory.GetLastAccessTime(path);
             Console.WriteLine("The last access time for this directory was {0}", dt);
-        } 
-
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Dir_SetLastWrite/CS/dir_setlastwrite.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Dir_SetLastWrite/CS/dir_setlastwrite.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string path = @"c:\MyDir";
             if (!Directory.Exists(path)) 
             {
@@ -27,11 +25,6 @@ class Test
             Directory.SetLastWriteTime(path, DateTime.Now);
             dt = Directory.GetLastWriteTime(path);
             Console.WriteLine("The last write time for this directory was {0}", dt);
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/EntryWrittenEventArgs_ctor1/CS/entrywritteneventargs_ctor1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EntryWrittenEventArgs_ctor1/CS/entrywritteneventargs_ctor1.cs
@@ -15,8 +15,6 @@ class MySample
 {
     public static void Main()
     {
-        try
-        {
             EventLog myNewLog = new EventLog();
             myNewLog.Log = "MyNewLog";
             myNewLog.Source = "MySource";
@@ -40,11 +38,6 @@ class MySample
             EntryWrittenEventArgs myEntryEventArgs =
                                  new EntryWrittenEventArgs();
             MyOnEntry(myNewLog, myEntryEventArgs);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("Exception Raised" + e.Message);
-        }
     }
     protected static void MyOnEntry(Object source, EntryWrittenEventArgs e)
     {

--- a/snippets/csharp/VS_Snippets_CLR/EntryWrittenEventArgs_ctor2/CS/entrywritteneventargs_ctor2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EntryWrittenEventArgs_ctor2/CS/entrywritteneventargs_ctor2.cs
@@ -16,8 +16,6 @@ class MySample
 {
     public static void Main()
     {
-        try
-        {
             EventLog myNewLog = new EventLog();
             myNewLog.Log = "MyNewLog";
             myNewLog.Source = "MySource";
@@ -41,11 +39,6 @@ class MySample
             EntryWrittenEventArgs myEntryEventArgs =
                                  new EntryWrittenEventArgs(entry);
             MyOnEntry(myNewLog, myEntryEventArgs);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("Exception Raised" + e.Message);
-        }
     }
     // <Snippet2>
     protected static void MyOnEntry(Object source, EntryWrittenEventArgs e)

--- a/snippets/csharp/VS_Snippets_CLR/EnumBuilder_Properties_4.cs/CS/enumbuilder_properties_4.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EnumBuilder_Properties_4.cs/CS/enumbuilder_properties_4.cs
@@ -30,8 +30,6 @@ public class MyEnumBuilderSample
    
    public static void Main()
    {
-      try
-      {
          CreateCallee(Thread.GetDomain(), AssemblyBuilderAccess.Save);
          Type[] myTypeArray = myModuleBuilder.GetTypes();
          foreach(Type myType in myTypeArray)
@@ -52,10 +50,6 @@ public class MyEnumBuilderSample
       catch(NotSupportedException ex)
       {
          Console.WriteLine("The following is the exception is raised: " + ex.Message);
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("The following is the exception raised: " + e.Message);
       }
    }
 

--- a/snippets/csharp/VS_Snippets_CLR/EnumBuilder_Properties_5/CS/enumbuilder_properties_5.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EnumBuilder_Properties_5/CS/enumbuilder_properties_5.cs
@@ -32,8 +32,6 @@ public class MyEnumBuilderSample
    
    public static void Main()
    {
-      try
-      {
          CreateCallee(Thread.GetDomain(), AssemblyBuilderAccess.Save);
          Type[] myTypeArray = myModuleBuilder.GetTypes();
          foreach(Type myType in myTypeArray)
@@ -54,10 +52,6 @@ public class MyEnumBuilderSample
       catch(NotSupportedException ex)
       {
          Console.WriteLine("The following is the exception is raised: " + ex.Message);
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("The following is the exception raised: " + e.Message);
       }
    }
 

--- a/snippets/csharp/VS_Snippets_CLR/EnumBuilder_SetCustomAttribute1/CS/enumbuilder_setcustomattribute1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EnumBuilder_SetCustomAttribute1/CS/enumbuilder_setcustomattribute1.cs
@@ -39,8 +39,6 @@ class MyApplication
 
    public static void Main()
    {
-      try
-      {
          CreateCallee(Thread.GetDomain());
          if(myEnumBuilder.IsDefined(typeof(MyAttribute),false))
          {
@@ -62,12 +60,6 @@ class MyApplication
          {
             Console.WriteLine("Custom Attributes are not set for the EnumBuilder");
          }
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("The following exception is raised:" +e.Message);
-      }
-
   }
 
    private static void CreateCallee(AppDomain domain)

--- a/snippets/csharp/VS_Snippets_CLR/EnumBuilder_SetCustomAttribute2/CS/enumbuilder_setcustomattribute2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EnumBuilder_SetCustomAttribute2/CS/enumbuilder_setcustomattribute2.cs
@@ -36,8 +36,6 @@ class MyApplication
    
    public static void Main()
    {
-      try
-      {
          CreateCallee(Thread.GetDomain());
          object[] myAttributesArray = myEnumBuilder.GetCustomAttributes(true);
 
@@ -51,11 +49,6 @@ class MyApplication
                                        ((MyAttribute)myAttributesArray[index]).myBoolValue);
             }
          }
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("The following exception is raised:" +e.Message);
-      }
    }
 
    private static void CreateCallee(AppDomain domain)

--- a/snippets/csharp/VS_Snippets_CLR/EventLogEntryType_6/CS/eventlogentrytype_6.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EventLogEntryType_6/CS/eventlogentrytype_6.cs
@@ -21,8 +21,6 @@ class MyEventLogEntryType
 {
     public static void Main()
     {
-        try
-        {
             EventLog myEventLog;
             string mySource = null;
             string myLog = null;
@@ -97,11 +95,6 @@ class MyEventLogEntryType
                + "is successfully written into event log.",
                myEventLog.Log, myID);
             // </Snippet2>
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("Exception: {0}", e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/EventLogEntry_CopyTo/CS/eventlogentry_copyto.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EventLogEntry_CopyTo/CS/eventlogentry_copyto.cs
@@ -17,8 +17,6 @@ class EventLogEntryCollection_Item
 {
     public static void Main()
     {
-        try
-        {
             string myLogName = "MyNewLog";
             // Check if the source exists.
             if (!EventLog.SourceExists("MySource"))
@@ -75,11 +73,6 @@ class EventLogEntryCollection_Item
                    + myEventLogEntry.TimeGenerated);
             }
             // </Snippet2>
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("Exception:{0}", e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/EventLogEntry_Item/CS/eventlogentry_item.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EventLogEntry_Item/CS/eventlogentry_item.cs
@@ -20,8 +20,6 @@ class EventLogEntryCollection_Item
 {
     public static void Main()
     {
-        try
-        {
             string myLogName = "MyNewLog";
             // Check if the source exists.
             if (!EventLog.SourceExists("MySource"))
@@ -63,10 +61,5 @@ class EventLogEntryCollection_Item
             }
             // </Snippet2>
             // </Snippet1>
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("Exception Caught!" + e.Message);
-        }
     }
 }

--- a/snippets/csharp/VS_Snippets_CLR/EventLog_Exists_1/CS/eventlog_exists_1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EventLog_Exists_1/CS/eventlog_exists_1.cs
@@ -12,8 +12,6 @@ class EventLog_Exists_1
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          string myLog = "myNewLog";
          if (EventLog.Exists(myLog))
@@ -25,10 +23,5 @@ class EventLog_Exists_1
             Console.WriteLine("Log '"+myLog+"' does not exist.");
          }
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception:"+ e.Message);
-      }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/EventLog_WriteEntry_4/CS/eventlog_writeentry_4.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EventLog_WriteEntry_4/CS/eventlog_writeentry_4.cs
@@ -13,8 +13,6 @@ class EventLog_WriteEntry_4
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          // Create the source, if it does not already exist.
          if(!EventLog.SourceExists("MySource"))
@@ -40,10 +38,5 @@ class EventLog_WriteEntry_4
          EventLog.WriteEntry("MySource",myMessage,
             myEventLogEntryType, myApplicationEventId);
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception:{0}",e.Message);
-      }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/EventLog_WriteEntry_5/CS/eventlog_writeentry_5.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EventLog_WriteEntry_5/CS/eventlog_writeentry_5.cs
@@ -17,8 +17,6 @@ class EventLog_WriteEntry_5
 {
    public static void Main()   
    {
-      try
-      {
 // <Snippet1>
          // Create the source, if it does not already exist.
          string myLogName = "myNewLog";
@@ -56,12 +54,7 @@ class EventLog_WriteEntry_5
          Console.WriteLine("Writing to EventLog.. ");
          myEventLog.WriteEntry(myMessage,myEventLogEntryType, 
             myApplicatinEventId, myApplicatinCategoryId, myRawData);
-// </Snippet1>        
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception:{0}",e.Message);
-      }
+// </Snippet1>
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/FInfo Class/CS/finfo class.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FInfo Class/CS/finfo class.cs
@@ -28,27 +28,19 @@ class Test
             }
         }
 
-        try 
-        {
-            string path2 = Path.GetTempFileName();
-            FileInfo fi2 = new FileInfo(path2);
+        string path2 = Path.GetTempFileName();
+        FileInfo fi2 = new FileInfo(path2);
 
-            //Ensure that the target does not exist.
-            fi2.Delete();
+        //Ensure that the target does not exist.
+        fi2.Delete();
 
-            //Copy the file.
-            fi1.CopyTo(path2);
-            Console.WriteLine("{0} was copied to {1}.", path, path2);
+        //Copy the file.
+        fi1.CopyTo(path2);
+        Console.WriteLine("{0} was copied to {1}.", path, path2);
 
-            //Delete the newly created file.
-            fi2.Delete();
-            Console.WriteLine("{0} was successfully deleted.", path2);
-
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
+        //Delete the newly created file.
+        fi2.Delete();
+        Console.WriteLine("{0} was successfully deleted.", path2);
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/FInfo Ctor/CS/finfo ctor.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FInfo Ctor/CS/finfo ctor.cs
@@ -31,8 +31,6 @@ class Test
             }
         }
 
-        try 
-        {
             string path2 = path + "temp";
             FileInfo fi2 = new FileInfo(path2);
 
@@ -46,12 +44,6 @@ class Test
             //Delete the newly created file.
             fi2.Delete();
             Console.WriteLine("{0} was successfully deleted.", path2);
-
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 //This code produces output similar to the following; 

--- a/snippets/csharp/VS_Snippets_CLR/FInfo Delete/CS/finfo delete.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FInfo Delete/CS/finfo delete.cs
@@ -10,8 +10,6 @@ class Test
         string path = @"c:\MyTest.txt";
         FileInfo fi1 = new FileInfo(path);
 
-        try 
-        {
             using (StreamWriter sw = fi1.CreateText()) {}
             string path2 = path + "temp";
             FileInfo fi2 = new FileInfo(path2);
@@ -26,12 +24,6 @@ class Test
             //Delete the newly created file.
             fi2.Delete();
             Console.WriteLine("{0} was successfully deleted.", path2);
-
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 //This code produces output similar to the following; 

--- a/snippets/csharp/VS_Snippets_CLR/FInfo Open2/CS/finfo open2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FInfo Open2/CS/finfo open2.cs
@@ -33,16 +33,8 @@ class Test
                 Console.WriteLine(temp.GetString(b));
             }
 
-            try 
-            {
-                //Try to write to the file.
-                fs.Write(b,0,b.Length);
-            } 
-            catch (Exception e) 
-            {
-                Console.WriteLine("Writing was disallowed, as expected: {0}",
-                    e.ToString());
-            }
+            //Try to write to the file.
+            fs.Write(b,0,b.Length);
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_CLR/FSizeSort/CS/fsizesort.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FSizeSort/CS/fsizesort.cs
@@ -11,8 +11,6 @@ class DirectoryFileCount
 
     static void Main()
     {
-        try
-        {
             Console.WriteLine("Enter the path to a directory:");
 
             string directory = Console.ReadLine();
@@ -37,17 +35,6 @@ class DirectoryFileCount
             // Display the results to the console. 
             Console.WriteLine("Directories: {0}", directories);
             Console.WriteLine("Files: {0}", files);
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-        finally
-        {
-
-            Console.ReadLine();
-        }
     }
 
     static void ListDirectoriesAndFiles(FileSystemInfo[] FSInfo)

--- a/snippets/csharp/VS_Snippets_CLR/FieldBuilder_Class_Name/CS/fieldbuilder_name.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FieldBuilder_Class_Name/CS/fieldbuilder_name.cs
@@ -68,8 +68,6 @@ public class FieldBuilder_Sample
    [PermissionSetAttribute(SecurityAction.Demand, Name="FullTrust")]
    public static void Main()
    {
-      try
-      {
          Type myType = CreateType(Thread.GetDomain());
          // Create an instance of the "HelloWorld" class.
          Object helloWorld = Activator.CreateInstance(myType, new Object[] { "HelloWorld" });
@@ -77,11 +75,6 @@ public class FieldBuilder_Sample
          Object myObject  = myType.InvokeMember("MyMethod",
                         BindingFlags.InvokeMethod, null, helloWorld, null);
          Console.WriteLine("MyClass.MyMethod returned: \"" + myObject + "\"");
-      }
-      catch( Exception e)
-      {
-         Console.WriteLine("Exception Caught "+e.Message);
-      }
   }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/FieldBuilder_SetCustomAttributes/CS/fieldbuilder_setcustomattributes.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FieldBuilder_SetCustomAttributes/CS/fieldbuilder_setcustomattributes.cs
@@ -93,8 +93,6 @@ namespace MySample
       }
       public static void Main()
       {
-         try
-         {
             Type myCustomClass = CreateCallee(Thread.GetDomain());
             // Construct an instance of a type.
             Object myObject = Activator.CreateInstance(myCustomClass);
@@ -123,11 +121,6 @@ namespace MySample
                   }
                }
             }
-         }
-         catch (Exception e)
-         {
-            Console.WriteLine("Exception Caught "+e.Message);
-         }
       }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/FieldBuilder_SetOffset/CS/fieldbuilder_setoffset.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FieldBuilder_SetOffset/CS/fieldbuilder_setoffset.cs
@@ -71,8 +71,6 @@ public class FieldBuilder_Sample
    [PermissionSetAttribute(SecurityAction.Demand, Name="FullTrust")]
    public static void Main()
    {
-      try
-      {
          Type myType = CreateType(Thread.GetDomain());
          Type myClass2 = myType.Module.GetType("MyClass2"); 
          object myParam2 = Activator.CreateInstance(myClass2);
@@ -81,11 +79,6 @@ public class FieldBuilder_Sample
          Object myObject  = myType.InvokeMember("OpenFile",BindingFlags.Public | 
             BindingFlags.InvokeMethod | BindingFlags.Static,null,null,myArgs);
          Console.WriteLine("MyClass.OpenFile method returned: \"{0}\"", myObject);
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception Caught "+e.Message);
-      }
    }
 
 }

--- a/snippets/csharp/VS_Snippets_CLR/FieldInfo_FieldHandle/CS/fieldinfo_fieldhandle.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FieldInfo_FieldHandle/CS/fieldinfo_fieldhandle.cs
@@ -17,8 +17,6 @@ public class FieldInfo_FieldHandle
         // Get the type of MyClass.
         Type myType = typeof(MyClass);
 
-        try
-        {
             // Get the field information of MyField.
             FieldInfo myFieldInfo = myType.GetField("MyField", BindingFlags.Public 
                 | BindingFlags.Instance);
@@ -35,11 +33,6 @@ public class FieldInfo_FieldHandle
             {
                 Console.WriteLine("The myFieldInfo object is null.");
             }
-        }  
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception: {0}", e.Message);
-        }
     }
 
     public static void DisplayFieldHandle(RuntimeFieldHandle myFieldHandle)

--- a/snippets/csharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/cs/source.cs
@@ -23,15 +23,9 @@ public class Example
         // field handle requires the type handle of the constructed
         // generic type. An exception is thrown if the type is not
         // included.
-        try
-        {
-            FieldInfo f1 = FieldInfo.GetFieldFromHandle(rfh);
-        }
-        catch(Exception ex)
-        {
-            Console.WriteLine("{0}: {1}", ex.GetType().Name, ex.Message);
-        }
-
+        
+        FieldInfo f1 = FieldInfo.GetFieldFromHandle(rfh);
+        
         // To get the FieldInfo for a field on a generic type, use the
         // overload that specifies the type handle.
         FieldInfo fi = FieldInfo.GetFieldFromHandle(rfh, rth);

--- a/snippets/csharp/VS_Snippets_CLR/FieldInfo_IsPrivate/CS/fieldinfo_isprivate.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FieldInfo_IsPrivate/CS/fieldinfo_isprivate.cs
@@ -23,8 +23,6 @@ class FieldInfo_IsPrivate
 {
     public static void Main()
     {
-        try
-        {
             // Gets the type of MyClass.
             Type myType = typeof(MyClass);
 
@@ -42,11 +40,6 @@ class FieldInfo_IsPrivate
                 else
                     Console.WriteLine("{0} is not a private field.", myFields[i].Name);
             }
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception : {0} " , e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/FieldInfo_IsSpecialName/CS/fieldinfo_isspecialname.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FieldInfo_IsSpecialName/CS/fieldinfo_isspecialname.cs
@@ -8,8 +8,6 @@ class FieldInfo_IsSpecialName
 {
     public static void Main()
     {     
-        try
-        {
             // Get the type handle of a specified class.
             Type myType = typeof(ViewTechnology);
          
@@ -26,11 +24,6 @@ class FieldInfo_IsSpecialName
                         myField[i].Name);
                 }
             }
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception : {0} " , e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/File Create1/CS/file create1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File Create1/CS/file create1.cs
@@ -9,9 +9,6 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try
-        {
-
             // Delete the file if it exists.
             if (File.Exists(path))
             {
@@ -40,12 +37,6 @@ class Test
                     Console.WriteLine(s);
                 }
             }
-        }
-
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/File GetLastAccess/CS/file getlastaccess.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File GetLastAccess/CS/file getlastaccess.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string path = @"c:\Temp\MyTest.txt";
 
             if (!File.Exists(path)) 
@@ -24,12 +22,6 @@ class Test
             File.SetLastAccessTime(path, DateTime.Now);
             dt = File.GetLastAccessTime(path);
             Console.WriteLine("The last access time for this file was {0}.", dt);
-        } 
-
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/File GetLastWrite/CS/file getlastwrite.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File GetLastWrite/CS/file getlastwrite.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string path = @"c:\Temp\MyTest.txt";
             if (!File.Exists(path)) 
             {
@@ -27,13 +25,6 @@ class Test
             File.SetLastWriteTime(path, DateTime.Now);
             dt = File.GetLastWriteTime(path);
             Console.WriteLine("The last write time for this file was {0}.", dt);
-
-        } 
-
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/File Move/CS/file move.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File Move/CS/file move.cs
@@ -8,8 +8,7 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
         string path2 = @"c:\temp2\MyTest.txt";
-        try 
-        {
+        
             if (!File.Exists(path)) 
             {
                 // This statement ensures that the file is created,
@@ -33,13 +32,7 @@ class Test
             else 
             {
                 Console.WriteLine("The original file no longer exists, which is expected.");
-            }			
-
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
+            }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/File Open2/CS/file open2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File Open2/CS/file open2.cs
@@ -35,15 +35,9 @@ class Test
                 Console.WriteLine(temp.GetString(b));
             }
 
-            try 
-            {
-                // Try to write to the file.
-                fs.Write(b,0,b.Length);
-            } 
-            catch (Exception e) 
-            {
-                Console.WriteLine("Writing was disallowed, as expected: {0}", e.ToString());
-            }
+            // Try to write to the file.
+            fs.Write(b,0,b.Length);
+            
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_CLR/File Open3/CS/file open3.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File Open3/CS/file open3.cs
@@ -33,18 +33,10 @@ class Test
                 Console.WriteLine(temp.GetString(b));
             }
 
-            try 
+            // Try to get another handle to the same file.
+            using (FileStream fs2 = File.Open(path, FileMode.Open)) 
             {
-                // Try to get another handle to the same file.
-                using (FileStream fs2 = File.Open(path, FileMode.Open)) 
-                {
-                    // Do some task here.
-                }
-            } 
-            catch (Exception e) 
-            {
-                Console.Write("Opening the file twice is disallowed.");
-                Console.WriteLine(", as expected: {0}", e.ToString());
+                // Do some task here.
             }
         }
     }

--- a/snippets/csharp/VS_Snippets_CLR/File SetLastAccess/CS/file setlastaccess.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File SetLastAccess/CS/file setlastaccess.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string path = @"c:\Temp\MyTest.txt";
 
             if (!File.Exists(path)) 
@@ -25,12 +23,6 @@ class Test
             File.SetLastAccessTime(path, DateTime.Now);
             dt = File.GetLastAccessTime(path);
             Console.WriteLine("The last access time for this file was {0}.", dt);
-
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/File SetLastWrite/CS/file setlastwrite.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File SetLastWrite/CS/file setlastwrite.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             string path = @"c:\Temp\MyTest.txt";
             if (!File.Exists(path)) 
             {
@@ -27,12 +25,6 @@ class Test
             File.SetLastWriteTime(path, DateTime.Now);
             dt = File.GetLastWriteTime(path);
             Console.WriteLine("The last write time for this file was {0}.", dt);
-
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/FileInfoCopyTo1/CS/fileinfocopyto1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/FileInfoCopyTo1/CS/fileinfocopyto1.cs
@@ -6,8 +6,6 @@ public class CopyToTest
 {
     public static void Main() 
     {
-        try
-        {
             // Create a reference to a file, which might or might not exist.
             // If it does not exist, it is not yet created.
             FileInfo fi = new FileInfo("temp.txt");
@@ -29,11 +27,6 @@ public class CopyToTest
             Console.WriteLine("{0}This is the information in the second file:", Environment.NewLine);
             while (sr.Peek() != -1)
                 Console.WriteLine(sr.ReadLine());
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
     }
 }
 //This code produces output similar to the following; 

--- a/snippets/csharp/VS_Snippets_CLR/Formatting.HowTo.Millisecond/cs/Millisecond.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Formatting.HowTo.Millisecond/cs/Millisecond.cs
@@ -9,8 +9,6 @@ public class MillisecondDisplay
    {
       string dateString = "7/16/2008 8:32:45.126 AM";
       
-      try
-      {
          DateTime dateValue = DateTime.Parse(dateString);
          DateTimeOffset dateOffsetValue = DateTimeOffset.Parse(dateString);
    
@@ -35,11 +33,6 @@ public class MillisecondDisplay
                            dateValue.ToString(fullPattern));
          Console.WriteLine("Modified full date time pattern: {0}",
                            dateOffsetValue.ToString(fullPattern));
-      }
-      catch (FormatException)
-      {
-         Console.WriteLine("Unable to convert {0} to a date.", dateString);
-      }
    }
 }
 // The example displays the following output if the current culture is en-US:

--- a/snippets/csharp/VS_Snippets_CLR/HowToDecryptXMLElementAsymmetric/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/HowToDecryptXMLElementAsymmetric/cs/sample.cs
@@ -15,15 +15,10 @@ class Program
 		XmlDocument xmlDoc = new XmlDocument();
 
 		// Load an XML file into the XmlDocument object.
-		try
-		{
-			xmlDoc.PreserveWhitespace = true;
-			xmlDoc.Load("test.xml");
-		}
-		catch (Exception e)
-		{
-			Console.WriteLine(e.Message);
-		}
+		
+		xmlDoc.PreserveWhitespace = true;
+		xmlDoc.Load("test.xml");
+	    
 		// </snippet4>
 		// <snippet2>
 		CspParameters cspParams = new CspParameters();

--- a/snippets/csharp/VS_Snippets_CLR/HowToDecryptXMLElementX509/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/HowToDecryptXMLElementX509/cs/sample.cs
@@ -9,8 +9,6 @@ class Program
 {
     static void Main(string[] args)
     {
-        try
-        {
             // Create an XmlDocument object.
             // <snippet2>
             XmlDocument xmlDoc = new XmlDocument();
@@ -32,13 +30,6 @@ class Program
             Console.WriteLine("Decrypted XML:");
             Console.WriteLine();
             Console.WriteLine(xmlDoc.OuterXml);
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-
     }
 
     public static void Decrypt(XmlDocument Doc)

--- a/snippets/csharp/VS_Snippets_CLR/HowToEncryptXMLElementAsymmetric/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/HowToEncryptXMLElementAsymmetric/cs/sample.cs
@@ -14,15 +14,9 @@ class Program
         XmlDocument xmlDoc = new XmlDocument();
 
         // Load an XML file into the XmlDocument object.
-        try
-        {
-            xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
+        xmlDoc.PreserveWhitespace = true;
+        xmlDoc.Load("test.xml");
+        
         // </snippet4>
 
         // Create a new CspParameters object to specify

--- a/snippets/csharp/VS_Snippets_CLR/HowToEncryptXMLElementSymmetric/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/HowToEncryptXMLElementSymmetric/cs/sample.cs
@@ -41,10 +41,6 @@ namespace CSCrypto
 
 				
 			}
-			catch (Exception e)
-			{
-				Console.WriteLine(e.Message);
-			}
 			finally
 			{
 				// Clear the key.

--- a/snippets/csharp/VS_Snippets_CLR/HowToEncryptXMLElementX509/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/HowToEncryptXMLElementX509/cs/sample.cs
@@ -9,8 +9,6 @@ class Program
 {
     static void Main(string[] args)
     {
-        try
-        {
             // Create an XmlDocument object.
             // <snippet7>
             XmlDocument xmlDoc = new XmlDocument();
@@ -71,13 +69,6 @@ class Program
             Console.WriteLine("Encrypted XML:");
             Console.WriteLine();
             Console.WriteLine(xmlDoc.OuterXml);
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
-
     }
 
     public static void Encrypt(XmlDocument Doc, string ElementToEncrypt, X509Certificate2 Cert)

--- a/snippets/csharp/VS_Snippets_CLR/HowToSignXMLDocumentRSA/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/HowToSignXMLDocumentRSA/cs/sample.cs
@@ -9,8 +9,6 @@ public class SignXML
 
     public static void Main(String[] args)
     {
-        try
-        {
             // Create a new CspParameters object to specify
             // a key container.
             // <snippet2>
@@ -41,14 +39,6 @@ public class SignXML
             // <snippet13>
             xmlDoc.Save("test.xml");
             // </snippet13>
-
-
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
     }
 
 

--- a/snippets/csharp/VS_Snippets_CLR/HowToVerifyXMLDocumentRSA/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/HowToVerifyXMLDocumentRSA/cs/sample.cs
@@ -9,8 +9,6 @@ public class VerifyXML
 
     public static void Main(String[] args)
     {
-        try
-        {
             // Create a new CspParameters object to specify
             // a key container.
             // <snippet2>
@@ -47,10 +45,6 @@ public class VerifyXML
                 Console.WriteLine("The XML signature is not valid.");
             }
 
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
         }
     }
 

--- a/snippets/csharp/VS_Snippets_CLR/ILGenerator_Begin_EndScope/CS/ilgenerator_begin_endscope.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ILGenerator_Begin_EndScope/CS/ilgenerator_begin_endscope.cs
@@ -22,8 +22,6 @@ public class ILGenerator_Begin_EndScope
    [PermissionSetAttribute(SecurityAction.Demand, Name="FullTrust")]
    public static void Main()
    {
-      try
-      {
 // <Snippet2>
 // <Snippet3>
          // Get the current AppDomain.
@@ -93,10 +91,6 @@ public class ILGenerator_Begin_EndScope
          // Invoke 'MyDynamicMethod' method of 'MyDynamicClass'.
          Object myObject2 = myType1.InvokeMember("MyDynamicMethod",
                            BindingFlags.InvokeMethod, null, myObject1, null);
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception: {0}", e.Message ); 
       }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/IO.DiretoryInfo.GetAccessControl-SetAccessControl/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.DiretoryInfo.GetAccessControl-SetAccessControl/CS/sample.cs
@@ -9,8 +9,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 string DirectoryName = "TestDirectory";
 
                 Console.WriteLine("Adding access control entry for " + DirectoryName);
@@ -24,12 +22,7 @@ namespace FileSystemExample
                 RemoveDirectorySecurity(DirectoryName, @"MYDOMAIN\MyAccount", FileSystemRights.ReadData, AccessControlType.Allow);
 
                 Console.WriteLine("Done.");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-
+         
             Console.ReadLine();
         }
 

--- a/snippets/csharp/VS_Snippets_CLR/IO.File.Encrypt-Decrypt/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.File.Encrypt-Decrypt/CS/sample.cs
@@ -9,8 +9,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 string FileName = "test.xml";
 
                 Console.WriteLine("Encrypt " + FileName);
@@ -24,12 +22,7 @@ namespace FileSystemExample
                 RemoveEncryption(FileName);
 
                 Console.WriteLine("Done");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-
+            
             Console.ReadLine();
         }
 

--- a/snippets/csharp/VS_Snippets_CLR/IO.File.GetAccessControl-SetAccessControl/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.File.GetAccessControl-SetAccessControl/CS/sample.cs
@@ -9,8 +9,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 string fileName = "test.xml";
 
                 Console.WriteLine("Adding access control entry for "
@@ -28,11 +26,6 @@ namespace FileSystemExample
                     FileSystemRights.ReadData, AccessControlType.Allow);
 
                 Console.WriteLine("Done.");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
         }
 
         // Adds an ACL entry on the specified file for the specified account.

--- a/snippets/csharp/VS_Snippets_CLR/IO.File.Replace/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.File.Replace/CS/sample.cs
@@ -8,8 +8,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 string OriginalFile = "test.xml";
                 string FileToReplace = "test2.xml";
                 string BackUpOfFileToReplace = "test2.xml.bac";
@@ -21,12 +19,7 @@ namespace FileSystemExample
                 ReplaceFile(OriginalFile, FileToReplace, BackUpOfFileToReplace);
 
                 Console.WriteLine("Done");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-
+            
             Console.ReadLine();
         }
 

--- a/snippets/csharp/VS_Snippets_CLR/IO.FileInfo.Encrypt-Decrypt/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.FileInfo.Encrypt-Decrypt/CS/sample.cs
@@ -8,9 +8,7 @@ namespace FileSystemExample
     class FileExample
     {
         public static void Main()
-        {
-            try
-            {
+        {   
                 string FileName = @"c:\MyTest.txt";
 
                 Console.WriteLine("Encrypt " + FileName);
@@ -24,11 +22,6 @@ namespace FileSystemExample
                 RemoveEncryption(FileName);
 
                 Console.WriteLine("Done");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
         }
 
         public static void AddEncryption(string FileName)

--- a/snippets/csharp/VS_Snippets_CLR/IO.FileInfo.GetAccessControl-SetAccessControl/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.FileInfo.GetAccessControl-SetAccessControl/CS/sample.cs
@@ -9,8 +9,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 string FileName = "c:/test.xml";
 
                 Console.WriteLine("Adding access control entry for " + FileName);
@@ -30,12 +28,6 @@ namespace FileSystemExample
                 RemoveFileSecurity(FileName, @"MyDomain\MyAccessAccount", FileSystemRights.ReadData, AccessControlType.Allow);
 
                 Console.WriteLine("Done.");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-
         }
 
         // Adds an ACL entry on the specified file for the specified account.

--- a/snippets/csharp/VS_Snippets_CLR/IO.FileInfo.Replace/CS/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.FileInfo.Replace/CS/sample.cs
@@ -8,8 +8,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 // originalFile and fileToReplace must contain the path to files that already exist in the  
                 // file system. backUpOfFileToReplace is created during the execution of the Replace method.
 
@@ -31,12 +29,7 @@ namespace FileSystemExample
                 {
                     Console.WriteLine("Either the file {0} or {1} doesn't " + "exist.", originalFile, fileToReplace);
                 }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.Message);
-            }
-
+            
             Console.ReadLine();
         }
 

--- a/snippets/csharp/VS_Snippets_CLR/IO.FileStream.ctor1/CS/example.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.FileStream.ctor1/CS/example.cs
@@ -10,8 +10,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 // Create a file and write data to it.
 
                 // Create an array of bytes.
@@ -50,12 +48,7 @@ namespace FileSystemExample
                 Console.WriteLine(Encoding.ASCII.GetString(readBytes));
 
                 Console.WriteLine("Done writing and reading data.");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-
+            
             Console.ReadLine();
         }
     }

--- a/snippets/csharp/VS_Snippets_CLR/IO.FileStream.ctor2/CS/example.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.FileStream.ctor2/CS/example.cs
@@ -10,8 +10,6 @@ namespace FileSystemExample
     {
         public static void Main()
         {
-            try
-            {
                 // Create a file and write data to it.
 
                 // Create an array of bytes.
@@ -57,12 +55,7 @@ namespace FileSystemExample
                 Console.WriteLine(Encoding.ASCII.GetString(readBytes));
 
                 Console.WriteLine("Done writing and reading data.");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-
+            
             Console.ReadLine();
         }
     }

--- a/snippets/csharp/VS_Snippets_CLR/InstallerCollection_Add/CS/installercollection_add.cs
+++ b/snippets/csharp/VS_Snippets_CLR/InstallerCollection_Add/CS/installercollection_add.cs
@@ -32,8 +32,6 @@ public class InstallerCollection_Add
       AssemblyInstaller myAssemblyInstaller;
       InstallContext myInstallContext;
 
-      try
-      {
          for(int i = 0; i < args.Length; i++)
          {
             // Process the arguments.
@@ -95,10 +93,6 @@ public class InstallerCollection_Add
             myTransactedInstaller.Install(new Hashtable());
          else
             myTransactedInstaller.Uninstall(null);
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine(" Exception raised : {0}", e.Message);
       }
    }
 

--- a/snippets/csharp/VS_Snippets_CLR/InstallerCollection_AddRange1/CS/installercollection_addrange1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/InstallerCollection_AddRange1/CS/installercollection_addrange1.cs
@@ -18,8 +18,6 @@ public class InstallerCollection_AddRange1
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          ArrayList myInstallers =new ArrayList();
          TransactedInstaller myTransactedInstaller = new TransactedInstaller();
@@ -51,10 +49,6 @@ public class InstallerCollection_AddRange1
 
          // Install an assembly.
          myTransactedInstaller.Install(new Hashtable());
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception raised : {0}", e.Message);
-      }
+     
    }  
 }

--- a/snippets/csharp/VS_Snippets_CLR/InstallerCollection_Item/CS/installercollection_item.cs
+++ b/snippets/csharp/VS_Snippets_CLR/InstallerCollection_Item/CS/installercollection_item.cs
@@ -19,8 +19,6 @@ public class InstallerCollection_Item
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          TransactedInstaller myTransactedInstaller = new TransactedInstaller();
          AssemblyInstaller myAssemblyInstaller;
@@ -59,10 +57,5 @@ public class InstallerCollection_Item
 
          // Install an assembly .
          myTransactedInstaller.Install(new Hashtable());
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception raised : {0}", e.Message);
-      }
    }  
 }

--- a/snippets/csharp/VS_Snippets_CLR/InstallerCollection_Remove/CS/installercollection_remove.cs
+++ b/snippets/csharp/VS_Snippets_CLR/InstallerCollection_Remove/CS/installercollection_remove.cs
@@ -24,8 +24,6 @@ public class InstallerCollection_Remove
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
 // <Snippet2>
 // <Snippet3>
@@ -77,10 +75,5 @@ public class InstallerCollection_Remove
 
          // Install an assembly.
          myTransactedInstaller.Install(new Hashtable());
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception raised : {0}", e.Message);
-      }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/Int16_Equals/CS/int16_equals.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Int16_Equals/CS/int16_equals.cs
@@ -11,8 +11,6 @@ class MyInt16_Equals
 {
      public static void Main()
      {
-         try
-         {
 // <Snippet1>            
             Int16 myVariable1 = 20;
             Int16 myVariable2 = 20;
@@ -31,12 +29,7 @@ class MyInt16_Equals
                Console.WriteLine( "\nStructures 'myVariable1' and "+
                      "'myVariable2' are not equal");
             
-// </Snippet1>            
-         }
-         catch(Exception e)
-         {
-            Console.WriteLine("Exception :{0}", e.Message);
-         }
+// </Snippet1>
      }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/Int32_Equals/CS/int32_equals.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Int32_Equals/CS/int32_equals.cs
@@ -11,8 +11,6 @@ class MyInt32_Equals
 {
      public static void Main()
      {
-         try
-         {
 // <Snippet1>            
             Int32 myVariable1 = 60;
             Int32 myVariable2 = 60;
@@ -31,12 +29,7 @@ class MyInt32_Equals
                Console.WriteLine( "\nStructures 'myVariable1' and "+
                      "'myVariable2' are not equal");
             
-// </Snippet1>            
-         }
-         catch(Exception e)
-         {
-            Console.WriteLine("Exception :{0}", e.Message);
-         }
+// </Snippet1>
      }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/Int64_Equals/CS/int64_equals.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Int64_Equals/CS/int64_equals.cs
@@ -11,8 +11,6 @@ class MyInt64_Equals
 {
      public static void Main()
      {
-         try
-         {
 // <Snippet1>            
             Int64 myVariable1 = 80;
             Int64 myVariable2 = 80;
@@ -31,12 +29,7 @@ class MyInt64_Equals
                Console.WriteLine( "\nStructures 'myVariable1' and "+
                      "'myVariable2' are not equal");
             
-// </Snippet1>            
-         }
-         catch(Exception e)
-         {
-            Console.WriteLine("Exception :{0}", e.Message);
-         }
+// </Snippet1>
      }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/LayoutKind/CS/layoutkind.cs
+++ b/snippets/csharp/VS_Snippets_CLR/LayoutKind/CS/layoutkind.cs
@@ -44,8 +44,6 @@ namespace InteropSample
    {
       public static void Main()
       {
-         try
-         {
             Bool bPointInRect = 0;
             Rect myRect = new Rect();
             myRect.left = 10;
@@ -60,11 +58,6 @@ namespace InteropSample
                Console.WriteLine("Point lies within the Rect");
             else
                Console.WriteLine("Point did not lie within the Rect");
-         }
-         catch(Exception e)
-         {
-            Console.WriteLine("Exception : " + e.Message);
-         }
       }
    }
 // </Snippet2>

--- a/snippets/csharp/VS_Snippets_CLR/MemberInfo_GetCustomAttribute_IsDefined/CS/memberinfo_getcustomattribute_isdefined.cs
+++ b/snippets/csharp/VS_Snippets_CLR/MemberInfo_GetCustomAttribute_IsDefined/CS/memberinfo_getcustomattribute_isdefined.cs
@@ -35,8 +35,6 @@ public class MemberInfo_GetCustomAttributes_IsDefined
 {
     public static void Main()
     {
-        try
-        {
             // Get the type of MyClass1.
             Type myType = typeof(MyClass1);
             // Get the members associated with MyClass1.
@@ -57,11 +55,6 @@ public class MemberInfo_GetCustomAttributes_IsDefined
                             ((MyAttribute)myAttributes[j]).Name);
                 }
             }
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("An exception occurred: {0}", e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/MemberInfo_GetCustomAttributes1/CS/memberinfo_getcustomattributes1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/MemberInfo_GetCustomAttributes1/CS/memberinfo_getcustomattributes1.cs
@@ -34,8 +34,6 @@ public class MemberInfo_GetCustomAttributes
 {
     public static void Main()
     {
-        try
-        {
             // Get the type of MyClass1.
             Type myType = typeof(MyClass1);
             // Get the members associated with MyClass1.
@@ -52,11 +50,6 @@ public class MemberInfo_GetCustomAttributes
                         Console.WriteLine("The type of the attribute is {0}.", myAttributes[j]);
                 }
             }
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("An exception occurred: {0}", e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/MethodBuilderClass_TypeSample/CS/methodbuilderclass.cs
+++ b/snippets/csharp/VS_Snippets_CLR/MethodBuilderClass_TypeSample/CS/methodbuilderclass.cs
@@ -17,8 +17,6 @@ public class MethodBuilderClass
 {
    public static void Main()
    {
-      try
-      {
          // Get the current AppDomain.
          AppDomain myAppDomain = AppDomain.CurrentDomain;
          AssemblyName myAssemblyName = new AssemblyName();
@@ -64,11 +62,6 @@ public class MethodBuilderClass
                                     myMethodBuilder.Attributes);
          Console.WriteLine("\nThe Signature of 'MyDynamicMethod' is : \n"
                                     + myMethodBuilder.Signature);
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception :{0}", e.Message);
-      }
    }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Microsoft.Win32.SafeHandles.SafeFileHandle.ctor/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Microsoft.Win32.SafeHandles.SafeFileHandle.ctor/cs/sample.cs
@@ -9,20 +9,9 @@ class SafeHandlesExample
 
     static void Main()
     {
-        try
-        {
+        UnmanagedFileLoader loader = new UnmanagedFileLoader("example.xml");
 
-            UnmanagedFileLoader loader = new UnmanagedFileLoader("example.xml");
-
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-        }
         Console.ReadLine();
-
-
     }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/Microsoft.Win32.SafeHandles.SafeFileHandle/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Microsoft.Win32.SafeHandles.SafeFileHandle/cs/sample.cs
@@ -9,20 +9,8 @@ class SafeHandlesExample
 
     static void Main()
     {
-        try
-        {
-
-            UnmanagedFileLoader loader = new UnmanagedFileLoader("example.xml");
-
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-        }
-        Console.ReadLine();
-
-
+         UnmanagedFileLoader loader = new UnmanagedFileLoader("example.xml");
+         Console.ReadLine();
     }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/Microsoft.Win32.SafeHandles.SafeWaitHandle-ctor/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Microsoft.Win32.SafeHandles.SafeWaitHandle-ctor/cs/sample.cs
@@ -16,13 +16,6 @@ class SafeHandlesExample
 
             uMutex.Create();
             Console.WriteLine("Mutex created. Press Enter to release it.");
-            Console.ReadLine();
-
-
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
         }
         finally
         {

--- a/snippets/csharp/VS_Snippets_CLR/Microsoft.Win32.SafeHandles.SafeWaitHandle/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Microsoft.Win32.SafeHandles.SafeWaitHandle/cs/sample.cs
@@ -20,10 +20,6 @@ class SafeHandlesExample
 
 
         }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-        }
         finally
         {
             uMutex.Release();

--- a/snippets/csharp/VS_Snippets_CLR/Module.MethodResolve/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Module.MethodResolve/cs/source.cs
@@ -91,16 +91,9 @@ namespace ResolveMethodExample
 
             // The overload that doesn't specify generic context throws an exception
             // because there is insufficient context to resolve the token.
-            try 
-            { 
-                miResolved2 = (MethodInfo) mod.ResolveMethod((int)Tokens.Case1);
-            } 
-            catch (Exception ex) 
-            { 
-                Console.WriteLine("{0}: {1}", ex.GetType(), ex.Message); 
-            }
-
-
+             
+            miResolved2 = (MethodInfo) mod.ResolveMethod((int)Tokens.Case1);
+            
             // Case 2: A non-generic method call that is dependent on its generic context.
             //
             // Create and display a MethodInfo representing the MemberRef of the 

--- a/snippets/csharp/VS_Snippets_CLR/Process.Start_instance/CS/processstart.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Process.Start_instance/CS/processstart.cs
@@ -11,8 +11,6 @@ namespace MyProcessSample
         {
             Process myProcess = new Process();
 
-            try
-            {
                 myProcess.StartInfo.UseShellExecute = false;
                 // You can start any process, HelloWorld is a do-nothing example.
                 myProcess.StartInfo.FileName = "C:\\HelloWorld.exe";
@@ -22,11 +20,6 @@ namespace MyProcessSample
                 // Given that is is started without a window so you cannot terminate it 
                 // on the desktop, it must terminate itself or you can do it programmatically
                 // from this application using the Kill method.
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.Message);
-            }
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_CLR/ProcessModule/CS/processmodule.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessModule/CS/processmodule.cs
@@ -11,8 +11,6 @@ class MyProcessModuleClass
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          Process myProcess = new Process();
          // Get the process start information of notepad.
@@ -53,11 +51,6 @@ class MyProcessModuleClass
             +myProcessModule.FileName);
          myProcess.CloseMainWindow();
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception : "+ e.Message);
-      }
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/ProcessModule_BaseAddress/CS/processmodule_baseaddress.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessModule_BaseAddress/CS/processmodule_baseaddress.cs
@@ -12,8 +12,6 @@ class MyProcessModuleClass
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          Process myProcess = new Process();
          // Get the process start information of notepad.
@@ -42,11 +40,6 @@ class MyProcessModuleClass
             +myProcessModule.BaseAddress);
           myProcess.CloseMainWindow();
 // </Snippet1>
-      } 
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception : "+ e.Message);
-      }
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/ProcessModule_EntryPoint/CS/processmodule_entrypoint.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessModule_EntryPoint/CS/processmodule_entrypoint.cs
@@ -12,8 +12,6 @@ class MyProcessModuleClass
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          Process myProcess = new Process();
          // Get the process start information of notepad.
@@ -41,11 +39,6 @@ class MyProcessModuleClass
             +myProcessModule.EntryPointAddress);
          myProcess.CloseMainWindow();
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception : "+ e.Message);
-      }
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/ProcessModule_FileName/CS/processmodule_filename.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessModule_FileName/CS/processmodule_filename.cs
@@ -12,8 +12,6 @@ class MyProcessModuleClass
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          Process myProcess = new Process();
          // Get the process start information of notepad.
@@ -42,11 +40,6 @@ class MyProcessModuleClass
             +myProcessModule.FileName);
          myProcess.CloseMainWindow();
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception : "+ e.Message);
-      }
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/ProcessModule_FileVersionInfo/CS/processmodule_fileversioninfo.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessModule_FileVersionInfo/CS/processmodule_fileversioninfo.cs
@@ -13,8 +13,6 @@ class MyProcessModuleClass
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          Process myProcess = new Process();
          // Get the process start information of notepad.
@@ -43,11 +41,6 @@ class MyProcessModuleClass
             +myProcessModule.FileVersionInfo);      
           myProcess.CloseMainWindow();
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception : "+ e.Message);
-      }
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/ProcessModule_ModuleMemorySize/CS/processmodule_modulememorysize.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessModule_ModuleMemorySize/CS/processmodule_modulememorysize.cs
@@ -12,8 +12,6 @@ class MyProcessModuleClass
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          Process myProcess = new Process();
          // Get the process start information of notepad.
@@ -42,11 +40,6 @@ class MyProcessModuleClass
             +myProcessModule.ModuleMemorySize); 
           myProcess.CloseMainWindow();
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception : "+ e.Message);
-      }
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/ProcessModule_ModuleName/CS/processmodule_modulename.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessModule_ModuleName/CS/processmodule_modulename.cs
@@ -12,8 +12,6 @@ class MyProcessModuleClass
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          Process myProcess = new Process();
          // Get the process start information of notepad.
@@ -40,11 +38,6 @@ class MyProcessModuleClass
          Console.WriteLine("The process's main moduleName is: "+myProcessModule.ModuleName);
          myProcess.CloseMainWindow();
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception : "+ e.Message);
-      }
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/ProcessModule_ToString/CS/processmodule_tostring.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessModule_ToString/CS/processmodule_tostring.cs
@@ -12,8 +12,6 @@ class MyProcessModuleClass
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
          Process myProcess = new Process();
          // Get the process start information of notepad.
@@ -41,11 +39,6 @@ class MyProcessModuleClass
          Console.WriteLine("The process's main module is : "+myProcessModule.ToString());
          myProcess.CloseMainWindow();
 // </Snippet1>
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("Exception : "+ e.Message);
-      }
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/Process_GetProcessesByName2_2/CS/process_getprocessesbyname2_2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Process_GetProcessesByName2_2/CS/process_getprocessesbyname2_2.cs
@@ -16,9 +16,6 @@ class GetProcessesByNameClass
 {
    public static void Main(string[] args)
    {
-      try
-      {
-
          Console.Write("Create notepad processes on remote computer \n");
          Console.Write("Enter remote computer name : ");
          string remoteMachineName = Console.ReadLine();
@@ -31,16 +28,6 @@ class GetProcessesByNameClass
             Console.Write("Process Name : " + myProcess.ProcessName + "  Process ID : "
                + myProcess.Id + "  MachineName : " + myProcess.MachineName + "\n");
          }
-
-      }
-      catch(SystemException e)
-      {
-         Console.Write("Caught Exception .... : " + e.Message);
-      }
-      catch(Exception e)
-      {
-         Console.Write("Caught Exception .... : " + e.Message);
-      }
    }
 }
 // </Snippet1> 

--- a/snippets/csharp/VS_Snippets_CLR/Process_MainWindowTitle/CS/process_mainwindowtitle.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Process_MainWindowTitle/CS/process_mainwindowtitle.cs
@@ -11,9 +11,6 @@ class MainWindowTitleClass
 {
    public static void Main()
    {
-      try
-      {
-
          // Create an instance of process component.
          Process myProcess = new Process();
          // Create an instance of 'myProcessStartInfo'.
@@ -28,12 +25,6 @@ class MainWindowTitleClass
 
          myProcess.CloseMainWindow();
          myProcess.Close();
-      }
-      catch(Exception e)
-      {
-         Console.Write(" Message : " + e.Message);
-      }
-    
    }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR/Process_StandardError/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Process_StandardError/CS/source.cs
@@ -58,10 +58,6 @@ namespace Process_StandardError
          {
             Console.WriteLine(e.Message);
          }
-         catch( Exception e)
-         {
-            Console.WriteLine(e.Message);
-         }
       }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/ProgIdAttribute_Value/CS/progidattribute_value.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProgIdAttribute_Value/CS/progidattribute_value.cs
@@ -23,17 +23,10 @@ namespace InteropSample
    {      
       public static void Main()
       {
-         try
-         {
             AttributeCollection attributes;
             attributes = TypeDescriptor.GetAttributes(typeof(MyClass));
             ProgIdAttribute progIdAttributeObj = (ProgIdAttribute)attributes[typeof(ProgIdAttribute)];
             Console.WriteLine("ProgIdAttribute's value is set to : " + progIdAttributeObj.Value);
-         }         
-         catch(Exception e)
-         {
-            Console.WriteLine("Exception : " + e.Message);
-         }
       }
    }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/PtrToStructure/CS/pts.cs
+++ b/snippets/csharp/VS_Snippets_CLR/PtrToStructure/CS/pts.cs
@@ -1,63 +1,107 @@
-using System;
-using System.Runtime.InteropServices;
-
-namespace Testing
-{
-	class Class1
+using System;
+
+using System.Runtime.InteropServices;
+
+
+
+namespace Testing
+
+{
+
+	class Class1
+
 	{
-		// <snippet1>
-		[StructLayout(LayoutKind.Sequential)]
-		public class  INNER
-		{
-			[MarshalAs(UnmanagedType.ByValTStr, SizeConst =  10)]
-			public string field1 = "Test";
-	 
-		}	
-		[StructLayout(LayoutKind.Sequential)]
-		public struct OUTER
-		{
-			[MarshalAs(UnmanagedType.ByValTStr, SizeConst =  10)]
-			public string field1;
-			[MarshalAs(UnmanagedType.ByValArray, SizeConst =  100)]
-			public byte[] inner;
-		}
-
-
-		[DllImport(@"SomeTestDLL.dll")]
-		public static extern void CallTest( ref OUTER po);
-
-		static void Main(string[] args)
-		{
-			OUTER ed = new OUTER();
-			INNER[] inn=new INNER[10];
-			INNER test = new INNER();
-			int iStructSize = Marshal.SizeOf(test);
-
-			int sz =inn.Length * iStructSize;
-			ed.inner = new byte[sz];
-
-			try
-			{
-				CallTest( ref ed);
-			}
-			catch(Exception e)
-			{
-				Console.WriteLine(e.Message);
-			}
-			IntPtr buffer = Marshal.AllocCoTaskMem(iStructSize*10);
-			Marshal.Copy(ed.inner,0,buffer,iStructSize*10);
-			
-			int iCurOffset = 0;
-			for(int i=0;i<10;i++)
-			{
-				
-				inn[i] = (INNER)Marshal.PtrToStructure(new
-IntPtr(buffer.ToInt32()+iCurOffset),typeof(INNER) );
-				iCurOffset += iStructSize;
-			}
-			Console.WriteLine(ed.field1);
-			Marshal.FreeCoTaskMem(buffer);
+		// <snippet1>
+
+		[StructLayout(LayoutKind.Sequential)]
+
+		public class  INNER
+
+		{
+
+			[MarshalAs(UnmanagedType.ByValTStr, SizeConst =  10)]
+
+			public string field1 = "Test";
+
+	 
+
+		}	
+
+		[StructLayout(LayoutKind.Sequential)]
+
+		public struct OUTER
+
+		{
+
+			[MarshalAs(UnmanagedType.ByValTStr, SizeConst =  10)]
+
+			public string field1;
+
+			[MarshalAs(UnmanagedType.ByValArray, SizeConst =  100)]
+
+			public byte[] inner;
+
 		}
-		// </snippet1>
-	}
-}
+
+
+
+
+
+		[DllImport(@"SomeTestDLL.dll")]
+
+		public static extern void CallTest( ref OUTER po);
+
+
+
+		static void Main(string[] args)
+
+		{
+
+			OUTER ed = new OUTER();
+
+			INNER[] inn=new INNER[10];
+
+			INNER test = new INNER();
+
+			int iStructSize = Marshal.SizeOf(test);
+
+
+
+			int sz =inn.Length * iStructSize;
+
+			ed.inner = new byte[sz];
+
+			CallTest( ref ed);
+
+			IntPtr buffer = Marshal.AllocCoTaskMem(iStructSize*10);
+
+			Marshal.Copy(ed.inner,0,buffer,iStructSize*10);
+
+			
+
+			int iCurOffset = 0;
+
+			for(int i=0;i<10;i++)
+
+			{
+
+				
+
+				inn[i] = (INNER)Marshal.PtrToStructure(new
+IntPtr(buffer.ToInt32()+iCurOffset),typeof(INNER) );
+
+				iCurOffset += iStructSize;
+
+			}
+
+			Console.WriteLine(ed.field1);
+
+			Marshal.FreeCoTaskMem(buffer);
+
+		}
+		// </snippet1>
+
+	}
+
+}
+

--- a/snippets/csharp/VS_Snippets_CLR/RIPEMD160/CS/ripemd160.cs
+++ b/snippets/csharp/VS_Snippets_CLR/RIPEMD160/CS/ripemd160.cs
@@ -56,10 +56,6 @@ public class HashDirectory
         {
             Console.WriteLine("Error: The directory specified could not be found.");
         }
-        catch (IOException)
-        {
-            Console.WriteLine("Error: A file in the directory could not be accessed.");
-        }
     }
     // Print the byte array in a readable format.
     public static void PrintByteArray(byte[] array)

--- a/snippets/csharp/VS_Snippets_CLR/ReadTextFile/CS/readtextfile.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ReadTextFile/CS/readtextfile.cs
@@ -6,8 +6,6 @@ class Test
 {
     public static void Main() 
     {
-        try 
-        {
             // Create an instance of StreamReader to read from a file.
             // The using statement also closes the StreamReader.
             using (StreamReader sr = new StreamReader("TestFile.txt")) 
@@ -20,13 +18,6 @@ class Test
                     Console.WriteLine(line);
                 }
             }
-        }
-        catch (Exception e) 
-        {
-            // Let the user know what went wrong.
-            Console.WriteLine("The file could not be read:");
-            Console.WriteLine(e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/RegistrySecurity101/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/RegistrySecurity101/CS/source.cs
@@ -20,12 +20,6 @@ public class Example
             // ArgumentException is thrown if the key does not exist. In
             // this case, there is no reason to display a message.
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Unable to delete the example key: {0}", ex);
-            return;
-        }
-
         string user = Environment.UserDomainName + "\\" + Environment.UserName;
 
         RegistrySecurity rs = new RegistrySecurity();
@@ -108,15 +102,8 @@ public class Example
         Console.WriteLine("\r\nPress Enter to delete the example key.");
         Console.ReadLine();
 
-        try
-        {
-            rk.DeleteSubKey("RegistryRightsExample");
-            Console.WriteLine("Example key was deleted.");
-        }
-        catch(Exception ex)
-        {
-            Console.WriteLine("Unable to delete the example key: {0}", ex);
-        }
+        rk.DeleteSubKey("RegistryRightsExample");
+        Console.WriteLine("Example key was deleted.");
 
         rk.Close();
     }

--- a/snippets/csharp/VS_Snippets_CLR/RijndaelManaged Example/CS/class1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/RijndaelManaged Example/CS/class1.cs
@@ -9,9 +9,6 @@ namespace RijndaelManaged_Example
     {
         public static void Main()
         {
-            try
-            {
-
                 string original = "Here is some data to encrypt!";
 
                 // Create a new instance of the RijndaelManaged
@@ -32,12 +29,6 @@ namespace RijndaelManaged_Example
                     Console.WriteLine("Original:   {0}", original);
                     Console.WriteLine("Round Trip: {0}", roundtrip);
                 }
-
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("Error: {0}", e.Message);
-            }
         }
         //<Snippet2>
         static byte[] EncryptStringToBytes(string plainText, byte[] Key, byte[] IV)

--- a/snippets/csharp/VS_Snippets_CLR/Runtime.InteropServices.PreserveSigAttribute/cs/example.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Runtime.InteropServices.PreserveSigAttribute/cs/example.cs
@@ -52,17 +52,10 @@ static class Program
         IntPtr iPtr = new IntPtr(0);
 
         // Call the SHAutoComplete function using exceptions.
-        try
-        {
-            Console.WriteLine("Calling the SHAutoComplete method with the PreserveSig field set to false.");
+        Console.WriteLine("Calling the SHAutoComplete method with the PreserveSig field set to false.");
 
-            Win32.SHAutoComplete(iPtr, Win32.SHAutoCompleteFlags.SHACF_DEFAULT);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("Exception handled: " + e.Message);
-        }
-
+        Win32.SHAutoComplete(iPtr, Win32.SHAutoCompleteFlags.SHACF_DEFAULT);
+        
         Console.WriteLine("Calling the SHAutoComplete method with the PreserveSig field set to true.");
 
         // Call the SHAutoComplete function using HRESULTS.

--- a/snippets/csharp/VS_Snippets_CLR/ServiceController/CS/servicecontroller.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ServiceController/CS/servicecontroller.cs
@@ -17,8 +17,6 @@ namespace ServiceControllerSample
       [STAThread]
       static void Main()
       {
-         try 
-         {
             // This is a simple interface for exercising the snippet code.
             Console.WriteLine("Service options:");
             Console.WriteLine("  1. Ensure the Alerter service is started");
@@ -63,13 +61,6 @@ namespace ServiceControllerSample
                   // Quit if input was any other key.
                   break;
             }
-
-         }
-         catch (Exception e)
-         {
-            Console.WriteLine("Exception:");
-            Console.WriteLine(e);
-         }
       }
 
       private static void CheckAlerterServiceStarted()

--- a/snippets/csharp/VS_Snippets_CLR/StrmReader Ctor1/CS/strmreader ctor1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader Ctor1/CS/strmreader ctor1.cs
@@ -9,8 +9,6 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try 
-        {
             if (File.Exists(path)) 
             {
                 File.Delete(path);
@@ -35,11 +33,6 @@ class Test
                     }
                 }
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/StrmReader Ctor2/CS/strmreader ctor2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader Ctor2/CS/strmreader ctor2.cs
@@ -9,8 +9,6 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try 
-        {
             if (File.Exists(path)) 
             {
                 File.Delete(path);
@@ -31,11 +29,6 @@ class Test
                     Console.WriteLine(sr.ReadLine());
                 }
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/StrmReader CurrentEncoding/CS/strmreader currentencoding.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader CurrentEncoding/CS/strmreader currentencoding.cs
@@ -10,8 +10,6 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try 
-        {
             if (File.Exists(path)) 
             {
                 File.Delete(path);
@@ -38,11 +36,6 @@ class Test
                 Console.WriteLine("The encoding used was {0}.", sr.CurrentEncoding);
                 Console.WriteLine();
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/StrmReader Peek/CS/strmreader peek.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader Peek/CS/strmreader peek.cs
@@ -9,8 +9,6 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try 
-        {
             if (File.Exists(path)) 
             {
                 File.Delete(path);
@@ -32,11 +30,6 @@ class Test
                     Console.WriteLine(sr.ReadLine());
                 }
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/StrmReader Read1/CS/strmreader read1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader Read1/CS/strmreader read1.cs
@@ -9,8 +9,6 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try 
-        {
             if (File.Exists(path)) 
             {
                 File.Delete(path);
@@ -31,11 +29,6 @@ class Test
                     Console.Write((char)sr.Read());
                 }
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/StrmReader Read2/CS/strmreader read2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader Read2/CS/strmreader read2.cs
@@ -9,8 +9,6 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try 
-        {
             if (File.Exists(path)) 
             {
                 File.Delete(path);
@@ -38,11 +36,6 @@ class Test
                     Console.WriteLine(c);
                 }
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/StrmReader ReadLine/CS/strmreader readline.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader ReadLine/CS/strmreader readline.cs
@@ -8,8 +8,7 @@ class Test
     public static void Main() 
     {
         string path = @"c:\temp\MyTest.txt";
-        try 
-        {
+        
             if (File.Exists(path)) 
             {
                 File.Delete(path);
@@ -30,11 +29,6 @@ class Test
                     Console.WriteLine(sr.ReadLine());
                 }
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/StrmReader ReadToEnd/CS/strmreader readtoend.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader ReadToEnd/CS/strmreader readtoend.cs
@@ -9,8 +9,6 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try 
-        {
             if (File.Exists(path)) 
             {
                 File.Delete(path);
@@ -29,11 +27,6 @@ class Test
                 //This allows you to do one Read operation.
                 Console.WriteLine(sr.ReadToEnd());
             }
-        } 
-        catch (Exception e) 
-        {
-            Console.WriteLine("The process failed: {0}", e.ToString());
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/StructLayoutAttribute/CS/structlayoutattribute.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StructLayoutAttribute/CS/structlayoutattribute.cs
@@ -51,10 +51,6 @@ namespace InteropSample
          {
             Console.WriteLine("TypeLoadException : " + e.Message);
          }
-         catch(Exception e)
-         {
-            Console.WriteLine("Exception : " + e.Message);
-         }
       }
    }
 // </Snippet3>

--- a/snippets/csharp/VS_Snippets_CLR/T.CompareTo/CS/cat.cs
+++ b/snippets/csharp/VS_Snippets_CLR/T.CompareTo/CS/cat.cs
@@ -44,8 +44,7 @@ class Sample
     UInt64   z1 = 11,    z2 = 11;
 //
     Console.WriteLine(msg, nl);
-    try 
-        {
+    
 // The second and third Show method call parameters are automatically boxed because
 // the second and third Show method declaration arguments expect type Object.
 
@@ -69,11 +68,6 @@ class Sample
         Show("UInt16:   ", x1, x2, x1.CompareTo(x2), x1.CompareTo((Object)x2));
         Show("UInt32:   ", y1, y2, y1.CompareTo(y2), y1.CompareTo((Object)y2));
         Show("UInt64:   ", z1, z2, z1.CompareTo(z2), z1.CompareTo((Object)z2));
-        }
-    catch (Exception e)
-        {
-        Console.WriteLine(e);
-        }
     }
 
     public static void Show(string caption, Object var1, Object var2, 

--- a/snippets/csharp/VS_Snippets_CLR/TransactedInstaller/CS/transactedinstaller.cs
+++ b/snippets/csharp/VS_Snippets_CLR/TransactedInstaller/CS/transactedinstaller.cs
@@ -37,8 +37,6 @@ public class TransactedInstaller_Example
       AssemblyInstaller myAssemblyInstaller;
       InstallContext myInstallContext;
 
-      try
-      {
          for(int i = 0; i < args.Length; i++)
          {
             // Process the arguments.
@@ -101,11 +99,7 @@ public class TransactedInstaller_Example
             myTransactedInstaller.Install(new Hashtable());
          else
             myTransactedInstaller.Uninstall(null);
-      }
-      catch(Exception e)
-      {
-         Console.WriteLine("\nException raised : {0}", e.Message);
-      }  
+        
 // </Snippet4>
 // </Snippet3>
 // </Snippet2>

--- a/snippets/csharp/VS_Snippets_CLR/TypeLoadException_Constructor3/CS/typeloadexception_constructor3.cs
+++ b/snippets/csharp/VS_Snippets_CLR/TypeLoadException_Constructor3/CS/typeloadexception_constructor3.cs
@@ -24,10 +24,6 @@ public class TypeLoadException_Constructor3
       {
          Console.WriteLine ("TypeLoadException: \n\tError Message = " + e.Message);
          Console.WriteLine ("TypeLoadException: \n\tInnerException Message = " + e.InnerException.Message );
-      }  
-      catch (Exception e)
-      {
-         Console.WriteLine ("Exception: \n\tError Message = " + e.Message);
       }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/Type_DefaultBinder/CS/type_defaultbinder.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_DefaultBinder/CS/type_defaultbinder.cs
@@ -6,18 +6,11 @@ public class MyDefaultBinderSample
 {
     public static void Main()
     {
-        try
-        {
             Binder defaultBinder = Type.DefaultBinder;
             MyClass myClass = new MyClass();
             // Invoke the HelloWorld method of MyClass.
             myClass.GetType().InvokeMember("HelloWorld", BindingFlags.InvokeMethod,
                 defaultBinder, myClass, new object [] {});
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception :" + e.Message);
-        }
     }	
 
     class MyClass

--- a/snippets/csharp/VS_Snippets_CLR/Type_FilterAttribute/CS/type_filterattribute.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_FilterAttribute/CS/type_filterattribute.cs
@@ -27,11 +27,7 @@ public class MyFilterAttributeSample
         catch(SecurityException e)
         {
             Console.Write("SecurityException : " + e.Message); 
-        }   
-        catch(Exception e)
-        {
-            Console.Write("Exception :" + e.Message); 
-        } 
+        }
     }	
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_FilterNameIgnoreCase/CS/type_filternameignorecase.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_FilterNameIgnoreCase/CS/type_filternameignorecase.cs
@@ -27,10 +27,6 @@ public class MyFilterNameIgnoreCaseSample
         catch(SecurityException e)
         {
             Console.Write("SecurityException : " + e.Message); 
-        }   
-        catch(Exception e)
-        {
-            Console.Write("Exception : " + e.Message); 
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_CLR/Type_FindInterfaces/CS/type_findinterfaces.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_FindInterfaces/CS/type_findinterfaces.cs
@@ -46,10 +46,6 @@ public class MyFindInterfacesSample
         {
             Console.WriteLine("TargetInvocationException: " + e.Message);
         }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception: " + e.Message);
-        }
     }
       
     public static bool MyInterfaceFilter(Type typeObj,Object criteriaObj)

--- a/snippets/csharp/VS_Snippets_CLR/Type_FindMembers/CS/type_findmembers.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_FindMembers/CS/type_findmembers.cs
@@ -9,8 +9,7 @@ class MyFindMembersClass
         Object objTest = new Object();
         Type objType = objTest.GetType ();
         MemberInfo[] arrayMemberInfo;
-        try
-        {
+        
             //Find all static or public methods in the Object class that match the specified name.
             arrayMemberInfo = objType.FindMembers(MemberTypes.Method,
                 BindingFlags.Public | BindingFlags.Static| BindingFlags.Instance,
@@ -18,12 +17,7 @@ class MyFindMembersClass
                 "ReferenceEquals");
 
             for(int index=0;index < arrayMemberInfo.Length ;index++)
-                Console.WriteLine ("Result of FindMembers -\t"+ arrayMemberInfo[index].ToString() +"\n");                 
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine ("Exception : " + e.ToString() );            
-        }           
+                Console.WriteLine ("Result of FindMembers -\t"+ arrayMemberInfo[index].ToString() +"\n");
     }
     public static bool DelegateToSearchCriteria(MemberInfo objMemberInfo, Object objSearch)
     {

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetArrayRank/CS/type_getarrayrank.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetArrayRank/CS/type_getarrayrank.cs
@@ -19,12 +19,6 @@ class MyArrayRankSample
             Console.WriteLine("Source: " + e.Source);
             Console.WriteLine("Message: " + e.Message);
         }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception raised.");
-            Console.WriteLine("Source: " + e.Source);
-            Console.WriteLine("Message: " + e.Message);
-        }      
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetConstructor/CS/type_getconstructor.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetConstructor/CS/type_getconstructor.cs
@@ -11,8 +11,6 @@ public class MyClass1
 
     public static void Main()
     {
-        try
-        {
             Type myType = typeof(MyClass1);
             Type[] types = new Type[1];
             types[0] = typeof(int);
@@ -29,13 +27,6 @@ public class MyClass1
                 Console.WriteLine("The constructor of MyClass1 that takes an integer " +
                     "as a parameter is not available."); 
             }
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception caught.");
-            Console.WriteLine("Source: " + e.Source);
-            Console.WriteLine("Message: " + e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetConstructor2/CS/type_getconstructor2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetConstructor2/CS/type_getconstructor2.cs
@@ -41,10 +41,6 @@ public class MyClass1
         {
             Console.WriteLine("SecurityException: " + e.Message);
         }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception: " + e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetConstructor3/CS/type_getconstructor3.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetConstructor3/CS/type_getconstructor3.cs
@@ -41,10 +41,6 @@ public class MyClass1
         {
             Console.WriteLine("SecurityException: " + e.Message);
         }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception: " + e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetDefaultMembers/CS/type_getdefaultmembers.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetDefaultMembers/CS/type_getdefaultmembers.cs
@@ -17,8 +17,6 @@ public class MyClass
     }
     public static void Main()
     {
-        try
-        {
             Type  myType = typeof(MyClass);
             MemberInfo[] memberInfoArray = myType.GetDefaultMembers();
             if (memberInfoArray.Length > 0)
@@ -40,10 +38,6 @@ public class MyClass
         catch(IOException e)
         {
             Console.WriteLine("IOException: " + e.Message);
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception: " + e.Message);
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetEvent/CS/type_getevent.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetEvent/CS/type_getevent.cs
@@ -30,10 +30,6 @@ class MyEventExample
             Console.WriteLine("An exception occurred.");
             Console.WriteLine("Message :"+e.Message);
         }
-        catch(Exception e)
-        {
-            Console.WriteLine("The following exception was raised : {0}",e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetHashCode_GetFields/CS/type_gethashcode_getfields.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetHashCode_GetFields/CS/type_gethashcode_getfields.cs
@@ -30,12 +30,6 @@ class FieldsSample
         {
             Console.WriteLine("An exception occurred.");
             Console.WriteLine("Message: "+e.Message);
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("An exception occurred.");
-            Console.WriteLine("Message: "+e.Message);
-
         }		
     }
 }	

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetInterface/CS/type_getinterface.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetInterface/CS/type_getinterface.cs
@@ -22,8 +22,7 @@ class MyInterfaceClass
         Type objType = hashtableObj.GetType();
         MethodInfo[] arrayMethodInfo;
         MemberInfo[] arrayMemberInfo;
-        try
-        {   
+           
             // Get the methods implemented in 'IDeserializationCallback' interface.
             arrayMethodInfo =objType.GetInterface("IDeserializationCallback").GetMethods();
             Console.WriteLine ("\nMethods of 'IDeserializationCallback' Interface :");
@@ -41,12 +40,7 @@ class MyInterfaceClass
             arrayMemberInfo = interfaceMappingObj.InterfaceMethods;
             Console.WriteLine ("\nHashtable class Implements the following IDictionary Interface methods :");
             foreach(MemberInfo memberInfo in arrayMemberInfo)
-               Console.WriteLine (memberInfo); 
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine ("Exception : " + e.ToString());            
-        }                 
+               Console.WriteLine (memberInfo);
     }
 // </Snippet3>
 // </Snippet2>   

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetMember/CS/type_getmember.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetMember/CS/type_getmember.cs
@@ -33,12 +33,6 @@ public class MyMemberSample
             Console.WriteLine("Source: " + e.Source);
             Console.WriteLine("Message: " + e.Message);
         }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception occurred.");
-            Console.WriteLine("Source: " + e.Source);
-            Console.WriteLine("Message: " + e.Message);
-        }
     }
 
     public void GetMemberInfo()

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetNestedTypes/CS/type_getnestedtypes.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetNestedTypes/CS/type_getnestedtypes.cs
@@ -18,8 +18,6 @@ public class MyMainClass
 {
     public static void Main() 
     {
-        try
-        {
             // Get the Type object corresponding to MyClass.
             Type myType=typeof(MyClass);
             // Get an array of nested type objects in MyClass. 
@@ -27,11 +25,6 @@ public class MyMainClass
             Console.WriteLine("The number of nested types is {0}.", nestType.Length);
             foreach(Type t in nestType)
                 Console.WriteLine("Nested type is {0}.", t.ToString());
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("Error"+e.Message);  
-        }         
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetProperty5/CS/type_getproperty2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetProperty5/CS/type_getproperty2.cs
@@ -21,8 +21,6 @@ public class MyTypeClass
 {
     public static void Main()
     {
-        try
-        {
             Type myType=typeof(MyPropertyClass);
             Type[] myTypeArray = new Type[2];
             // Create an instance of the Type array representing the number, order 
@@ -35,11 +33,6 @@ public class MyTypeClass
                 typeof(int),myTypeArray,null);
             Console.WriteLine(myType.FullName + "." + myPropertyInfo.Name + 
                 " has a property type of " + myPropertyInfo.PropertyType);
-         }
-        catch(Exception ex)
-        {
-            Console.WriteLine("An exception occurred " + ex.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetTypeCode/CS/type_gettypecode.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetTypeCode/CS/type_gettypecode.cs
@@ -62,10 +62,6 @@ namespace TypeCodeNamespace
                 Console.WriteLine(e.Message);
             }
 // </Snippet4>
-            catch(Exception e)
-            {
-                Console.WriteLine(e.Message);
-            }
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetTypeFromProgID2/CS/type_gettypefromprogid2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetTypeFromProgID2/CS/type_gettypefromprogid2.cs
@@ -4,8 +4,6 @@ class MainApp
 {
     public static void Main()
     {
-        try
-        {
             // Use the ProgID HKEY_CLASSES_ROOT\DirControl.DirList.1.
             string myString1 ="DIRECT.ddPalette.3"; 
             // Use a nonexistent ProgID WrongProgID.
@@ -16,13 +14,6 @@ class MainApp
             // Throw an exception because the ProgID is invalid and the throwOnError  
             // parameter is set to True.
             Type myType2 =Type.GetTypeFromProgID(myString2,true);
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("An exception occurred.");
-            Console.WriteLine("Source: {0}", e.Source);
-            Console.WriteLine("Message: {0}", e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetTypeFromProgID3/CS/type_gettypefromprogid3.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetTypeFromProgID3/CS/type_gettypefromprogid3.cs
@@ -4,8 +4,6 @@ class MainApp
 {
     public static void Main()
     {
-        try
-        {
             // Use the ProgID localhost\HKEY_CLASSES_ROOT\DirControl.DirList.1.
             string theProgramID ="DirControl.DirList.1"; 
             // Use the server name localhost.
@@ -17,13 +15,6 @@ class MainApp
                 throw new Exception("Invalid ProgID or Server.");
             }
             Console.WriteLine("GUID for ProgID DirControl.DirList.1 is {0}.", myType.GUID);
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("An exception occurred.");
-            Console.WriteLine("Source: {0}" , e.Source);
-            Console.WriteLine("Message: {0}" , e.Message);
-        }		
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_GetTypeFromProgID4/CS/type_gettypefromprogid4.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_GetTypeFromProgID4/CS/type_gettypefromprogid4.cs
@@ -5,8 +5,6 @@ class MainApp
 {
     public static void Main()
     {
-        try
-        {
             // Use server localhost.
             string theServer="localhost";
             // Use  ProgID HKEY_CLASSES_ROOT\DirControl.DirList.1.
@@ -19,13 +17,6 @@ class MainApp
             // Throw an exception because the ProgID is invalid and the throwOnError 
             // parameter is set to True.
             Type myType2 =Type.GetTypeFromProgID(myString2, theServer, true);
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("An exception occurred. The ProgID is wrong.");
-            Console.WriteLine("Source: {0}" , e.Source);
-            Console.WriteLine("Message: {0}" , e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_HasElementTypeImpl/CS/type_haselementtypeimpl.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_HasElementTypeImpl/CS/type_haselementtypeimpl.cs
@@ -38,8 +38,6 @@ public class Type_HasElementTypeImpl
 {
     public static void Main()
     {
-        try
-        {
             int myInt = 0 ; 
             int[] myArray = new int[5];
             MyTypeDelegator myType = new MyTypeDelegator(myArray.GetType());
@@ -55,11 +53,6 @@ public class Type_HasElementTypeImpl
                 Console.WriteLine("The type of myInt is {0}.", myType.myElementType);
             else
                 Console.WriteLine("myInt is not an array, pointer, or reference type.");
-        }
-        catch( Exception e )
-        {
-            Console.WriteLine("Exception: {0}", e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_IsAnsiClass/CS/type_isansiclass.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_IsAnsiClass/CS/type_isansiclass.cs
@@ -9,8 +9,6 @@ public class MyType_IsAnsiClass
 {
     public static void Main()
     {
-        try
-        {
             MyClass myObject = new MyClass();
             // Get the type of the 'MyClass'.
             Type myType = typeof(MyClass);
@@ -19,11 +17,6 @@ public class MyType_IsAnsiClass
             Console.WriteLine( "\nChecking for the AnsiClass attribute for a field.\n"); 
             // Get and display the name, field, and the AnsiClass attribute.
             Console.WriteLine("Name of Class: {0} \nValue of Field: {1} \nIsAnsiClass = {2}", myType.FullName, myFieldInfo.GetValue(myObject), myType.IsAnsiClass);
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("Exception: {0}",e.Message);
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_IsArrayImpl/CS/type_isarrayimpl.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_IsArrayImpl/CS/type_isarrayimpl.cs
@@ -26,8 +26,6 @@ public class Type_IsArrayImpl
 {
     public static void Main()
     {
-        try
-        {
             int myInt = 0 ; 
             // Create an instance of an array element.
             int[] myArray = new int[5];
@@ -45,11 +43,6 @@ public class Type_IsArrayImpl
                 Console.WriteLine("The type of myInt is {0}.", myType.myElementType);
             else
                 Console.WriteLine("myInt is not an array.");
-        }
-        catch( Exception e )
-        {
-            Console.WriteLine("Exception: {0}", e.Message );
-        }
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_IsClass/CS/type_isclass.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_IsClass/CS/type_isclass.cs
@@ -10,16 +10,9 @@ public class MyTypeClass
 {
     public static void Main(string[] args)
     {
-        try
-        {
             Type  myType = typeof(MyDemoClass);
             // Get and display the 'IsClass' property of the 'MyDemoClass' instance.
-            Console.WriteLine("\nIs the specified type a class? {0}.", myType.IsClass); 
-        }
-        catch(Exception e)
-        {
-            Console.WriteLine("\nAn exception occurred: {0}." ,e.Message);
-        }
+            Console.WriteLine("\nIs the specified type a class? {0}.", myType.IsClass);
     }
 }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR/Type_IsContextfulImpl/CS/type_iscontextfulimpl.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Type_IsContextfulImpl/CS/type_iscontextfulimpl.cs
@@ -26,8 +26,6 @@ public class MyTypeDemoClass
 {
     public static void Main()
     {
-        try
-        {
             MyTypeDelegatorClass myType;
             Console.WriteLine ("Check whether MyContextBoundClass can be hosted in a context.");
             // Check whether MyContextBoundClass is contextful.
@@ -50,12 +48,7 @@ public class MyTypeDemoClass
             else
             {
                 Console.WriteLine(typeof(MyTypeDemoClass) + " cannot be hosted in a context.");
-            }
-        }
-        catch( Exception e )
-        {
-            Console.WriteLine("Exception: {0}", e.Message);
-        }
+            }        
     }
 }
 // This class demonstrates IsContextfulImpl.

--- a/snippets/csharp/VS_Snippets_Remoting/PortCollection_Item/CS/portcollection_item.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/PortCollection_Item/CS/portcollection_item.cs
@@ -21,8 +21,6 @@ class PortCollection_Item
 {
    public static void Main()
    {
-      try
-      {
 // <Snippet1>
 // <Snippet2>
 // <Snippet3>
@@ -77,10 +75,5 @@ class PortCollection_Item
 // </Snippet2>
 // </Snippet1>
          }
-      }
-      catch(Exception ex)
-      {
-         Console.WriteLine("Exception: " + ex.Message);
-      }
    }
 }


### PR DESCRIPTION
## Summary

Several catches were removed from c# examples (~15%)
No formatting for easier review. (Formatting will be added next PR)
VB and c++ examples will be fixed next.

Related to dotnet/docs#4870