### PR TITLE
Update expr-bodied-ctor.cs

### DIFF
--- a/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs
@@ -5,7 +5,7 @@ public class Location
 {
    private string locationName;
    
-   public Location(string name) => locationName = name;
+   public Location(string name) => Name = name;
 
    public string Name
    {


### PR DESCRIPTION
Above the example, it is said:
"The following example defines a Location class whose constructor has a single string parameter named name.
The expression body definition assigns the argument to the Name property."

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
