### PR TITLE
Fix build of the keywords project

### DIFF
--- a/snippets/csharp/keywords/ReadonlyKeywordExamples.cs
+++ b/snippets/csharp/keywords/ReadonlyKeywordExamples.cs
@@ -40,7 +40,7 @@ namespace keywords
             z = p3;
         }
 
-        static void Main()
+        public static void Main()
         {
             SampleClass p1 = new SampleClass(11, 21, 32);   // OK
             Console.WriteLine($"p1: x={p1.x}, y={p1.y}, z={p1.z}");
@@ -72,7 +72,7 @@ namespace keywords
     {
         public static void Examples()
         {
-            SampleClass.Usage();
+            SampleClass.Main();
             ReadonlyRefReturns();
         }
 


### PR DESCRIPTION
Fixed build of the [keywords project](https://github.com/dotnet/samples/tree/master/snippets/csharp/keywords)

There is no `SampleClass.Usage` method, the `Main` method must be called.
