### PR TITLE
Added remainder operator snippets

### DIFF
--- a/snippets/csharp/language-reference/operators/Program.cs
+++ b/snippets/csharp/language-reference/operators/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace operators
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            RemainderExamples.Examples();
+        }
+    }
+}

--- a/snippets/csharp/language-reference/operators/Program.cs
+++ b/snippets/csharp/language-reference/operators/Program.cs
@@ -6,6 +6,7 @@ namespace operators
     {
         static void Main(string[] args)
         {
+            Console.WriteLine("============== Remainder operator examples =============");
             RemainderExamples.Examples();
         }
     }

--- a/snippets/csharp/language-reference/operators/RemainderExamples.cs
+++ b/snippets/csharp/language-reference/operators/RemainderExamples.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace operators
+{
+    public static class RemainderExamples
+    {
+        public static void Examples()
+        {
+            IntegerRemainder();
+            FloatingPointRemainer();
+        }
+
+        private static void IntegerRemainder()
+        {
+            Console.WriteLine("Integer");
+        }
+
+        private static void FloatingPointRemainer()
+        {
+            Console.WriteLine("Floating-point");
+        }
+    }
+}

--- a/snippets/csharp/language-reference/operators/RemainderExamples.cs
+++ b/snippets/csharp/language-reference/operators/RemainderExamples.cs
@@ -6,18 +6,42 @@ namespace operators
     {
         public static void Examples()
         {
+            Console.WriteLine("Integer remainder:");
             IntegerRemainder();
+
+            Console.WriteLine("Remainder with binary floating-point types:");
             FloatingPointRemainer();
+
+            Console.WriteLine("Remainder assignment example:");
+            RemainderAssignment();
         }
 
         private static void IntegerRemainder()
         {
-            Console.WriteLine("Integer");
+            // <Snippet1>
+            Console.WriteLine(5 % 4);   // output: 1
+            Console.WriteLine(5 % -4);  // output: 1
+            Console.WriteLine(-5 % 4);  // output: -1
+            Console.WriteLine(-5 % -4); // output: -1
+            // </Snippet1>
         }
 
         private static void FloatingPointRemainer()
         {
-            Console.WriteLine("Floating-point");
+            // <Snippet2>
+            Console.WriteLine(-5.2f % 2.0f); // output: -1.2
+            Console.WriteLine(5.0 % 2.2);    // output: 0.6
+            Console.WriteLine(.41 % .2);     // output: 0.00999999999999995
+            // </Snippet2>
+        }
+
+        private static void RemainderAssignment()
+        {
+            // <Snippet3>
+            int a = 5;
+            a %= 3;
+            Console.WriteLine(a);  // output: 2
+            // </Snippet3>
         }
     }
 }

--- a/snippets/csharp/language-reference/operators/operators.csproj
+++ b/snippets/csharp/language-reference/operators/operators.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>7.3</LangVersion>
+    <StartupObject>operators.Program</StartupObject>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Supports dotnet/docs#7464

@BillWagner @mairaw @rpetrusha 
This PR not only adds the remainder operator snippets, but starts up the dedicated C# project for the operator snippets. Like the existing one for [keywords](https://github.com/dotnet/samples/tree/master/snippets/csharp/keywords). If you don't mind, as time goes (rather flies, though), I'll move all the operator snippets from the [docs repo](https://github.com/dotnet/docs/tree/master/docs/csharp/language-reference/operators/codesnippet/CSharp) to this project (might be a good excuse to revise the code examples and the articles).
