### PR TITLE
Add snippet tags to Person Class

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/TabControlContentTemplateSelector/CSharp/Data.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/TabControlContentTemplateSelector/CSharp/Data.cs
@@ -1,3 +1,4 @@
+//<Snippet1>
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -72,7 +73,7 @@ namespace TabControlContentTemplateSelector
             }
         }
     }
-
+    //</Snippet1>
     // Create a collection of Person objects.
     public class People : ObservableCollection<Person>
     {

--- a/snippets/visualbasic/VS_Snippets_Wpf/TabControlContentTemplateSelector/VisualBasic/Person.vb
+++ b/snippets/visualbasic/VS_Snippets_Wpf/TabControlContentTemplateSelector/VisualBasic/Person.vb
@@ -1,3 +1,4 @@
+'<Snippet1>
 Imports System
 Imports System.ComponentModel
 
@@ -63,4 +64,4 @@ Public Class Person
     Private _hometown As String
     Private _lastname As String
 End Class
-
+'</Snippet1>


### PR DESCRIPTION
The person class was not included in the [TabControl.ContentTemplateSelector Property](https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.tabcontrol.contenttemplateselector?view=netframework-4.7.2#examples) topic, but it is in samples. Added snippets to be included in the topic.

Fixes dotnet/docs [#6106](https://github.com/dotnet/docs/issues/6106)
