### PR TITLE
Updated sample to reflect usage of 4 parameters

### DIFF
--- a/snippets/cpp/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/CPP/source.cpp
+++ b/snippets/cpp/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/CPP/source.cpp
@@ -12,13 +12,18 @@ int main()
    
    // Create a new element node.
    XmlNode^ newElem;
-   newElem = doc->CreateNode( XmlNodeType::Element, "pages", "" );
-   newElem->InnerText = "290";
-   Console::WriteLine( "Add the new element to the document..." );
+   newElem = doc->CreateNode( XmlNodeType::Element, "g" , "ISBN" , "https://global.ISBN/list" );
+   newElem->InnerText = "1-861001-57-5";
+    
+   // Add the new element to the document
    XmlElement^ root = doc->DocumentElement;
    root->AppendChild( newElem );
-   Console::WriteLine( "Display the modified XML document..." );
+    
+   // Display the modified XML document
    Console::WriteLine( doc->OuterXml );
+    
+    // Output:
+    // <book><title>Oberon's Legacy</title><price>5.95</price><g:ISBN xmlns:g="https://global.ISBN/list">1-861001-57-5</g:ISBN></book>
 }
 
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/CS/source.cs
@@ -5,24 +5,29 @@ using System.Xml;
 public class Sample {
 
   public static void Main() {
+      
+        // Create a new document containing information about a book
+        XmlDocument doc = new XmlDocument();
+        doc.LoadXml("<book>" +
+                    "  <title>Oberon's Legacy</title>" +
+                    "  <price>5.95</price>" +
+                    "</book>");
 
-       XmlDocument doc = new XmlDocument();
-       doc.LoadXml("<book>" +
-                   "  <title>Oberon's Legacy</title>" +
-                   "  <price>5.95</price>" +
-                   "</book>"); 
- 
-       // Create a new element node.
-       XmlNode newElem;
-       newElem = doc.CreateNode(XmlNodeType.Element, "pages", "");  
-       newElem.InnerText = "290";
-     
-       Console.WriteLine("Add the new element to the document...");
-       XmlElement root = doc.DocumentElement;
-       root.AppendChild(newElem);
-     
-       Console.WriteLine("Display the modified XML document...");
-       Console.WriteLine(doc.OuterXml);
+        // Create a new element node for the ISBN of the book
+        // It is possible to supply a prefix for this node, and specify a qualified namespace.
+        XmlNode newElem;
+        newElem = doc.CreateNode(XmlNodeType.Element, "g", "ISBN", "https://global.ISBN/list");
+        newElem.InnerText = "ABC12345";
+
+        // Add the new element to the document
+        XmlElement root = doc.DocumentElement;
+        root.AppendChild(newElem);
+
+        // Display the modified XML document
+        Console.WriteLine(doc.OuterXml);
+
+        //Output: 
+        // <book><title>Oberon's Legacy</title><price>5.95</price><g:ISBN xmlns:g="https://global.ISBN/list">ABC12345</g:ISBN></book>
    }
  }
 // </Snippet1>

--- a/snippets/csharp/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/CS/source.cs
@@ -17,7 +17,7 @@ public class Sample {
         // It is possible to supply a prefix for this node, and specify a qualified namespace.
         XmlNode newElem;
         newElem = doc.CreateNode(XmlNodeType.Element, "g", "ISBN", "https://global.ISBN/list");
-        newElem.InnerText = "ABC12345";
+        newElem.InnerText = "1-861001-57-5";
 
         // Add the new element to the document
         XmlElement root = doc.DocumentElement;

--- a/snippets/csharp/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/CS/source.cs
@@ -27,7 +27,7 @@ public class Sample {
         Console.WriteLine(doc.OuterXml);
 
         //Output: 
-        // <book><title>Oberon's Legacy</title><price>5.95</price><g:ISBN xmlns:g="https://global.ISBN/list">ABC12345</g:ISBN></book>
+        // <book><title>Oberon's Legacy</title><price>5.95</price><g:ISBN xmlns:g="https://global.ISBN/list">1-861001-57-5</g:ISBN></book>
    }
  }
 // </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/VB/source.vb
+++ b/snippets/visualbasic/VS_Snippets_Data/Classic WebData XmlDocument.CreateNode2 Example/VB/source.vb
@@ -6,23 +6,27 @@ public class Sample
 
   public shared sub Main() 
 
-       Dim doc as XmlDocument = new XmlDocument()
-       doc.LoadXml("<book>" & _
-                   "  <title>Oberon's Legacy</title>" & _
-                   "  <price>5.95</price>" & _
-                   "</book>") 
+        Dim doc as XmlDocument = new XmlDocument()
+        doc.LoadXml("<book>" & _
+                    "  <title>Oberon's Legacy</title>" & _
+                    "  <price>5.95</price>" & _
+                       "</book>") 
  
-       ' Create a new element node.
-       Dim newElem as XmlNode
-       newElem = doc.CreateNode(XmlNodeType.Element, "pages", "")  
-       newElem.InnerText = "290"
+        ' Create a new element node.
+        ' It is possible to supply a prefix for this node, and specify a qualified namespace
+        Dim newElem as XmlNode
+        newElem = doc.CreateNode(XmlNodeType.Element,"g", "ISBN","https://global.ISBN/list")
+        newElem.InnerText = "1-861001-57-5"
      
-       Console.WriteLine("Add the new element to the document...")
-       Dim root as XmlElement = doc.DocumentElement
-       root.AppendChild(newElem)
+        ' Add the new element to the document
+        Dim root as XmlElement = doc.DocumentElement
+        root.AppendChild(newElem)
      
-       Console.WriteLine("Display the modified XML document...")
-       Console.WriteLine(doc.OuterXml)
+        ' Display the modified XML document
+        Console.WriteLine(doc.OuterXml)
+        
+        ' Output:
+        ' <book><title>Oberon's Legacy</title><price>5.95</price><g:ISBN xmlns:g="https://global.ISBN/list">1-861001-57-5</g:ISBN></book>
    end sub
 end class
 ' </Snippet1>


### PR DESCRIPTION
The sample did not show the usage of the `prefix` parameter.
This is now updated to include an example of how to use the `prefix` parameter.

## Summary

I tried to find a good example on how to use the `prefix` parameter in this method, while still keeping the same narrative as the other examples for `XmlDocument.CreateNode()`.
If anyone has a better idea for the namespace, please change 👍 

Fixes dotnet/docs#7260
