### PR TITLE
Use classes instead of structs in pattern matching sample

### DIFF
--- a/csharp/PatternMatching/Shapes.cs
+++ b/csharp/PatternMatching/Shapes.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace PatternMatching
 {
     #region 01_ShapeDefinitions
-    public struct Square
+    public class Square
     {
         public double Side { get; }
 
@@ -16,7 +16,7 @@ namespace PatternMatching
             Side = side;
         }
     }
-    public struct Circle
+    public class Circle
     {
         public double Radius { get; }
 
@@ -25,7 +25,7 @@ namespace PatternMatching
             Radius = radius;
         }
     }
-    public struct Rectangle
+    public class Rectangle
     {
         public double Length { get; }
         public double Height { get; }
@@ -36,7 +36,7 @@ namespace PatternMatching
             Height = height;
         }
     }
-    public struct Triangle
+    public class Triangle
     {
         public double Base { get; }
         public double Height { get; }


### PR DESCRIPTION
I don't see much point in using structs here:

* It does not avoid any allocations, since values of these types are boxed right after creation.
* Classes are more commonly used in C#, so I think this makes the code easier to understand.

I have also considered making the classes `sealed`, but decided against it. It would probably be a good practice here, but it's adding a concept that does not really add anything to examples that are this simple.