### PR TITLE
Getting Started Instructions for WinForms on top of .NET Core 3.0. 

### DIFF
--- a/windowsforms/README.md
+++ b/windowsforms/README.md
@@ -53,29 +53,30 @@ Ideally you should migrate all projects in your solution to target .NET Core 3.0
 6. Copy the `PackageReference` elements generated in the previous step from the original project into the new project's .csproj file.
 7. Copy the `ProjectReference` elements from the original project. Note: The new project format does not use the `Name` and `ProjectGuid` elements so you can safely delete those.
 8. At this point it's a good idea to try and restore/build to make sure all dependencies are properly configured.
-9. Copy the project files from the .NET Framework WinForms project to the new .NET Core 3.0 WinForms project. 
+9. [Link the files](#link-files-from-the-old-project) from your existing .NET Framework WinForms project to the .NET Core 3.0 WinForms project.
+10. **Optional** If you have difficulties with compiler linking, you can copy the project files from the .NET Framework WinForms project to the new .NET Core 3.0 WinForms project. 
     * C# files (files with the `.cs.` extension) are included by default in the .csproj.
     * Other project elements like `EmbeddedResources` can also use globbing.
 
 ### Migration tips
 
-**Configure Assembly File generation**
+#### Configure Assembly File generation
 
 Most existing projects include an `AssemblyInfo.cs` file in the Properties folder. The new project style uses a different approach and generate the same assembly attributes as part of the build process. To disable that behavior you can add the property:
 ```xml
 <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 ```
-**Include the Windows.Compatibility Pack**
+#### Include the Windows.Compatibility Pack
 Not every framework assembly is available in the .NET Core base class library. Windows applications like WinForms and WPF could have dependencies that are not available in .NET Core or .NET Standard. Adding a reference to the [Windows Compatibilty Pack](https://docs.microsoft.com/en-us/dotnet/core/porting/windows-compat-pack) will help reduce missing assembly dependencies as it includes several types that might be needed by your application.
 
 ```cmd
 dotnet add package Microsoft.Windows.Compatibility
 ```
-**Link Files from the old Project**
+#### Link Files from the old project
 
 Visual Studio does not yet support designers and custom tools for .NET desktop development. You can keep your files in the original project and link the generated files to the new project by using the link attribute in the project elements, e.g. `<Compile Link="" />`. See the [sample](helloworld-sharedsource) in this repo for an example of this.
 
-**Migrating WCF Clients**
+#### Migrating WCF Clients
 
 .NET Core has its own implementation of `System.ServiceModel` with some differences:
 * It's available as NuGet packages (also included in the Windows Compatiblity Pack)

--- a/windowsforms/README.md
+++ b/windowsforms/README.md
@@ -37,13 +37,13 @@ dotnet build
 dotnet run
 ```
 
-### Porting existing applications
+## Porting existing applications
 
 >We recommend running the [APIPort tool](https://github.com/Microsoft/dotnet-apiport-ui/releases) first to determine if there are any APIs your application depends on that will be missing with .NET Core. 
 
 There is no tooling available to help with project migration. In order to migrate your WinForms application, you will create a new project and manually port all of the elements defined in your original project. You will notice the new project is based on the simplified project format, and not everything will be migrated. 
 
-#### Migrate the head project
+### Migrate the head project
 Ideally you should migrate all projects in your solution to target .NET Core 3.0 and/or .NET Standard 2.0. The first step to migrate will be to retarget the application's entry point (i.e. 'head' project) and mantain your existing references.
 
 1. Start from a working Solution. You must be able to open the solution in Visual Studio and double check that you can build and run without any issues.
@@ -58,7 +58,7 @@ Ideally you should migrate all projects in your solution to target .NET Core 3.0
     * XAML files need to be included using the `<Page />` element. Remember that globbing is allowed, so you can add all XAML files from a given folder with a single `<Page Include=Views\*.xaml />` element.
     * Other project elements like `EmbeddedResources` can also use globbing.
 
-#### Migration tips
+### Migration tips
 
 **Configure Assembly File generation**
 

--- a/windowsforms/README.md
+++ b/windowsforms/README.md
@@ -9,6 +9,11 @@ If you're new to .NET Core, here are a few resources to help you understand the 
 ## Quality disclaimer
 .NET Core 3 support for desktop development is not yet in preview. There are early daily builds available supporting WinForms and WPF. You will likely encounter missing tools, bugs, and unexpected behavior. We do not recommend using this SDK and tools for building applications for production scenarios. We do recommend using this SDK and tools to evaluate your how easy it will be to migrate your existing applications, or if you're just interested in trying out the latest upcoming Windows development technology.
 
+## Samples in this repo
+| Sample Name | Descirption |
+| ----------- | ----------- |
+| [Hello World - shared source](helloworld-sharedsource) | This sample shows you how to share source between a .NET Framework WinForms application and a .NET Core WinForms application. Use this to get the full .NET Framework tooling experience while still building for .NET Core. |
+
 ## Getting Started
 
 ### Prerequisites and getting the tools
@@ -21,7 +26,7 @@ Install the latest [.NET Core 3.0 SDK daily build](https://dotnetcli.blob.core.w
 ### Analyzing your applications for .NET Core 3.0 readiness
 If you want to first understand your existing applications readiness for targeting .NET Core 3.0, you can run the .NET Portability Analyzer using the instructions [here](https://blogs.msdn.microsoft.com/dotnet/2018/08/08/are-your-windows-forms-and-wpf-applications-ready-for-net-core-3-0/). This will produce a report that will show you API compatibility for each assembly that your application depends on.
 
-### Creating .NET Core 3.0 WinForms applications
+### Creating new .NET Core 3.0 WinForms applications
 To create a new application you can use the `dotnet new` command, using the new templates for WinForms.
 
 In your favorite console run:
@@ -31,11 +36,6 @@ cd MyWinFormsApp
 dotnet build
 dotnet run
 ```
-
-## Samples in this repo
-| Sample Name | Descirption |
-| ----------- | ----------- |
-| [Hello World - shared source](helloworld-sharedsource) | This sample shows you how to share source between a .NET Framework WinForms application and a .NET Core WinForms application. Use this to get the full .NET Framework tooling experience while still building for .NET Core. |
 
 ### Porting existing applications
 

--- a/windowsforms/README.md
+++ b/windowsforms/README.md
@@ -55,7 +55,6 @@ Ideally you should migrate all projects in your solution to target .NET Core 3.0
 8. At this point it's a good idea to try and restore/build to make sure all dependencies are properly configured.
 9. Copy the project files from the .NET Framework WinForms project to the new .NET Core 3.0 WinForms project. 
     * C# files (files with the `.cs.` extension) are included by default in the .csproj.
-    * XAML files need to be included using the `<Page />` element. Remember that globbing is allowed, so you can add all XAML files from a given folder with a single `<Page Include=Views\*.xaml />` element.
     * Other project elements like `EmbeddedResources` can also use globbing.
 
 ### Migration tips

--- a/windowsforms/README.md
+++ b/windowsforms/README.md
@@ -10,7 +10,7 @@ If you're new to .NET Core, here are a few resources to help you understand the 
 .NET Core 3 support for desktop development is not yet in preview. There are early daily builds available supporting WinForms and WPF. You will likely encounter missing tools, bugs, and unexpected behavior. We do not recommend using this SDK and tools for building applications for production scenarios. We do recommend using this SDK and tools to evaluate your how easy it will be to migrate your existing applications, or if you're just interested in trying out the latest upcoming Windows development technology.
 
 ## Samples in this repo
-| Sample Name | Descirption |
+| Sample Name | Description |
 | ----------- | ----------- |
 | [Hello World - shared source](helloworld-sharedsource) | This sample shows you how to share source between a .NET Framework WinForms application and a .NET Core WinForms application. Use this to get the full .NET Framework tooling experience while still building for .NET Core. |
 

--- a/windowsforms/README.md
+++ b/windowsforms/README.md
@@ -7,7 +7,7 @@ If you're new to .NET Core, here are a few resources to help you understand the 
 * [Video: Modernizing Desktop Apps on Windows 10 with .NET Core 3.0 and much more](https://channel9.msdn.com/events/Build/2018/BRK3501?term=scott%20hunter&pubDate=year&lang-en=true)
 
 ## Quality disclaimer
-.NET Core 3 support for desktop development is not yet in preview. We have early daily builds available supporting these scenarios. You will likely encounter missing tools, bugs, and unexpected behavior. We do not recommend using this SDK and tools for building applications for production scenarios. We do recommend using this SDK and tools to evaluate your how easy it will be to migrate your existing applications, or if you're just interested in trying out the latest upcoming Windows development technology.
+.NET Core 3 support for desktop development is not yet in preview. There are early daily builds available supporting WinForms and WPF. You will likely encounter missing tools, bugs, and unexpected behavior. We do not recommend using this SDK and tools for building applications for production scenarios. We do recommend using this SDK and tools to evaluate your how easy it will be to migrate your existing applications, or if you're just interested in trying out the latest upcoming Windows development technology.
 
 ## Getting Started
 

--- a/windowsforms/README.md
+++ b/windowsforms/README.md
@@ -1,9 +1,88 @@
-# Windows Forms Samples
+# .NET Core 3.0 Windows Forms Samples
+Beginning with [.NET Core 3.0](https://github.com/dotnet/core-sdk#installers-and-binaries), you can build Windows Forms applications. 
 
-You build desktop applications with both .NET Framework and .NET Core. The following are samples that you can use to expore the capabilities of Windows Forms.
+## Why build WinForms applications on top of .NET Core?
+If you're new to .NET Core, here are a few resources to help you understand the advantages of .NET Core for building Windows applications:
+* [Blog: .NET Core 3 and Support for Windows Desktop Applications](https://blogs.msdn.microsoft.com/dotnet/2018/05/07/net-core-3-and-support-for-windows-desktop-applications/)
+* [Video: Modernizing Desktop Apps on Windows 10 with .NET Core 3.0 and much more](https://channel9.msdn.com/events/Build/2018/BRK3501?term=scott%20hunter&pubDate=year&lang-en=true)
 
-Note: Windows Forms is supported on [.NET Core 3.0](https://github.com/dotnet/core-sdk#installers-and-binaries) and later.
+## Quality disclaimer
+.NET Core 3 support for desktop development is not yet in preview. We have early daily builds available supporting these scenarios. You will likely encounter missing tools, bugs, and unexpected behavior. We do not recommend using this SDK and tools for building applications for production scenarios. We do recommend using this SDK and tools to evaluate your how easy it will be to migrate your existing applications, or if you're just interested in trying out the latest upcoming Windows development technology.
 
-## Samples
+## Getting Started
 
-* [Hello world -- shared source](helloworld-sharedsource)
+### Prerequisites and getting the tools
+
+Install Visual Studio 2017 Update 15.8 or higher from [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/), selecting the **.NET desktop development** workload with the options: **.NET Framwork 4.7.2 development tools** and **.NET Core 2.1 development tools**. 
+
+Install the latest [.NET Core 3.0 SDK daily build](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-win-x64.exe) available in the [dotnet/code-sdk repo](https://github.com/dotnet/core-sdk).
+
+
+### Analyzing your applications for .NET Core 3.0 readiness
+If you want to first understand your existing applications readiness for targeting .NET Core 3.0, you can run the .NET Portability Analyzer using the instructions [here](https://blogs.msdn.microsoft.com/dotnet/2018/08/08/are-your-windows-forms-and-wpf-applications-ready-for-net-core-3-0/). This will produce a report that will show you API compatibility for each assembly that your application depends on.
+
+### Creating .NET Core 3.0 WinForms applications
+To create a new application you can use the `dotnet new` command, using the new templates for WinForms.
+
+In your favorite console run:
+```cmd
+dotnet new winforms -o MyWinFormsApp
+cd MyWinFormsApp
+dotnet build
+dotnet run
+```
+
+## Samples in this repo
+| Sample Name | Descirption |
+| ----------- | ----------- |
+| [Hello World - shared source](helloworld-sharedsource) | This sample shows you how to share source between a .NET Framework WinForms application and a .NET Core WinForms application. Use this to get the full .NET Framework tooling experience while still building for .NET Core. |
+
+### Porting existing applications
+
+>We recommend running the [APIPort tool](https://github.com/Microsoft/dotnet-apiport-ui/releases) first to determine if there are any APIs your application depends on that will be missing with .NET Core. 
+
+There is no tooling available to help with project migration. In order to migrate your WinForms application, you will create a new project and manually port all of the elements defined in your original project. You will notice the new project is based on the simplified project format, and not everything will be migrated. 
+
+#### Migrate the head project
+Ideally you should migrate all projects in your solution to target .NET Core 3.0 and/or .NET Standard 2.0. The first step to migrate will be to retarget the application's entry point (i.e. 'head' project) and mantain your existing references.
+
+1. Start from a working Solution. You must be able to open the solution in Visual Studio and double check that you can build and run without any issues.
+2. If your solution also has server side projects, such as ASP.NET, we recommend splitting your solution into different server and client solutions. For this effort, work with the client solution only. 
+3. Add a new .NET Core 3.0 Windows Forms project to the solution. Adding this project to a sibling folder to your existing 'head' project will make it easier to port references later (using relative paths to other projects or assemblies in the solution)
+4.  If your 'head' project uses NuGet packages, you must add the same NuGet packages to the new project. The new SDK-Style projects only support the PackageReference format for adding NuGet package references. If your existing project is using `packages.config`, you must migrate to the new format. You can use the Migrator Tool described [here](https://docs.microsoft.com/en-us/nuget/reference/migrate-packages-config-to-package-reference) to automate this process.
+6. Copy the `PackageReference` elements generated in the previous step from the original project into the new project's .csproj file.
+7. Copy the `ProjectReference` elements from the original project. Note: The new project format does not use the `Name` and `ProjectGuid` elements so you can safely delete those.
+8. At this point it's a good idea to try and restore/build to make sure all dependencies are properly configured.
+9. Copy the project files from the .NET Framework WinForms project to the new .NET Core 3.0 WinForms project. 
+    * C# files (files with the `.cs.` extension) are included by default in the .csproj.
+    * XAML files need to be included using the `<Page />` element. Remember that globbing is allowed, so you can add all XAML files from a given folder with a single `<Page Include=Views\*.xaml />` element.
+    * Other project elements like `EmbeddedResources` can also use globbing.
+
+#### Migration tips
+
+**Configure Assembly File generation**
+
+Most existing projects include an `AssemblyInfo.cs` file in the Properties folder. The new project style uses a different approach and generate the same assembly attributes as part of the build process. To disable that behavior you can add the property:
+```xml
+<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+```
+**Include the Windows.Compatibility Pack**
+Not every framework assembly is available in the .NET Core base class library. Windows applications like WinForms and WPF could have dependencies that are not available in .NET Core or .NET Standard. Adding a reference to the [Windows Compatibilty Pack](https://docs.microsoft.com/en-us/dotnet/core/porting/windows-compat-pack) will help reduce missing assembly dependencies as it includes several types that might be needed by your application.
+
+```cmd
+dotnet add package Microsoft.Windows.Compatibility
+```
+**Link Files from the old Project**
+
+Visual Studio does not yet support designers and custom tools for .NET desktop development. You can keep your files in the original project and link the generated files to the new project by using the link attribute in the project elements, e.g. `<Compile Link="" />`. See the [sample](helloworld-sharedsource) in this repo for an example of this.
+
+**Migrating WCF Clients**
+
+.NET Core has its own implementation of `System.ServiceModel` with some differences:
+* It's available as NuGet packages (also included in the Windows Compatiblity Pack)
+* Review if your application uses some of the [unsupported features](https://github.com/dotnet/wcf/blob/master/release-notes/SupportedFeatures-v2.1.0.md).
+* If you want to reuse the ServiceReference created by Visual Studio you might get the error `System.PlatformNotSupportedException: 'Configuration files are not supported.'`. This error requires a code change to specify the binding and endpoint address in the service client constructor.
+ 
+## Known Issues
+**Launching a .NET Core 3.0 WinForms application on a device with a touch screen will fail with '.NET Core Host has stopped working'**
+* Workaround: [Disable your touchscreen](https://support.microsoft.com/en-us/help/4028019/windows-enable-and-disable-your-touchscreen-in-windows-10), or use a device without a touchscreen.


### PR DESCRIPTION
Adding getting started instructions for WinForms on top of .NET Core 3.0 and reformatting the samples to include a more helpful description