### PR TITLE
Update window1.xaml.cs

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/HostingAxInWpf/CSharp/HostingAxInWpf/window1.xaml.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/HostingAxInWpf/CSharp/HostingAxInWpf/window1.xaml.cs
@@ -24,7 +24,7 @@ namespace HostingAxInWpf
                 new System.Windows.Forms.Integration.WindowsFormsHost();
 
             // Create the ActiveX control.
-            AxWMPLib.AxWindowsMediaPlayer axWmp = new AxWMPLib.AxWindowsMediaPlayer();
+            WmpAxLib.AxWindowsMediaPlayer axWmp = new WmpAxLib.AxWindowsMediaPlayer();
 
             // Assign the ActiveX control as the host control's child.
             host.Child = axWmp;


### PR DESCRIPTION
Namespace WmpAxLib now matches the project name in the documentation

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
