### PR TITLE
replace ?. with . on return from Trim

### DIFF
--- a/csharp/PatternMatching/PatternMatching.csproj
+++ b/csharp/PatternMatching/PatternMatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/PatternMatching/Program.cs
+++ b/csharp/PatternMatching/Program.cs
@@ -44,7 +44,7 @@ namespace PatternMatching
                 case "large-circle":
                     return new Circle(12);
 
-                case var o when (o?.Trim()?.Length ?? 0) == 0:
+                case var o when (o?.Trim().Length ?? 0) == 0:
                     // white space
                     return null;
                 default:


### PR DESCRIPTION
Fixes dotnet/docs#6397

The `Trim` method never returns `null`, so `?.` is unnecessary.

Also, upgrade to .NET Core 2.1 framework.

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
