### PR TITLE
Modernized and streamlined example

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/ProcessVerbs_Diagnostics/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ProcessVerbs_Diagnostics/CS/source.cs
@@ -1,89 +1,90 @@
 //<Snippet1>
 //<Snippet3>
-
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Diagnostics;
-using System.Text;
 using System.Windows.Forms;
 
 class ProcessInformation
 {
     [STAThread]
-    static void Main(string[] args)
+    static void Main()
     {
-        string fileName = "";
-        string arguments = "";
-        string verbToUse = "";
-        int i = 0;
-        ProcessStartInfo startInfo = new ProcessStartInfo();
         OpenFileDialog openFileDialog1 = new OpenFileDialog();
 
         openFileDialog1.InitialDirectory = "c:\\";
         openFileDialog1.Filter = "txt files (*.txt)|*.txt|All files (*.*)|*.*";
         openFileDialog1.FilterIndex = 2;
         openFileDialog1.RestoreDirectory = true;
+        openFileDialog1.CheckFileExists = true; 
 
         if (openFileDialog1.ShowDialog() == DialogResult.OK)
         {
-            if ((fileName = openFileDialog1.FileName) != null)
-            {
-                //<Snippet4>
-                startInfo = new ProcessStartInfo(fileName);
+            var fileName = openFileDialog1.FileName;
 
-                if (File.Exists(fileName))
+            //<Snippet4>
+            int i = 0;
+            var startInfo = new ProcessStartInfo(fileName);
+
+
+            // Display the possible verbs.
+            foreach (var verb in startInfo.Verbs)
+            {
+                Console.WriteLine($"  {i++}. {verb}");
+            }
+
+            Console.Write("Select the index of the verb: ");
+            var indexInput = Console.ReadLine();
+            int index;
+            if (Int32.TryParse(indexInput, out index))  
+            {
+                if (index < 0 || index >= i) 
                 {
-                    i = 0;
-                    foreach (String verb in startInfo.Verbs)
-                    {
-                        // Display the possible verbs.
-                        Console.WriteLine("  {0}. {1}", i.ToString(), verb);
-                        i++;
-                    }
+                    Console.WriteLine("Invalid index value.");
+                    return;
+                } 
+
+                var verbToUse = startInfo.Verbs[index];
+
+                startInfo.Verb = verbToUse;
+                if (verbToUse.ToLower().IndexOf("printto") >= 0)
+                {
+                    // printto implies a specific printer.  Ask for the network address.
+                    // The address must be in the form \\server\printer.
+                    // The printer address is passed as the Arguments property.
+                    Console.Write("Enter the network address of the target printer: ");
+                    var arguments = Console.ReadLine();
+                    startInfo.Arguments = arguments;
                 }
-            }
+                //</Snippet4>
 
-            Console.WriteLine("Select the index of the verb.");
-            string index = Console.ReadLine();
-            if (Convert.ToInt32(index) < i)
-                verbToUse = startInfo.Verbs[Convert.ToInt32(index)];
+                var newProcess = new Process();
+                newProcess.StartInfo = startInfo;
+                try
+                {
+                    newProcess.Start();
+
+                    Console.WriteLine($"{newProcess.ProcessName} for file {fileName} " + 
+                                      $"started successfully with verb '{startInfo.Verb}'!");
+                }
+                catch (Win32Exception e)
+                {
+                    Console.WriteLine("  Win32Exception caught!");
+                    Console.WriteLine($"  Win32 error = {e.Message}");
+                }
+                catch (InvalidOperationException)
+                {
+                    // Catch this exception if the process exits quickly, 
+                    // and the properties are not accessible.
+                    Console.WriteLine($"Unable to start '{fileName}' with verb {verbToUse}");
+                }
+            }    
             else
-                return;
-            startInfo.Verb = verbToUse;
-            if (verbToUse.ToLower().IndexOf("printto") >= 0)
             {
-                // printto implies a specific printer.  Ask for the network address.
-                // The address must be in the form \\server\printer.
-                // The printer address is passed as the Arguments property.
-                Console.WriteLine("Enter the network address of the target printer:");
-                arguments = Console.ReadLine();
-                startInfo.Arguments = arguments;
-            }
-            //</Snippet4>
-
-            Process newProcess = new Process();
-            newProcess.StartInfo = startInfo;
-
-            try
-            {
-                newProcess.Start();
-
-                Console.WriteLine(
-                    "{0} for file {1} started successfully with verb \"{2}\"!",
-                    newProcess.ProcessName, fileName, startInfo.Verb);
-            }
-            catch (System.ComponentModel.Win32Exception e)
-            {
-                Console.WriteLine("  Win32Exception caught!");
-                Console.WriteLine("  Win32 error = {0}",
-                    e.Message);
-            }
-            catch (System.InvalidOperationException)
-            {
-                // Catch this exception if the process exits quickly, 
-                // and the properties are not accessible.
-                Console.WriteLine("File {0} started with verb {1}",
-                    fileName, verbToUse);
+                {
+                    Console.WriteLine("You did not enter a number.");
+                }
             }
         }
     }

--- a/snippets/visualbasic/VS_Snippets_CLR/ProcessVerbs_Diagnostics/VB/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/ProcessVerbs_Diagnostics/VB/source.vb
@@ -1,84 +1,73 @@
  '<Snippet1>
 '<Snippet3>
-Imports System
+Imports System.ComponentModel
 Imports System.IO
 Imports System.Diagnostics
-Imports System.Text
 Imports System.Windows.Forms
 
-
-
-Class ProcessInformation
-    
-    <STAThread()>  _
-    Shared Sub Main(ByVal args() As String) 
-        Dim fileName As String = ""
-        Dim arguments As String = ""
-        Dim verbToUse As String = ""
-        Dim i As Integer = 0
-        Dim startInfo As New ProcessStartInfo()
+Module ProcessInformation
+    Public Sub Main() 
         Dim openFileDialog1 As New OpenFileDialog()
         
         openFileDialog1.InitialDirectory = "c:\"
         openFileDialog1.Filter = "txt files (*.txt)|*.txt|All files (*.*)|*.*"
         openFileDialog1.FilterIndex = 2
         openFileDialog1.RestoreDirectory = True
-        
+        openFileDialog1.CheckFileExists = True
+       
         If openFileDialog1.ShowDialog() = DialogResult.OK Then
-            fileName = openFileDialog1.FileName
-            If Not (fileName Is Nothing) Then
-                '<Snippet4>
-                startInfo = New ProcessStartInfo(fileName)
+            Dim fileName = openFileDialog1.FileName
 
-                If File.Exists(fileName) Then
-                    i = 0
-                    Dim verb As String
-                    For Each verb In startInfo.Verbs
-                        ' Display the possible verbs.
-                        Console.WriteLine("  {0}. {1}", i.ToString(), verb)
-                        i += 1
-                    Next verb
+            '<Snippet4>
+            Dim i = 0
+            Dim startInfo = New ProcessStartInfo(fileName)
+
+            Dim verb As String
+            For Each verb In startInfo.Verbs
+                ' Display the possible verbs.
+                Console.WriteLine($"  {i}. {verb}")
+                i += 1
+            Next 
+
+            Console.Write("Select the index of the verb: ")
+            Dim indexInput = Console.ReadLine()
+            Dim index As Integer
+            If Int32.TryParse(indexInput, index) Then
+                If index < 0 OrElse index >= i Then  
+                    Console.WriteLine("Invalid index value.")
+                    Return
+                End if
+
+                Dim  verbToUse = startInfo.Verbs(Convert.ToInt32(index))
+
+                startInfo.Verb = verbToUse
+                If verbToUse.ToLower().IndexOf("printto") >= 0 Then
+                    ' printto implies a specific printer.  Ask for the network address.
+                    ' The address must be in the form \\server\printer.
+                    Console.Write("Enter the network address of the target printer: ")
+                    Dim arguments = Console.ReadLine()
+                    startInfo.Arguments = arguments
                 End If
+                '</Snippet4>
+
+                Dim newProcess As New Process
+                newProcess.StartInfo = startInfo
+                Try
+                    newProcess.Start()
+
+                    Console.WriteLine($"{newProcess.ProcessName} for file {fileName} " +
+                                      $" started successfully with verb '{startInfo.Verb}'!")
+                Catch e As Win32Exception
+                    Console.WriteLine("  Win32Exception caught!")
+                    Console.WriteLine($"  Win32 error = {e.Message}")
+                Catch e As InvalidOperationException
+                    Console.WriteLine($"Unable to start '{fileName}' with verb {verbToUse}")
+                End Try
             Else
-                ' Return if no file is selected.
-                Return
-            End If
-
-            Console.WriteLine("Select the index of the verb.")
-            Dim index As String = Console.ReadLine()
-            If Convert.ToInt32(index) < i Then
-                verbToUse = startInfo.Verbs(Convert.ToInt32(index))
-            Else
-                Return
-            End If
-
-            startInfo.Verb = verbToUse
-            If verbToUse.ToLower().IndexOf("printto") >= 0 Then
-                ' printto implies a specific printer.  Ask for the network address.
-                ' The address must be in the form \\server\printer.
-                Console.WriteLine("Enter the network address of the target printer:")
-                arguments = Console.ReadLine()
-                startInfo.Arguments = arguments
-            End If
-            '</Snippet4>
-            Dim newProcess As New Process
-            newProcess.StartInfo = startInfo
-
-            Try
-                newProcess.Start()
-
-                Console.WriteLine("{0} for file {1} started successfully with verb ""{2}""!", newProcess.ProcessName, fileName, startInfo.Verb)
-            Catch e As System.ComponentModel.Win32Exception
-                Console.WriteLine("  Win32Exception caught!")
-                Console.WriteLine("  Win32 error = {0}", e.Message)
-            Catch
-                ' Catch this exception if the process exits quickly, 
-                ' and the properties are not accessible.
-                Console.WriteLine("File {0} started with verb {1}", fileName, verbToUse)
-            End Try
+                Console.WriteLine("You did not enter a number.")
+            End If    
         End If
-    
-    End Sub 'Main
-End Class 'ProcessInformation
+    End Sub
+End Module 
 ' </Snippet3>
 '</Snippet1>


### PR DESCRIPTION
## Modernized and streamlined example

This was an extremely badly written example even for the .NET Framework 1.x timeframe.

Updated code and removed checks for a null filename and a non-existent file. Because the default value of OpenFileDialog.CheckFileExists is true, the user must select a valid file before selecting OK to close the dialog. So the checks are unnecessary (though there's always a possibility that the file can be deleted between the time the user closes the dialog and the code that operates on the file executes.

Fixes dotnet/docs#7299

