### PR TITLE
Use async WhenAll rather than blocking WaitAll

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.threading.tasks.task.ctor/cs/startnew3.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.threading.tasks.task.ctor/cs/startnew3.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 public class Example
 {
-   public static void Main()
+   public static async Task Main()
    {
       var tasks = new List<Task>();
       Random rnd = new Random();
@@ -27,7 +27,7 @@ public class Example
          t.Start();
          tasks.Add(t);
       }
-      Task.WaitAll(tasks.ToArray());
+      await Task.WhenAll(tasks.ToArray());
    }
 }
 // The example displays output like the following:


### PR DESCRIPTION
## Summary

`async Task Main()` and `await Task.WhenAll()` rather than `void Main` and `Task.WaitAll()` as that encourages worse practices further down the stack, like blocking in threadpool threads