### PR TITLE
Update and rename verbatim4.cs to verbatim2.cs

### DIFF
--- a/snippets/csharp/language-reference/keywords/verbatim2.cs
+++ b/snippets/csharp/language-reference/keywords/verbatim2.cs
@@ -23,7 +23,7 @@ public class InfoAttribute : Attribute
    }
 }
 
-[@Info("A simple executable.")]
+[Info("A simple executable.")] // Prepend '@' to 'Info' to avoid compiler error CS1614.
 public class Example
 {
    [InfoAttribute("The entry point.")]


### PR DESCRIPTION
This is a change for the 'docs/docs/csharp/language-reference/tokens/verbatim.md' file.

The goal is to simplify and use only one example instead of two.