### PR TITLE
Make `Rectangle` a struct

### DIFF
--- a/csharp/PatternMatching/Shapes.cs
+++ b/csharp/PatternMatching/Shapes.cs
@@ -25,7 +25,7 @@ namespace PatternMatching
             Radius = radius;
         }
     }
-    public class Rectangle
+    public struct Rectangle
     {
         public double Length { get; }
         public double Height { get; }


### PR DESCRIPTION
## Make Rectangle a `struct`

In #165 all `struct`s became classes, but further down in the pattern matching doc, the fact that `Rectangle` is a struct is used to illustrate the fact that the `is` expression works with both value and reference types.

>Also, notice that this version includes
>the `Rectangle` type, which is a `struct`. The new `is` expression works with
>value types as well as reference types.

As I believe this note to be relevant, I decided to revert `Rectangle` to be a `struct` instead of removing the note that references a Rectangle as a `struct`  from the documentation


