### PR TITLE
Added using statement to dispose SqlDataReader, fixes 5914.

### DIFF
--- a/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlDataReader.Close Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlDataReader.Close Example/CS/source.cs
@@ -21,21 +21,24 @@ class Program
         using (SqlConnection connection =
                    new SqlConnection(connectionString))
         {
-            SqlCommand command =
-                new SqlCommand(queryString, connection);
             connection.Open();
 
-            SqlDataReader reader = command.ExecuteReader();
-
-            // Call Read before accessing data.
-            while (reader.Read())
+            using (SqlCommand command =
+                new SqlCommand(queryString, connection))
             {
-                Console.WriteLine(String.Format("{0}, {1}",
-                    reader[0], reader[1]));
-            }
+                using (SqlDataReader reader = command.ExecuteReader())
+                {
+                    // Call Read before accessing data.
+                    while (reader.Read())
+                    {
+                        Console.WriteLine(String.Format("{0}, {1}",
+                            reader[0], reader[1]));
+                    }
 
-            // Call Close when done reading.
-            reader.Close();
+                    // Call Close when done reading.
+                   reader.Close();
+                }
+        }
         }
     }
     // </Snippet1>


### PR DESCRIPTION
## Summary

Added a using statement to dispose the SqlDataReader (and other objects) per customer suggestion and best practices.

Fixes dotnet/docs#5914

