### PR TITLE
Fix Sentiment-Analysis Tutorial with "Legacy" namespaces in v0.6

### DIFF
--- a/machine-learning/tutorials/TaxiFarePrediction/Program.cs
+++ b/machine-learning/tutorials/TaxiFarePrediction/Program.cs
@@ -3,11 +3,11 @@ using System;
 using System.IO;
 // </Snippet17>
 // <Snippet1>
-using Microsoft.ML;
-using Microsoft.ML.Data;
-using Microsoft.ML.Models;
-using Microsoft.ML.Trainers;
-using Microsoft.ML.Transforms;
+using Microsoft.ML.Legacy;
+using Microsoft.ML.Legacy.Data;
+using Microsoft.ML.Legacy.Models;
+using Microsoft.ML.Legacy.Trainers;
+using Microsoft.ML.Legacy.Transforms;
 // </Snippet1>
 // <Snippet9>
 using System.Threading.Tasks;


### PR DESCRIPTION
In v0.6 the LearningPipeline API is in the "Legacy" namespaces, such as:
using Microsoft.ML.Legacy;
using Microsoft.ML.Legacy.Models;
