### PR TITLE
Remove redundant string assignment in File class example

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/File Class Example/CS/file class example.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File Class Example/CS/file class example.cs
@@ -21,7 +21,7 @@ class Test
         // Open the file to read from.
         using (StreamReader sr = File.OpenText(path))
         {
-            string s = "";
+            string s;
             while ((s = sr.ReadLine()) != null)
             {
                 Console.WriteLine(s);


### PR DESCRIPTION
## Summary

Assigning the string to "" is redundant, as it is immediately overwritten in the while loop.