### PR TITLE
Modifying order of the case clauses

### DIFF
--- a/snippets/csharp/language-reference/keywords/when/when.cs
+++ b/snippets/csharp/language-reference/keywords/when/when.cs
@@ -57,15 +57,15 @@ public class Example
          case Shape shape when shape.Area == 0:
             Console.WriteLine($"The shape: {shape.GetType().Name} with no dimensions");
             break;
-         case Rectangle r when r.Area > 0:
-            Console.WriteLine("Information about the rectangle:");
-            Console.WriteLine($"   Dimensions: {r.Length} x {r.Width}");
-            Console.WriteLine($"   Area: {r.Area}");
-            break;
          case Square sq when sq.Area > 0:
             Console.WriteLine("Information about the square:");
             Console.WriteLine($"   Length of a side: {sq.Side}");
             Console.WriteLine($"   Area: {sq.Area}");
+            break;
+         case Rectangle r when r.Area > 0:
+            Console.WriteLine("Information about the rectangle:");
+            Console.WriteLine($"   Dimensions: {r.Length} x {r.Width}");
+            Console.WriteLine($"   Area: {r.Area}");
             break;
          case Shape shape:
             Console.WriteLine($"A {shape.GetType().Name} shape");
@@ -80,8 +80,8 @@ public class Example
    }
 }
 // The example displays the following output:
-//       Information about the rectangle:
-//          Dimensions: 10 x 10
+//       Information about the square:
+//          Length of a side: 10
 //          Area: 100
 //       Information about the rectangle:
 //          Dimensions: 5 x 7


### PR DESCRIPTION
The previous order prevented the clause `case Square sq when sq.Area > 0:` from ever being executed, acording to the sample data provided. Because **Rectangle** class is more general than **Square** class, the fact that the clause `case Rectangle r when r.Area > 0:` is placed first, prevents the execution of the `case Square sq when sq.Area > 0:`

Fixes dotnet/docs#7270

## Summary

This change is related to the discussion opened on the [dotnet/docs](https://github.com/dotnet/docs/issues/7270#issuecomment-416354624) repository, regarding the order of the **case** clauses according to the sample data provided in the snippet file.
