### PR TITLE
Added config file from Notes to Inheritors

### DIFF
--- a/snippets/csharp/VS_Snippets_WebNet/System.Web.Profile.HttpProfileBase/CS/config.xml
+++ b/snippets/csharp/VS_Snippets_WebNet/System.Web.Profile.HttpProfileBase/CS/config.xml
@@ -1,0 +1,24 @@
+<configuration>
+   <system.web>
+      <profile inherits="Samples.AspNet.Profile.EmployeeProfile"  
+      defaultProvider="SqlProvider">  
+      <providers>  
+         <clear />  
+         <add  
+            name="SqlProvider"  
+            type="System.Web.Profile.SqlProfileProvider"   
+            connectionStringName="SqlServices"   
+            description="SQL Profile Provider for Sample"/>   
+         <add  
+            name="EmployeeInfoProvider"  
+            type="System.Web.Profile.SqlProfileProvider"   
+            connectionStringName="SqlServices"   
+            description="SQL Profile Provider for Employee Info"/>   
+      </providers>  
+      
+      <properties>  
+         <add name="GarmentSize" />  
+      </properties>  
+      </profile>  
+   </system.web>
+</configuration>


### PR DESCRIPTION
## Add config file from Notes to Inheritors section of ProfileBase

The Notes to Inheritors section contains fenced code inside XML, which is not supported. This PR moves the code into the Samples repo.

Related to dotnet/dotnet-api-docs#483
