### PR TITLE
Added sample code to read attributes for C# tour

### DIFF
--- a/snippets/csharp/tour/attributes/Program.cs
+++ b/snippets/csharp/tour/attributes/Program.cs
@@ -31,6 +31,7 @@
     {
         public static void Main(string[] args)
         {
+            // <SnippetReadAttributes>
             Type widgetType = typeof(Widget);
 
             //Gets every HelpAttribute defined for the Widget type
@@ -54,6 +55,7 @@
             }
 
             Console.ReadLine();
+            // </SnippetReadAttributes>
         }
     }
 }

--- a/snippets/csharp/tour/attributes/Program.cs
+++ b/snippets/csharp/tour/attributes/Program.cs
@@ -31,6 +31,29 @@
     {
         public static void Main(string[] args)
         {
+            Type widgetType = typeof(Widget);
+
+            //Gets every HelpAttribute defined for the Widget type
+            object[] widgetClassAttributes = widgetType.GetCustomAttributes(typeof(HelpAttribute), false);
+
+            if (widgetClassAttributes.Length > 0)
+            {
+                HelpAttribute attr = (HelpAttribute)widgetClassAttributes[0];
+                Console.WriteLine($"Widget class help URL : {attr.Url} - Related topic : {attr.Topic}");
+            }
+
+            System.Reflection.MethodInfo displayMethod = widgetType.GetMethod(nameof(Widget.Display));
+
+            //Gets every HelpAttribute defined for the Widget.Display method
+            object[] displayMethodAttributes = displayMethod.GetCustomAttributes(typeof(HelpAttribute), false);
+
+            if (displayMethodAttributes.Length > 0)
+            {
+                HelpAttribute attr = (HelpAttribute)displayMethodAttributes[0];
+                Console.WriteLine($"Display method help URL : {attr.Url} - Related topic : {attr.Topic}");
+            }
+
+            Console.ReadLine();
         }
     }
 }


### PR DESCRIPTION
This PR adds a snippet to demonstrate how to read attributes with C# at [C# Attributes - A tour of the C# language](https://docs.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/attributes)

Fixes dotnet/docs#5424 
