### PR TITLE
Fix logic comparison (docs issue #7481)

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/system.windows.forms.methodinvoker/cs/form1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/system.windows.forms.methodinvoker/cs/form1.cs
@@ -16,7 +16,7 @@ namespace _454942_CS_MethodInvoker
         {
             // Don't do anything if the form's handle hasn't been created 
             // or the form has been disposed.
-            if (!this.IsHandleCreated || !this.IsDisposed) return;
+            if (!this.IsHandleCreated || this.IsDisposed) return;
             
             // Invoke an anonymous method on the thread of the form.
             this.Invoke((MethodInvoker) delegate

--- a/snippets/csharp/VS_Snippets_Winforms/system.windows.forms.methodinvoker/cs/form1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/system.windows.forms.methodinvoker/cs/form1.cs
@@ -16,7 +16,7 @@ namespace _454942_CS_MethodInvoker
         {
             // Don't do anything if the form's handle hasn't been created 
             // or the form has been disposed.
-            if (!this.IsHandleCreated && !this.IsDisposed) return;
+            if (!this.IsHandleCreated || !this.IsDisposed) return;
             
             // Invoke an anonymous method on the thread of the form.
             this.Invoke((MethodInvoker) delegate

--- a/snippets/visualbasic/VS_Snippets_Winforms/system.windows.forms.methodinvoker/vb/form1.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/system.windows.forms.methodinvoker/vb/form1.vb
@@ -14,7 +14,7 @@ Partial Public Class Form1
     Sub ShowTime(ByVal x As Object)
         ' Don't do anything if the form's handle hasn't been created 
         ' or the form has been disposed.
-        If (Not Me.IsHandleCreated And Not Me.IsDisposed) Then Return
+        If (Not Me.IsHandleCreated Or Me.IsDisposed) Then Return
 
         ' Create the method invoker.
         ' The method body shows the current time in the forms title bar.

--- a/snippets/visualbasic/VS_Snippets_Winforms/system.windows.forms.methodinvoker/vb/form1.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/system.windows.forms.methodinvoker/vb/form1.vb
@@ -14,7 +14,7 @@ Partial Public Class Form1
     Sub ShowTime(ByVal x As Object)
         ' Don't do anything if the form's handle hasn't been created 
         ' or the form has been disposed.
-        If (Not Me.IsHandleCreated Or Me.IsDisposed) Then Return
+        If (Not Me.IsHandleCreated OrElse Me.IsDisposed) Then Return
 
         ' Create the method invoker.
         ' The method body shows the current time in the forms title bar.


### PR DESCRIPTION
## Summary

The code should exit early if the handle is not created or the form is disposed.

Fixes dotnet/docs#7481
