### PR TITLE
Removed redundant Attribute suffix

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR_System/system.Threading.Thread.DoNotUseDataSlots/CPP/source.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.Threading.Thread.DoNotUseDataSlots/CPP/source.cpp
@@ -6,7 +6,7 @@ using namespace System::Threading;
 ref class ThreadData
 {
 private:
-   [ThreadStaticAttribute]
+   [ThreadStatic]
    static int threadSpecificData;
 
 public:

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Threading.Thread.DoNotUseDataSlots/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Threading.Thread.DoNotUseDataSlots/CS/source.cs
@@ -16,7 +16,7 @@ class Test
 
 class ThreadData
 {
-    [ThreadStaticAttribute]
+    [ThreadStatic]
     static int threadSpecificData;
 
     public static void ThreadStaticDemo()

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.Thread.DoNotUseDataSlots/vb/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.Thread.DoNotUseDataSlots/vb/source.vb
@@ -18,7 +18,7 @@ End Class
 
 Class ThreadData
 
-    <ThreadStaticAttribute> _
+    <ThreadStatic> _
     Shared threadSpecificData As Integer
 
     Shared Sub ThreadStaticDemo()


### PR DESCRIPTION
## Summary
using [ThreadStaticAttribute] is not a bug; it's equivalent to using [ThreadStatic]. Given that, Visual Studio suggests to simplify [ThreadStaticAttribute] into [ThreadStatic].

Fixes dotnet/docs#Issue_Number [7939](https://github.com/dotnet/docs/issues/7939)
