### PR TITLE
removed code snippet tags

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/BusinessLayerValidation/CSharp/Window1.xaml
+++ b/snippets/csharp/VS_Snippets_Wpf/BusinessLayerValidation/CSharp/Window1.xaml
@@ -21,7 +21,7 @@
 
     <StackPanel Margin="20">
         <TextBlock>Enter your age:</TextBlock>
-<!--<SnippetBoundTextBox>-->
+
         <TextBox Style="{StaticResource textBoxInError}">
             <TextBox.Text>
                 <!--By setting ValidatesOnExceptions to True, it checks for exceptions
@@ -40,7 +40,7 @@
                 </Binding>
             </TextBox.Text>
         </TextBox>
-<!--</SnippetBoundTextBox>-->
+
         <TextBlock>Mouse-over to see the validation error message.</TextBlock>
     </StackPanel>
 </Window>


### PR DESCRIPTION
## Removed code snippet tags

The code in window1.xaml will be displayed using highlighting rather than a snippet tag.

Do not merge until *after* the related PR (dotnet/docs#6806) has merged.

Related to PR dotnet/docs#6806

Addresses issue dotnet/docs#6789



