### PR TITLE
Update IdentifyNullableType.cs

### DIFF
--- a/snippets/csharp/programming-guide/nullable-types/IdentifyNullableType.cs
+++ b/snippets/csharp/programming-guide/nullable-types/IdentifyNullableType.cs
@@ -18,7 +18,7 @@ namespace nullable_types
             Console.WriteLine($"int? is {(IsNullable(typeof(int?)) ? "nullable" : "non nullable")} type");
             Console.WriteLine($"int is {(IsNullable(typeof(int)) ? "nullable" : "non nullable")} type");
 
-            bool IsNullable(Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+            bool IsNullable(Type type) => Nullable.GetUnderlyingType(type) != null;
 
             // Output:
             // int? is nullable type
@@ -70,7 +70,7 @@ namespace nullable_types
             bool IsOfNullableType<T>(T o)
             {
                 var type = typeof(T);
-                return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+                return Nullable.GetUnderlyingType(type) != null;
             }
             
             // Output:


### PR DESCRIPTION
Use existing API.
Note: updated code returns `true` only for closed nullable types. I think it's fine and has been intended for the docs.

Fixes dotnet/docs#7865
