### PR TITLE
Fix Iris-Clustering Tutorial: In v0.6 the LearningPipeline is in the …

### DIFF
--- a/machine-learning/tutorials/IrisClustering/IrisClustering.csproj
+++ b/machine-learning/tutorials/IrisClustering/IrisClustering.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.5.0" />
+    <PackageReference Include="Microsoft.ML" Version="0.6.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/machine-learning/tutorials/IrisClustering/Program.cs
+++ b/machine-learning/tutorials/IrisClustering/Program.cs
@@ -6,10 +6,10 @@ using System.IO;
 using System.Threading.Tasks;
 // </Snippet12>
 // <Snippet3>
-using Microsoft.ML;
-using Microsoft.ML.Data;
-using Microsoft.ML.Trainers;
-using Microsoft.ML.Transforms;
+using Microsoft.ML.Legacy;
+using Microsoft.ML.Legacy.Data;
+using Microsoft.ML.Legacy.Trainers;
+using Microsoft.ML.Legacy.Transforms;
 // </Snippet3>
 
 namespace IrisClustering


### PR DESCRIPTION
…"Legacy" namespaces

In v0.6 the LearningPipeline API is in the "Legacy" namespaces, such as:
using Microsoft.ML.Legacy;
using Microsoft.ML.Legacy.Models;

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
