### PR TITLE
Attempt to correct fragmented WPF code

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/CustomControlNumericUpDown/CSharp/CustomControlLibrary/CustomControlLibrary.csproj
+++ b/snippets/csharp/VS_Snippets_Wpf/CustomControlNumericUpDown/CSharp/CustomControlLibrary/CustomControlLibrary.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NumericUpDown.cs" />
+    <Compile Include="NumericUpDown2.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <AppDesigner Include="Properties\" />
   </ItemGroup>

--- a/snippets/csharp/VS_Snippets_Wpf/CustomControlNumericUpDown/CSharp/CustomControlLibrary/NumericUpDown.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/CustomControlNumericUpDown/CSharp/CustomControlLibrary/NumericUpDown.cs
@@ -10,21 +10,8 @@ using System.Diagnostics;
 
 namespace CustomControlLibrary
 {
-    //<SnippetStaticCtorOfCustomClassCommonTasks>
-    public class NumericUpDown : Control
+    public partial class NumericUpDown : Control
     {
-        static NumericUpDown()
-        {
-            InitializeCommands();
-
-            // Listen to MouseLeftButtonDown event to determine if slide should move focus to itself
-            EventManager.RegisterClassHandler(typeof(NumericUpDown), 
-                Mouse.MouseDownEvent, new MouseButtonEventHandler(NumericUpDown.OnMouseLeftButtonDown), true);
-
-            DefaultStyleKeyProperty.OverrideMetadata(typeof(NumericUpDown), new FrameworkPropertyMetadata(typeof(NumericUpDown)));
-        }
-        //</SnippetStaticCtorOfCustomClassCommonTasks>
-
         public NumericUpDown()
             : base()
         {

--- a/snippets/csharp/VS_Snippets_Wpf/CustomControlNumericUpDown/CSharp/CustomControlLibrary/NumericUpDown.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/CustomControlNumericUpDown/CSharp/CustomControlLibrary/NumericUpDown.cs
@@ -12,6 +12,8 @@ namespace CustomControlLibrary
 {
     public partial class NumericUpDown : Control
     {
+// <staticctorofcustomclasscommontasks>
+// </staticctorofcustomclasscommontasks>
         public NumericUpDown()
             : base()
         {

--- a/snippets/csharp/VS_Snippets_Wpf/CustomControlNumericUpDown/CSharp/CustomControlLibrary/NumericUpDown2.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/CustomControlNumericUpDown/CSharp/CustomControlLibrary/NumericUpDown2.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Automation;
+using System.Globalization;
+using System.Diagnostics;
+
+namespace CustomControlLibrary
+{
+    public partial class NumericUpDown : Control
+    {
+        static NumericUpDown()
+        {
+            InitializeCommands();
+
+            // Listen to MouseLeftButtonDown event to determine if slide should move focus to itself
+            EventManager.RegisterClassHandler(typeof(NumericUpDown), 
+                Mouse.MouseDownEvent, new MouseButtonEventHandler(NumericUpDown.OnMouseLeftButtonDown), true);
+
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(NumericUpDown), new FrameworkPropertyMetadata(typeof(NumericUpDown)));
+        }
+    }
+}

--- a/snippets/visualbasic/VS_Snippets_Wpf/CustomControlNumericUpDown/visualbasic/customcontrollibrary/customcontrollibrary.vbproj
+++ b/snippets/visualbasic/VS_Snippets_Wpf/CustomControlNumericUpDown/visualbasic/customcontrollibrary/customcontrollibrary.vbproj
@@ -45,7 +45,7 @@
     <Reference Include="UIAutomationProvider" />
     <Reference Include="UIAutomationTypes" />
   </ItemGroup>
-  <ItemGroup>
+    <ItemGroup>
     <Page Include="themes\Luna.NormalColor.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -56,7 +56,26 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Import Include="System.Threading.Tasks" />
+    <Import Include="System.Linq" />
+    <Import Include="Microsoft.VisualBasic" />
+    <Import Include="System" />
+    <Import Include="System.Collections" />
+    <Import Include="System.Collections.Generic" />
+    <Import Include="System.Diagnostics" />
+    <Import Include="System.Windows" />
+    <Import Include="System.Windows.Controls" />
+    <Import Include="System.Windows.Data" />
+    <Import Include="System.Windows.Documents" />
+    <Import Include="System.Windows.Input" />
+    <Import Include="System.Windows.Shapes" />
+    <Import Include="System.Windows.Media" />
+    <Import Include="System.Windows.Media.Imaging" />
+    <Import Include="System.Windows.Navigation" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="NumericUpDown.vb" />
+    <Compile Include="NumericUpDown2.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
     <AppDesigner Include="My Project\" />
   </ItemGroup>

--- a/snippets/visualbasic/VS_Snippets_Wpf/CustomControlNumericUpDown/visualbasic/customcontrollibrary/numericupdown.vb
+++ b/snippets/visualbasic/VS_Snippets_Wpf/CustomControlNumericUpDown/visualbasic/customcontrollibrary/numericupdown.vb
@@ -1,5 +1,3 @@
-Imports Microsoft.VisualBasic
-Imports System
 Imports System.Windows
 Imports System.Windows.Controls
 Imports System.Windows.Input
@@ -10,18 +8,8 @@ Imports System.Globalization
 Imports System.Diagnostics
 
 Namespace CustomControlLibrary
-	'<SnippetStaticCtorOfCustomClassCommonTasks>
-	Public Class NumericUpDown
+	Public Partial Class NumericUpDown
 		Inherits Control
-		Shared Sub New()
-			InitializeCommands()
-
-			' Listen to MouseLeftButtonDown event to determine if slide should move focus to itself
-			EventManager.RegisterClassHandler(GetType(NumericUpDown), Mouse.MouseDownEvent, New MouseButtonEventHandler(AddressOf NumericUpDown.OnMouseLeftButtonDown), True)
-
-			DefaultStyleKeyProperty.OverrideMetadata(GetType(NumericUpDown), New FrameworkPropertyMetadata(GetType(NumericUpDown)))
-		End Sub
-		'</SnippetStaticCtorOfCustomClassCommonTasks>
 
 		Public Sub New()
 			MyBase.New()
@@ -414,7 +402,5 @@ Namespace CustomControlLibrary
 				Return CType(MyBase.Owner, NumericUpDown)
 			End Get
 		End Property
-	'<SnippetClose>
 	End Class
-	'</SnippetClose>
 End Namespace

--- a/snippets/visualbasic/VS_Snippets_Wpf/CustomControlNumericUpDown/visualbasic/customcontrollibrary/numericupdown.vb
+++ b/snippets/visualbasic/VS_Snippets_Wpf/CustomControlNumericUpDown/visualbasic/customcontrollibrary/numericupdown.vb
@@ -10,7 +10,8 @@ Imports System.Diagnostics
 Namespace CustomControlLibrary
 	Public Partial Class NumericUpDown
 		Inherits Control
-
+' <snippetstaticctorofcustomclasscommontasks>
+' </snippetstaticctorofcustomclasscommontasks>
 		Public Sub New()
 			MyBase.New()
 			updateValueString()
@@ -401,6 +402,8 @@ Namespace CustomControlLibrary
 			Get
 				Return CType(MyBase.Owner, NumericUpDown)
 			End Get
-		End Property
+		   End Property
+	' <snippetclose>
 	End Class
+	' </snippetclose>
 End Namespace

--- a/snippets/visualbasic/VS_Snippets_Wpf/CustomControlNumericUpDown/visualbasic/customcontrollibrary/numericupdown2.vb
+++ b/snippets/visualbasic/VS_Snippets_Wpf/CustomControlNumericUpDown/visualbasic/customcontrollibrary/numericupdown2.vb
@@ -1,0 +1,18 @@
+Imports System.Windows
+Imports System.Windows.Controls
+Imports System.Windows.Input
+
+Namespace CustomControlLibrary
+	Public Partial Class NumericUpDown
+		Inherits Control
+
+		Shared Sub New()
+			InitializeCommands()
+
+			' Listen to MouseLeftButtonDown event to determine if slide should move focus to itself
+			EventManager.RegisterClassHandler(GetType(NumericUpDown), Mouse.MouseDownEvent, New MouseButtonEventHandler(AddressOf NumericUpDown.OnMouseLeftButtonDown), True)
+
+			DefaultStyleKeyProperty.OverrideMetadata(GetType(NumericUpDown), New FrameworkPropertyMetadata(GetType(NumericUpDown)))
+		End Sub
+	End Class
+End Namespace


### PR DESCRIPTION
## Attempt to correct fragmented WPF code

In the past, we've addressed the issue of fragmented WPF code by including the entire source code file and using highlighting to highlight the relevant lines of code. In this case, the source code file is too large to make highlighting particularly useful. This PR attempts to use the partial class feature of both VB and C# to place the relevant code in a smaller file.

I've left the old snippets in the source code file (though one has no actual code in it), so this PR can be merged without build breaks.

Related to dotnet/docs#8185

