### PR TITLE
Fix Sentiment-Analysis Tutorial: In v0.6 the LearningPipeline is in the "Legacy" namespaces

### DIFF
--- a/machine-learning/tutorials/SentimentAnalysis/Program.cs
+++ b/machine-learning/tutorials/SentimentAnalysis/Program.cs
@@ -4,12 +4,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.ML;
-using Microsoft.ML.Data;
-using Microsoft.ML.Models;
 using Microsoft.ML.Runtime.Api;
-using Microsoft.ML.Trainers;
-using Microsoft.ML.Transforms;
+using Microsoft.ML.Legacy;
+using Microsoft.ML.Legacy.Models;
+using Microsoft.ML.Legacy.Data;
+using Microsoft.ML.Legacy.Transforms;
+using Microsoft.ML.Legacy.Trainers;
 // </Snippet1>
 
 namespace SentimentAnalysis


### PR DESCRIPTION
In v0.6 the LearningPipeline API is in the "Legacy" namespaces, such as:
using Microsoft.ML.Legacy;
using Microsoft.ML.Legacy.Models;

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
