### PR TITLE
Replaced MD5 with SHA256 for HashAlgorithm.ComputeHash examples

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_Classic/classic SHA256 Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR_Classic/classic SHA256 Example/CS/source.cs
@@ -2,73 +2,63 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
-using System.Windows.Forms;
 
 public class HashDirectory
 {
-
-    [STAThreadAttribute]
     public static void Main(String[] args)
     {
-        string directory = "";
         if (args.Length < 1)
         {
-            FolderBrowserDialog fbd = new FolderBrowserDialog();
-            DialogResult dr = fbd.ShowDialog();
-            if (dr == DialogResult.OK)
-                directory = fbd.SelectedPath;
-            else
-            {
-                Console.WriteLine("No directory selected.");
-                return;
-            }
+            Console.WriteLine("No directory selected.");
+            return;
         }
-        else
-            directory = args[0];
-        try
+
+        string directory = args[0];
+        if (Directory.Exists(directory))
         {
             // Create a DirectoryInfo object representing the specified directory.
-            DirectoryInfo dir = new DirectoryInfo(directory);
+           var dir = new DirectoryInfo(directory);
             // Get the FileInfo objects for every file in the directory.
             FileInfo[] files = dir.GetFiles();
             // Initialize a SHA256 hash object.
             SHA256 mySHA256 = SHA256Managed.Create();
            
-            byte[] hashValue;
             // Compute and print the hash values for each file in directory.
-            foreach (FileInfo fInfo in files)
+            foreach (var fInfo in files)
             {
-                // Create a fileStream for the file.
-                FileStream fileStream = fInfo.Open(FileMode.Open);
-                // Be sure it's positioned to the beginning of the stream.
-                fileStream.Position = 0;
-                // Compute the hash of the fileStream.
-                hashValue = mySHA256.ComputeHash(fileStream);
-                // Write the name of the file to the Console.
-                Console.Write(fInfo.Name + ": ");
-                // Write the hash value to the Console.
-                PrintByteArray(hashValue);
-                // Close the file.
-                fileStream.Close();
+                try { 
+                    // Create a fileStream for the file.
+                    FileStream fileStream = fInfo.Open(FileMode.Open);
+                    // Be sure it's positioned to the beginning of the stream.
+                    fileStream.Position = 0;
+                    // Compute the hash of the fileStream.
+                    var hashValue = mySHA256.ComputeHash(fileStream);
+                    // Write the name and hash value of the file to the console.
+                    Console.Write($"{fInfo.Name}: ");
+                    PrintByteArray(hashValue);
+                    // Close the file.
+                    fileStream.Close();
+                }
+                catch (IOException e) {
+                    Console.WriteLine($"I/O Exception: {e.Message}");
+                }
+                catch (UnauthorizedAccessException e) {
+                    Console.WriteLine($"Access Exception: {e.Message}");
+                }
             }
-            return;
         }
-        catch (DirectoryNotFoundException)
+        else
         {
-            Console.WriteLine("Error: The directory specified could not be found.");
-        }
-        catch (IOException)
-        {
-            Console.WriteLine("Error: A file in the directory could not be accessed.");
+            Console.WriteLine("The directory specified could not be found.");
         }
     }
-    // Print the byte array in a readable format.
+
+    // Display the byte array in a readable format.
     public static void PrintByteArray(byte[] array)
     {
-        int i;
-        for (i = 0; i < array.Length; i++)
+        for (int i = 0; i < array.Length; i++)
         {
-            Console.Write(String.Format("{0:X2}", array[i]));
+            Console.Write($"{array[i]:X2}");
             if ((i % 4) == 3) Console.Write(" ");
         }
         Console.WriteLine();

--- a/snippets/csharp/VS_Snippets_CLR_Classic/classic SHA256 Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR_Classic/classic SHA256 Example/CS/source.cs
@@ -21,29 +21,30 @@ public class HashDirectory
             // Get the FileInfo objects for every file in the directory.
             FileInfo[] files = dir.GetFiles();
             // Initialize a SHA256 hash object.
-            SHA256 mySHA256 = SHA256Managed.Create();
-           
-            // Compute and print the hash values for each file in directory.
-            foreach (var fInfo in files)
+            using (SHA256 mySHA256 = SHA256.Create())
             {
-                try { 
-                    // Create a fileStream for the file.
-                    FileStream fileStream = fInfo.Open(FileMode.Open);
-                    // Be sure it's positioned to the beginning of the stream.
-                    fileStream.Position = 0;
-                    // Compute the hash of the fileStream.
-                    var hashValue = mySHA256.ComputeHash(fileStream);
-                    // Write the name and hash value of the file to the console.
-                    Console.Write($"{fInfo.Name}: ");
-                    PrintByteArray(hashValue);
-                    // Close the file.
-                    fileStream.Close();
-                }
-                catch (IOException e) {
-                    Console.WriteLine($"I/O Exception: {e.Message}");
-                }
-                catch (UnauthorizedAccessException e) {
-                    Console.WriteLine($"Access Exception: {e.Message}");
+                // Compute and print the hash values for each file in directory.
+                foreach (FileInfo fInfo in files)
+                {
+                    try { 
+                        // Create a fileStream for the file.
+                        FileStream fileStream = fInfo.Open(FileMode.Open);
+                        // Be sure it's positioned to the beginning of the stream.
+                        fileStream.Position = 0;
+                        // Compute the hash of the fileStream.
+                        byte[] hashValue = mySHA256.ComputeHash(fileStream);
+                        // Write the name and hash value of the file to the console.
+                        Console.Write($"{fInfo.Name}: ");
+                        PrintByteArray(hashValue);
+                        // Close the file.
+                        fileStream.Close();
+                    }
+                    catch (IOException e) {
+                        Console.WriteLine($"I/O Exception: {e.Message}");
+                    }
+                    catch (UnauthorizedAccessException e) {
+                        Console.WriteLine($"Access Exception: {e.Message}");
+                    }
                 }
             }
         }

--- a/snippets/csharp/api/system.security.cryptography/hashalgorithm/example1.cs
+++ b/snippets/csharp/api/system.security.cryptography/hashalgorithm/example1.cs
@@ -2,20 +2,20 @@ using System;
 using System.Security.Cryptography;
 using System.Text;
 
-class Program
+public class Program
 {
-    static void Main()
+    public static void Main()
     {
         string source = "Hello World!";
-        using (SHA256 sha256Hash = SHA256Managed.Create())
+        using (SHA256 sha256Hash = SHA256.Create())
         {
-            string hash = GetSHA256Hash(sha256Hash, source);
+            string hash = GetHash(sha256Hash, source);
 
             Console.WriteLine($"The SHA256 hash of {source} is: {hash}.");
 
             Console.WriteLine("Verifying the hash...");
 
-            if (VerifySHA256Hash(sha256Hash, source, hash))
+            if (VerifyHash(sha256Hash, source, hash))
             {
                 Console.WriteLine("The hashes are the same.");
             }
@@ -26,11 +26,11 @@ class Program
         }
     }
 
-    static string GetSHA256Hash(SHA256 sha256Hash, string input)
+    private static string GetHash(HashAlgorithm hashAlgorithm, string input)
     {
 
         // Convert the input string to a byte array and compute the hash.
-        var data = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(input));
+        byte[] data = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(input));
 
         // Create a new Stringbuilder to collect the bytes
         // and create a string.
@@ -48,13 +48,13 @@ class Program
     }
 
     // Verify a hash against a string.
-    static bool VerifySHA256Hash(SHA256 sha256Hash, string input, string hash)
+    private static bool VerifyHash(HashAlgorithm hashAlgorithm, string input, string hash)
     {
         // Hash the input.
-        var hashOfInput = GetSHA256Hash(sha256Hash, input);
+        var hashOfInput = GetHash(hashAlgorithm, input);
 
         // Create a StringComparer an compare the hashes.
-        var comparer = StringComparer.OrdinalIgnoreCase;
+        StringComparer comparer = StringComparer.OrdinalIgnoreCase;
 
         return comparer.Compare(hashOfInput, hash) == 0;
     }

--- a/snippets/csharp/api/system.security.cryptography/hashalgorithm/example1.cs
+++ b/snippets/csharp/api/system.security.cryptography/hashalgorithm/example1.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+class Program
+{
+    static void Main()
+    {
+        string source = "Hello World!";
+        using (SHA256 sha256Hash = SHA256Managed.Create())
+        {
+            string hash = GetSHA256Hash(sha256Hash, source);
+
+            Console.WriteLine($"The SHA256 hash of {source} is: {hash}.");
+
+            Console.WriteLine("Verifying the hash...");
+
+            if (VerifySHA256Hash(sha256Hash, source, hash))
+            {
+                Console.WriteLine("The hashes are the same.");
+            }
+            else
+            {
+                Console.WriteLine("The hashes are not same.");
+            }
+        }
+    }
+
+    static string GetSHA256Hash(SHA256 sha256Hash, string input)
+    {
+
+        // Convert the input string to a byte array and compute the hash.
+        var data = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(input));
+
+        // Create a new Stringbuilder to collect the bytes
+        // and create a string.
+        var sBuilder = new StringBuilder();
+
+        // Loop through each byte of the hashed data 
+        // and format each one as a hexadecimal string.
+        for (int i = 0; i < data.Length; i++)
+        {
+            sBuilder.Append(data[i].ToString("x2"));
+        }
+
+        // Return the hexadecimal string.
+        return sBuilder.ToString();
+    }
+
+    // Verify a hash against a string.
+    static bool VerifySHA256Hash(SHA256 sha256Hash, string input, string hash)
+    {
+        // Hash the input.
+        var hashOfInput = GetSHA256Hash(sha256Hash, input);
+
+        // Create a StringComparer an compare the hashes.
+        var comparer = StringComparer.OrdinalIgnoreCase;
+
+        return comparer.Compare(hashOfInput, hash) == 0;
+    }
+
+}
+// The example displays the following output:
+//    The SHA256 hash of Hello World! is: 7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069.
+//    Verifying the hash...
+//    The hashes are the same.

--- a/snippets/visualbasic/VS_Snippets_CLR_Classic/classic SHA256 Example/VB/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_Classic/classic SHA256 Example/VB/source.vb
@@ -18,28 +18,29 @@ Public Module HashDirectory
             ' Get the FileInfo objects for every file in the directory.
             Dim files As FileInfo() = dir.GetFiles()
             ' Initialize a SHA256 hash object.
-            Dim mySHA256 As SHA256 = SHA256Managed.Create()
-            ' Compute and print the hash values for each file in directory.
-            For Each fInfo In files
-                Try
-                    ' Create a fileStream for the file.
-                    Dim fileStream = fInfo.Open(FileMode.Open)
-                    ' Be sure it's positioned to the beginning of the stream.
-                    fileStream.Position = 0
-                    ' Compute the hash of the fileStream.
-                    Dim hashValue = mySHA256.ComputeHash(fileStream)
-                    ' Write the name of the file to the Console.
-                    Console.Write(fInfo.Name + ": ")
-                    ' Write the hash value to the Console.
-                    PrintByteArray(hashValue)
-                    ' Close the file.
-                    fileStream.Close()
-                Catch e As IOException
-                    Console.WriteLine($"I/O Exception: {e.Message}")
-                Catch e As UnauthorizedAccessException 
-                    Console.WriteLine($"Access Exception: {e.Message}")
-                End Try    
-            Next 
+            Using mySHA256 As SHA256 = SHA256.Create()
+                ' Compute and print the hash values for each file in directory.
+                For Each fInfo  As FileInfo In files
+                    Try
+                        ' Create a fileStream for the file.
+                        Dim fileStream = fInfo.Open(FileMode.Open)
+                        ' Be sure it's positioned to the beginning of the stream.
+                        fileStream.Position = 0
+                        ' Compute the hash of the fileStream.
+                        Dim hashValue() As Byte = mySHA256.ComputeHash(fileStream)
+                        ' Write the name of the file to the Console.
+                        Console.Write(fInfo.Name + ": ")
+                        ' Write the hash value to the Console.
+                        PrintByteArray(hashValue)
+                        ' Close the file.
+                        fileStream.Close()
+                    Catch e As IOException
+                        Console.WriteLine($"I/O Exception: {e.Message}")
+                    Catch e As UnauthorizedAccessException 
+                        Console.WriteLine($"Access Exception: {e.Message}")
+                    End Try    
+                Next 
+            End Using
         Else
            Console.WriteLine("The directory specified could not be found.")
         End If

--- a/snippets/visualbasic/VS_Snippets_CLR_Classic/classic SHA256 Example/VB/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_Classic/classic SHA256 Example/VB/source.vb
@@ -2,68 +2,59 @@
 Imports System
 Imports System.IO
 Imports System.Security.Cryptography
-Imports System.Windows.Forms
 
-Public Class HashDirectory
+Public Module HashDirectory
 
-    Public Shared Sub Main(ByVal args() As String)
-        Dim directory As String
+    Public Sub Main(ByVal args() As String)
         If args.Length < 1 Then
-            Dim fdb As New FolderBrowserDialog
-            Dim dr As DialogResult = fdb.ShowDialog()
-            If (dr = DialogResult.OK) Then
-                directory = fdb.SelectedPath
-            Else
-                Console.WriteLine("No directory selected")
-                Return
-            End If
-        Else
-            directory = args(0)
+            Console.WriteLine("No directory selected")
+            Return
         End If
-        Try
+
+        Dim targetDirectory As String = args(0)
+        If Directory.Exists(targetDirectory) Then
             ' Create a DirectoryInfo object representing the specified directory.
-            Dim dir As New DirectoryInfo(directory)
+            Dim dir As New DirectoryInfo(targetDirectory)
             ' Get the FileInfo objects for every file in the directory.
             Dim files As FileInfo() = dir.GetFiles()
             ' Initialize a SHA256 hash object.
             Dim mySHA256 As SHA256 = SHA256Managed.Create()
-            Dim hashValue() As Byte
             ' Compute and print the hash values for each file in directory.
-            Dim fInfo As FileInfo
             For Each fInfo In files
-                ' Create a fileStream for the file.
-                Dim fileStream As FileStream = fInfo.Open(FileMode.Open)
-                ' Be sure it's positioned to the beginning of the stream.
-                fileStream.Position = 0
-                ' Compute the hash of the fileStream.
-                hashValue = mySHA256.ComputeHash(fileStream)
-                ' Write the name of the file to the Console.
-                Console.Write(fInfo.Name + ": ")
-                ' Write the hash value to the Console.
-                PrintByteArray(hashValue)
-                ' Close the file.
-                fileStream.Close()
-            Next fInfo
-            Return
-        Catch DExc As DirectoryNotFoundException
-            Console.WriteLine("Error: The directory specified could not be found.")
-        Catch IOExc As IOException
-            Console.WriteLine("Error: A file in the directory could not be accessed.")
-        End Try
-
+                Try
+                    ' Create a fileStream for the file.
+                    Dim fileStream = fInfo.Open(FileMode.Open)
+                    ' Be sure it's positioned to the beginning of the stream.
+                    fileStream.Position = 0
+                    ' Compute the hash of the fileStream.
+                    Dim hashValue = mySHA256.ComputeHash(fileStream)
+                    ' Write the name of the file to the Console.
+                    Console.Write(fInfo.Name + ": ")
+                    ' Write the hash value to the Console.
+                    PrintByteArray(hashValue)
+                    ' Close the file.
+                    fileStream.Close()
+                Catch e As IOException
+                    Console.WriteLine($"I/O Exception: {e.Message}")
+                Catch e As UnauthorizedAccessException 
+                    Console.WriteLine($"Access Exception: {e.Message}")
+                End Try    
+            Next 
+        Else
+           Console.WriteLine("The directory specified could not be found.")
+        End If
     End Sub
 
     ' Print the byte array in a readable format.
-    Public Shared Sub PrintByteArray(ByVal array() As Byte)
-        Dim i As Integer
-        For i = 0 To array.Length - 1
-            Console.Write(String.Format("{0:X2}", array(i)))
+    Public Sub PrintByteArray(array() As Byte)
+        For i As Integer = 0 To array.Length - 1
+            Console.Write($"{array(i):X2}")
             If i Mod 4 = 3 Then
                 Console.Write(" ")
             End If
-        Next i
+        Next 
         Console.WriteLine()
 
-    End Sub 'PrintByteArray
-End Class
+    End Sub 
+End Module
 '</Snippet1>

--- a/snippets/visualbasic/api/system.security.cryptography/hashalgorithm/example1.vb
+++ b/snippets/visualbasic/api/system.security.cryptography/hashalgorithm/example1.vb
@@ -1,0 +1,58 @@
+Imports System.Security.Cryptography
+Imports System.Text
+
+Module Program
+    Sub Main()
+        Dim source As String = "Hello World!"
+        Using sha256Hash As SHA256 = SHA256.Create()
+
+            Dim hash As String = GetSHA256Hash(sha256Hash, source)
+
+            Console.WriteLine($"The SHA256 hash of {source} is: {hash}.")
+
+            Console.WriteLine("Verifying the hash...")
+
+            If VerifySHA256Hash(sha256Hash, source, hash) Then
+                Console.WriteLine("The hashes are the same.")
+            Else
+                Console.WriteLine("The hashes are not same.")
+            End If
+        End Using
+    End Sub 
+
+    Function GetSHA256Hash(ByVal sha256Hash As SHA256, ByVal input As String) As String
+
+        ' Convert the input string to a byte array and compute the hash.
+        Dim data As Byte() = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(input))
+
+        ' Create a new Stringbuilder to collect the bytes
+        ' and create a string.
+        Dim sBuilder As New StringBuilder()
+
+        ' Loop through each byte of the hashed data 
+        ' and format each one as a hexadecimal string.
+        For i As Integer = 0 To data.Length - 1
+            sBuilder.Append(data(i).ToString("x2"))
+        Next
+
+        ' Return the hexadecimal string.
+        Return sBuilder.ToString()
+
+    End Function
+
+
+    ' Verify a hash against a string.
+    Function VerifySHA256Hash(sha256Hash As SHA256, input As String, hash As String) As Boolean
+        ' Hash the input.
+        Dim hashOfInput As String = GetSHA256Hash(sha256Hash, input)
+
+        ' Create a StringComparer an compare the hashes.
+        Dim comparer As StringComparer = StringComparer.OrdinalIgnoreCase
+
+        Return comparer.Compare(hashOfInput, hash) = 0
+    End Function
+End Module
+' The example displays the following output:
+'    The SHA256 hash of Hello World! is: 7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069.
+'    Verifying the hash...
+'    The hashes are the same.

--- a/snippets/visualbasic/api/system.security.cryptography/hashalgorithm/example1.vb
+++ b/snippets/visualbasic/api/system.security.cryptography/hashalgorithm/example1.vb
@@ -1,18 +1,18 @@
 Imports System.Security.Cryptography
 Imports System.Text
 
-Module Program
-    Sub Main()
+Public Module Program
+    Public Sub Main()
         Dim source As String = "Hello World!"
         Using sha256Hash As SHA256 = SHA256.Create()
 
-            Dim hash As String = GetSHA256Hash(sha256Hash, source)
+            Dim hash As String = GetHash(sha256Hash, source)
 
             Console.WriteLine($"The SHA256 hash of {source} is: {hash}.")
 
             Console.WriteLine("Verifying the hash...")
 
-            If VerifySHA256Hash(sha256Hash, source, hash) Then
+            If VerifyHash(sha256Hash, source, hash) Then
                 Console.WriteLine("The hashes are the same.")
             Else
                 Console.WriteLine("The hashes are not same.")
@@ -20,10 +20,10 @@ Module Program
         End Using
     End Sub 
 
-    Function GetSHA256Hash(ByVal sha256Hash As SHA256, ByVal input As String) As String
+    Private Function GetHash(ByVal hashAlgorithm As HashAlgorithm, ByVal input As String) As String
 
         ' Convert the input string to a byte array and compute the hash.
-        Dim data As Byte() = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(input))
+        Dim data As Byte() = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(input))
 
         ' Create a new Stringbuilder to collect the bytes
         ' and create a string.
@@ -37,14 +37,12 @@ Module Program
 
         ' Return the hexadecimal string.
         Return sBuilder.ToString()
-
     End Function
 
-
     ' Verify a hash against a string.
-    Function VerifySHA256Hash(sha256Hash As SHA256, input As String, hash As String) As Boolean
+    Private Function VerifyHash(hashAlgorithm As HashAlgorithm, input As String, hash As String) As Boolean
         ' Hash the input.
-        Dim hashOfInput As String = GetSHA256Hash(sha256Hash, input)
+        Dim hashOfInput As String = GetHash(hashAlgorithm, input)
 
         ' Create a StringComparer an compare the hashes.
         Dim comparer As StringComparer = StringComparer.OrdinalIgnoreCase


### PR DESCRIPTION
## Replaced MD5 with SHA256 for HashAlgorithm.ComputeHash examples

Related to dotnet/docs#6809
