### PR TITLE
Fixes #7965 properly dispose of Socket

### DIFF
--- a/snippets/cpp/VS_Snippets_Remoting/System.Net.Sockets.Socket/CPP/socket.cpp
+++ b/snippets/cpp/VS_Snippets_Remoting/System.Net.Sockets.Socket/CPP/socket.cpp
@@ -74,6 +74,8 @@ String^ SocketSendReceive( String^ server, int port )
       strRetPage = String::Concat( strRetPage, Encoding::ASCII->GetString( bytesReceived, 0, bytes ) );
    }
    while ( bytes > 0 );
+   
+   s->Dispose();
 
    return strRetPage;
 }

--- a/snippets/csharp/VS_Snippets_Remoting/System.Net.Sockets.Socket/CS/socket.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/System.Net.Sockets.Socket/CS/socket.cs
@@ -57,24 +57,25 @@ public class GetSocket
         Byte[] bytesReceived = new Byte[256];
        
         // Create a socket connection with the specified server and port.
-        Socket s = ConnectSocket(server, port);
+        using(Socket s = ConnectSocket(server, port)) {
 
-        if (s == null)
-            return ("Connection failed");
-      
-        // Send request to the server.
-        s.Send(bytesSent, bytesSent.Length, 0);  
+            if (s == null)
+                return ("Connection failed");
         
-        // Receive the server home page content.
-        int bytes = 0;
-        string page = "Default HTML page on " + server + ":\r\n";
+            // Send request to the server.
+            s.Send(bytesSent, bytesSent.Length, 0);  
+            
+            // Receive the server home page content.
+            int bytes = 0;
+            string page = "Default HTML page on " + server + ":\r\n";
 
-        // The following will block until the page is transmitted.
-        do {
-            bytes = s.Receive(bytesReceived, bytesReceived.Length, 0);
-            page = page + Encoding.ASCII.GetString(bytesReceived, 0, bytes);
+            // The following will block until the page is transmitted.
+            do {
+                bytes = s.Receive(bytesReceived, bytesReceived.Length, 0);
+                page = page + Encoding.ASCII.GetString(bytesReceived, 0, bytes);
+            }
+            while (bytes > 0);
         }
-        while (bytes > 0);
         
         return page;
     }


### PR DESCRIPTION
## Summary
Snippet before was not properly disposing of the socket as it should. Feels like a proper snippet should follow best practices of properly cleaning up its unmanaged resources.

Fixes dotnet/docs#7965
