### PR TITLE
Modernized and format example

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml
+++ b/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml
@@ -4,7 +4,7 @@
       WindowTitle="Drawing Misc Snippets">
     <StackPanel>
 
-        <Button Content="Enumerate" Click="retrieveDrawings" />
+        <Button Content="Enumerate" Click="EnumerateButton_OnClick" />
 
         <Border Name="MainBorder"
                 BorderBrush="Black" BorderThickness="1" Margin="20">

--- a/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml
+++ b/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml
@@ -1,21 +1,16 @@
-<Page  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  x:Class="SDKSample.EnumerateDrawingsExample"
-  WindowTitle="Drawing Misc Snippets">
-  <StackPanel>
+<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Class="SDKSample.EnumerateDrawingsExample"
+      WindowTitle="Drawing Misc Snippets">
+    <StackPanel>
 
-    <Button Content="Enumerate" Click="retrieveDrawings" />
-    
-    <Border Name="MainBorder" 
-      BorderBrush="Black" BorderThickness="1" Margin="20">
-      <StackPanel Background="Orange">
-        <Rectangle Width="100" Height="100" Fill="Gray" />
-      </StackPanel>
-    </Border>
-    
-    
-  </StackPanel>
+        <Button Content="Enumerate" Click="retrieveDrawings" />
 
-    
-
+        <Border Name="MainBorder"
+                BorderBrush="Black" BorderThickness="1" Margin="20">
+            <StackPanel Background="Orange">
+                <Rectangle Width="100" Height="100" Fill="Gray" />
+            </StackPanel>
+        </Border>
+    </StackPanel>
 </Page>

--- a/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
@@ -5,14 +5,10 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Navigation;
 
-
 namespace SDKSample
 {
-
-
-    public partial class EnumerateDrawingsExample: Page
+    public partial class EnumerateDrawingsExample : Page
     {
-
         public EnumerateDrawingsExample()
         {
             InitializeComponent();
@@ -28,43 +24,40 @@ namespace SDKSample
         {
             DrawingGroup dGroup = VisualTreeHelper.GetDrawing(v);
             EnumDrawingGroup(dGroup);
-
         }
 
-         // Enumerate the drawings in the DrawingGroup.
-         public void EnumDrawingGroup(DrawingGroup drawingGroup)
-         {
-             DrawingCollection dc = drawingGroup.Children;
+        // Enumerate the drawings in the DrawingGroup.
+        public void EnumDrawingGroup(DrawingGroup drawingGroup)
+        {
+            DrawingCollection dc = drawingGroup.Children;
 
-             // Enumerate the drawings in the DrawingCollection.
-             foreach (Drawing drawing in dc)
-             {
-                 // If the drawing is a DrawingGroup, call the function recursively.
-                 if (drawing.GetType() == typeof(DrawingGroup))
-                 {
-                     EnumDrawingGroup((DrawingGroup)drawing);
-                 }
-                 else if (drawing.GetType() == typeof(GeometryDrawing))
-                 {
-                     // Perform action based on drawing type.  
-                 }
-                 else if (drawing.GetType() == typeof(ImageDrawing))
-                 {
-                     // Perform action based on drawing type.
-                 }
-                 else if (drawing.GetType() == typeof(GlyphRunDrawing))
-                 {
-                     // Perform action based on drawing type.
-                 }
-                 else if (drawing.GetType() == typeof(VideoDrawing))
-                 {
-                     // Perform action based on drawing type.
-                 }
-             }
-         }
-         //</SnippetGraphicsMMRetrieveDrawings>
-     
+            // Enumerate the drawings in the DrawingCollection.
+            foreach (Drawing drawing in dc)
+            {
+                // If the drawing is a DrawingGroup, call the function recursively.
+                if (drawing.GetType() == typeof(DrawingGroup))
+                {
+                    EnumDrawingGroup((DrawingGroup)drawing);
+                }
+                else if (drawing.GetType() == typeof(GeometryDrawing))
+                {
+                    // Perform action based on drawing type.  
+                }
+                else if (drawing.GetType() == typeof(ImageDrawing))
+                {
+                    // Perform action based on drawing type.
+                }
+                else if (drawing.GetType() == typeof(GlyphRunDrawing))
+                {
+                    // Perform action based on drawing type.
+                }
+                else if (drawing.GetType() == typeof(VideoDrawing))
+                {
+                    // Perform action based on drawing type.
+                }
+            }
+        }
+
+        //</SnippetGraphicsMMRetrieveDrawings>
     }
-    
-
 }

--- a/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
@@ -18,7 +18,7 @@ namespace SDKSample
             InitializeComponent();
         }
 
-        private void retrieveDrawings(object sender, RoutedEventArgs e)
+        private void EnumerateButton_OnClick(object sender, RoutedEventArgs e)
         {
             RetrieveDrawing(MainBorder);
         }
@@ -63,7 +63,8 @@ namespace SDKSample
              }
          }
          //</SnippetGraphicsMMRetrieveDrawings>
-     }
+     
+    }
     
 
 }

--- a/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
@@ -22,8 +22,8 @@ namespace SDKSample
         //<SnippetGraphicsMMRetrieveDrawings>
         public void RetrieveDrawing(Visual v)
         {
-            DrawingGroup dGroup = VisualTreeHelper.GetDrawing(v);
-            EnumDrawingGroup(dGroup);
+            DrawingGroup drawingGroup = VisualTreeHelper.GetDrawing(v);
+            EnumDrawingGroup(drawingGroup);
         }
 
         // Enumerate the drawings in the DrawingGroup.

--- a/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
@@ -35,9 +35,9 @@ namespace SDKSample
             foreach (Drawing drawing in dc)
             {
                 // If the drawing is a DrawingGroup, call the function recursively.
-                if (drawing is DrawingGroup @group)
+                if (drawing is DrawingGroup group)
                 {
-                    EnumDrawingGroup(@group);
+                    EnumDrawingGroup(group);
                 }
                 else if (drawing is GeometryDrawing)
                 {

--- a/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/DrawingMiscSnippets_snip/CSharp/EnumerateDrawingsExample.xaml.cs
@@ -35,23 +35,23 @@ namespace SDKSample
             foreach (Drawing drawing in dc)
             {
                 // If the drawing is a DrawingGroup, call the function recursively.
-                if (drawing.GetType() == typeof(DrawingGroup))
+                if (drawing is DrawingGroup @group)
                 {
-                    EnumDrawingGroup((DrawingGroup)drawing);
+                    EnumDrawingGroup(@group);
                 }
-                else if (drawing.GetType() == typeof(GeometryDrawing))
+                else if (drawing is GeometryDrawing)
                 {
                     // Perform action based on drawing type.  
                 }
-                else if (drawing.GetType() == typeof(ImageDrawing))
+                else if (drawing is ImageDrawing)
                 {
                     // Perform action based on drawing type.
                 }
-                else if (drawing.GetType() == typeof(GlyphRunDrawing))
+                else if (drawing is GlyphRunDrawing)
                 {
                     // Perform action based on drawing type.
                 }
-                else if (drawing.GetType() == typeof(VideoDrawing))
+                else if (drawing is VideoDrawing)
                 {
                     // Perform action based on drawing type.
                 }


### PR DESCRIPTION
## Summary

The previous code uses the first character lowercase method and the method uses `xx.GetType() == typeof(foo)` that can be instead of `is` and I modernize the code.
