### PR TITLE
Use await rather than .Wait()

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.threading.tasks.task.ctor/cs/run4.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.threading.tasks.task.ctor/cs/run4.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 public class Example
 {
-   public static void Main()
+   public static async Task Main()
    {
       var tokenSource = new CancellationTokenSource();
       var token = tokenSource.Token;
@@ -32,7 +32,7 @@ public class Example
       t.Start();
       tokenSource.Cancel();
       try {
-         t.Wait(); 
+         await t; 
          Console.WriteLine("Retrieved information for {0} files.", files.Count);
       }
       catch (AggregateException e) {


### PR DESCRIPTION
## Summary

`async Task Main()` and `await Task.WhenAll()` rather than `void Main` and `Task.WaitAll()` as that encourages worse practices further down the stack, like blocking in threadpool threads