### PR TITLE
Synced System.Single snippets with the text

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.single.structure/cs/representation2.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.single.structure/cs/representation2.cs
@@ -6,12 +6,11 @@ public class Example
 {
    public static void Main()
    {
-      Single value = 123456789e4f;
-      Single additional = Single.Epsilon * 1e12f;
-      Console.WriteLine("{0} + {1} = {2}", value, additional, 
-                                           value + additional);
+      Single value = 123.456f;
+      Single additional = Single.Epsilon * 1e15f;
+      Console.WriteLine($"{value} + {additional} = {value + additional}");
    }
 }
 // The example displays the following output:
-//    1.234568E+12 + 1.401298E-33 = 1.234568E+12
+//    123.456 + 1.401298E-30 = 123.456
 // </Snippet4>

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.single.structure/vb/representation2.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.single.structure/vb/representation2.vb
@@ -4,13 +4,12 @@ Option Strict On
 ' <Snippet4>
 Module Example
    Public Sub Main()
-      Dim value As Single = 123456789e4
-      Dim additional As Single = Single.Epsilon * 1e12
-      Console.WriteLine("{0} + {1} = {2}", value, additional, 
-                                           value + additional)
+      Dim value As Single = 123.456
+      Dim additional As Single = Single.Epsilon * 1e15
+      Console.WriteLine($"{value} + {additional} = {value + additional}")
    End Sub
 End Module
 ' The example displays the following output:
-'   1.234568E+12 + 1.401298E-33 = 1.234568E+12
+'   123.456 + 1.401298E-30 = 123.456
 ' </Snippet4>
 


### PR DESCRIPTION
Related to dotnet/dotnet-api-docs#452

Changes made in code to match the article text:
- use quadrillion in the product
- make the least significant digit in `value` be thousandths
