### PR TITLE
Adding examples for Append and Prepend

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.Linq.Enumerable/CS/enumerable.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Linq.Enumerable/CS/enumerable.cs
@@ -3179,5 +3179,67 @@ namespace SequenceExamples
         }
         #endregion
 
+        #region Append
+        static void AppendEx()
+        {
+            // <Snippet201>
+            // Creating a list of numbers
+            List<int> numbers = new List<int> { 1, 2, 3, 4 };
+
+            // Trying to append any value of the same type
+            numbers.Append(5);
+
+            // It doesn't work because the original list has not been changed
+            Console.WriteLine(string.Join(", ", numbers));
+
+            // It works now because we are using a changed copy of the original list
+            Console.WriteLine(string.Join(", ", numbers.Append(5)));
+
+            // If you prefer, you can create a new list explicitly
+            List<int> newNumbers = numbers.Append(5).ToList();
+
+            // And then write to the console output
+            Console.WriteLine(string.Join(", ", newNumbers));
+
+            // This code produces the following output:
+            //
+            // 1, 2, 3, 4
+            // 1, 2, 3, 4, 5
+            // 1, 2, 3, 4, 5
+            // </Snippet201>
+        }
+        #endregion
+
+        #region Prepend
+        static void PrependEx()
+        {
+            // <Snippet202>
+            // Creating a list of numbers
+            List<int> numbers = new List<int> { 1, 2, 3, 4 };
+
+            // Trying to prepend any value of the same type
+            numbers.Prepend(0);
+
+            // It doesn't work because the original list has not been changed
+            Console.WriteLine(string.Join(", ", numbers));
+
+            // It works now because we are using a changed copy of the original list
+            Console.WriteLine(string.Join(", ", numbers.Prepend(0)));
+
+            // If you prefer, you can create a new list explicitly
+            List<int> newNumbers = numbers.Prepend(0).ToList();
+
+            // And then write to the console output
+            Console.WriteLine(string.Join(", ", newNumbers));
+
+            // This code produces the following output:
+            //
+            // 1, 2, 3, 4
+            // 0, 1, 2, 3, 4
+            // 0, 1, 2, 3, 4
+            // </Snippet202>
+        }
+        #endregion
+
     }
 }

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.Linq.Enumerable/VB/Enumerable.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.Linq.Enumerable/VB/Enumerable.vb
@@ -3223,6 +3223,66 @@ Namespace SequenceExamples
         End Sub
 #End Region
 
+#Region "Append"
+        Sub AppendEx()
+            ' <Snippet201>
+            ' Creating a list of numbers
+            Dim numbers As New List(Of Integer)(New Integer() {1, 2, 3, 4})
+
+            ' Trying to append any value of the same type
+            numbers.Append(5)
+
+            ' It doesn't work because the original list has not been changed
+            Console.WriteLine(String.Join(", ", numbers))
+
+            ' It works now because we are using a changed copy of the original list
+            Console.WriteLine(String.Join(", ", numbers.Append(5)))
+
+            ' If you prefer, you can create a new list explicitly
+            Dim newNumbers As List(Of Integer) = numbers.Append(5).ToList
+
+            ' And then write to the console output
+            Console.WriteLine(String.Join(", ", newNumbers))
+
+            ' This code produces the following output:
+            '
+            ' 1, 2, 3, 4
+            ' 1, 2, 3, 4, 5
+            ' 1, 2, 3, 4, 5
+            ' </Snippet201>
+        End Sub
+#End Region
+
+#Region "Prepend"
+        Sub PrependEx()
+            ' <Snippet202>
+            ' Creating a list of numbers
+            Dim numbers As New List(Of Integer)(New Integer() {1, 2, 3, 4})
+
+            ' Trying to prepend any value of the same type
+            numbers.Prepend(0)
+
+            ' It doesn't work because the original list has not been changed
+            Console.WriteLine(String.Join(", ", numbers))
+
+            ' It works now because we are using a changed copy of the original list
+            Console.WriteLine(String.Join(", ", numbers.Prepend(0)))
+
+            ' If you prefer, you can create a new list explicitly
+            Dim newNumbers As List(Of Integer) = numbers.Prepend(0).ToList
+
+            ' And then write to the console output
+            Console.WriteLine(String.Join(", ", newNumbers))
+
+            ' This code produces the following output:
+            '
+            ' 1, 2, 3, 4
+            ' 0, 1, 2, 3, 4
+            ' 0, 1, 2, 3, 4
+            ' </Snippet202>
+        End Sub
+#End Region
+
     End Module
 
 End Namespace


### PR DESCRIPTION
## Summary

There was no example for Append and Prepend.
Adding the corresponding examples.

Fixes dotnet/docs#7713
