### PR TITLE
Made SampleEventArgs field readonly

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -227,7 +227,7 @@ namespace csrefKeywordsModifiers
     public class SampleEventArgs
     {
         public SampleEventArgs(string s) { Text = s; }
-        public String Text {get; private set;} // readonly
+        public String Text { get; } // readonly
     }
     public class Publisher
     {


### PR DESCRIPTION
Made SampleEventArgs field readonly by removing setter

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
