### PR TITLE
Stream Disposal in StreamReader Constructor Snippet

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/StrmReader Ctor1/CS/strmreader ctor1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader Ctor1/CS/strmreader ctor1.cs
@@ -2,41 +2,36 @@
 using System;
 using System.IO;
 
-class Test 
+class Test
 {
-	
-    public static void Main() 
+    public static void Main()
     {
         string path = @"c:\temp\MyTest.txt";
 
-        try 
+        try
         {
-            if (File.Exists(path)) 
+            if (File.Exists(path))
             {
                 File.Delete(path);
             }
 
-            using (StreamWriter sw = new StreamWriter(path)) 
+            using (StreamWriter sw = new StreamWriter(path))
             {
                 sw.WriteLine("This");
                 sw.WriteLine("is some text");
                 sw.WriteLine("to test");
-                sw.WriteLine("Reading");
+                sw.WriteLine("reading");
             }
 
-            using (FileStream fs = new FileStream(path, FileMode.Open)) 
+            using (StreamReader sr = new StreamReader(new FileStream(path, FileMode.Open)))
             {
-                using (StreamReader sr = new StreamReader(fs)) 
+                while (sr.Peek() >= 0)
                 {
-
-                    while (sr.Peek() >= 0) 
-                    {
-                        Console.WriteLine(sr.ReadLine());
-                    }
+                    Console.WriteLine(sr.ReadLine());
                 }
             }
-        } 
-        catch (Exception e) 
+        }
+        catch (Exception e)
         {
             Console.WriteLine("The process failed: {0}", e.ToString());
         }


### PR DESCRIPTION
## Summary

 - Disposing of the StreamReader instance will dispose of the stream, so
 there is no need to explicitly dispose

 - Fixed other miscellaneous whitespace and capitalization issues