### PR TITLE
Update default-literal.cs

### DIFF
--- a/snippets/csharp/programming-guide/statements-expressions-operators/default-literal.cs
+++ b/snippets/csharp/programming-guide/statements-expressions-operators/default-literal.cs
@@ -21,7 +21,7 @@ public class LabeledPoint
     {
         X = x;
         Y = y;
-        this.Label = label;
+        Label = label;
     }
 
     public static LabeledPoint MovePoint(LabeledPoint source, 


### PR DESCRIPTION
Unnecessary `this`.

found in: [default value expressions (C# programming guide)](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/default-value-expressions)