### PR TITLE
Fix formatting on System.Environment sample

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/environment.class/CS/env0.cs
+++ b/snippets/csharp/VS_Snippets_CLR/environment.class/CS/env0.cs
@@ -3,78 +3,78 @@
 using System;
 using System.Collections;
 
-class Sample 
+class Sample
 {
-    public static void Main() 
+    public static void Main()
     {
-    String str;
-    String nl = Environment.NewLine;
-//
-    Console.WriteLine();
-    Console.WriteLine("-- Environment members --");
+        String str;
+        String nl = Environment.NewLine;
+        //
+        Console.WriteLine();
+        Console.WriteLine("-- Environment members --");
 
-//  Invoke this sample with an arbitrary set of command line arguments.
-    Console.WriteLine("CommandLine: {0}", Environment.CommandLine);
+        //  Invoke this sample with an arbitrary set of command line arguments.
+        Console.WriteLine("CommandLine: {0}", Environment.CommandLine);
 
-    String[] arguments = Environment.GetCommandLineArgs();
-    Console.WriteLine("GetCommandLineArgs: {0}", String.Join(", ", arguments));
+        String[] arguments = Environment.GetCommandLineArgs();
+        Console.WriteLine("GetCommandLineArgs: {0}", String.Join(", ", arguments));
 
-//  <-- Keep this information secure! -->
-    Console.WriteLine("CurrentDirectory: {0}", Environment.CurrentDirectory);
+        //  <-- Keep this information secure! -->
+        Console.WriteLine("CurrentDirectory: {0}", Environment.CurrentDirectory);
 
-    Console.WriteLine("ExitCode: {0}", Environment.ExitCode);
+        Console.WriteLine("ExitCode: {0}", Environment.ExitCode);
 
-    Console.WriteLine("HasShutdownStarted: {0}", Environment.HasShutdownStarted);
+        Console.WriteLine("HasShutdownStarted: {0}", Environment.HasShutdownStarted);
 
-//  <-- Keep this information secure! -->
-    Console.WriteLine("MachineName: {0}", Environment.MachineName);
+        //  <-- Keep this information secure! -->
+        Console.WriteLine("MachineName: {0}", Environment.MachineName);
 
-    Console.WriteLine("NewLine: {0}  first line{0}  second line{0}  third line",
-                          Environment.NewLine);
+        Console.WriteLine("NewLine: {0}  first line{0}  second line{0}  third line",
+                              Environment.NewLine);
 
-    Console.WriteLine("OSVersion: {0}", Environment.OSVersion.ToString());
+        Console.WriteLine("OSVersion: {0}", Environment.OSVersion.ToString());
 
-    Console.WriteLine("StackTrace: '{0}'", Environment.StackTrace);
+        Console.WriteLine("StackTrace: '{0}'", Environment.StackTrace);
 
-//  <-- Keep this information secure! -->
-    Console.WriteLine("SystemDirectory: {0}", Environment.SystemDirectory);
+        //  <-- Keep this information secure! -->
+        Console.WriteLine("SystemDirectory: {0}", Environment.SystemDirectory);
 
-    Console.WriteLine("TickCount: {0}", Environment.TickCount);
+        Console.WriteLine("TickCount: {0}", Environment.TickCount);
 
-//  <-- Keep this information secure! -->
-    Console.WriteLine("UserDomainName: {0}", Environment.UserDomainName);
+        //  <-- Keep this information secure! -->
+        Console.WriteLine("UserDomainName: {0}", Environment.UserDomainName);
 
-    Console.WriteLine("UserInteractive: {0}", Environment.UserInteractive);
+        Console.WriteLine("UserInteractive: {0}", Environment.UserInteractive);
 
-//  <-- Keep this information secure! -->
-    Console.WriteLine("UserName: {0}", Environment.UserName);
+        //  <-- Keep this information secure! -->
+        Console.WriteLine("UserName: {0}", Environment.UserName);
 
-    Console.WriteLine("Version: {0}", Environment.Version.ToString());
+        Console.WriteLine("Version: {0}", Environment.Version.ToString());
 
-    Console.WriteLine("WorkingSet: {0}", Environment.WorkingSet);
+        Console.WriteLine("WorkingSet: {0}", Environment.WorkingSet);
 
-//  No example for Exit(exitCode) because doing so would terminate this example.
+        //  No example for Exit(exitCode) because doing so would terminate this example.
 
-//  <-- Keep this information secure! -->
-    String query = "My system drive is %SystemDrive% and my system root is %SystemRoot%";
-    str = Environment.ExpandEnvironmentVariables(query);
-    Console.WriteLine("ExpandEnvironmentVariables: {0}  {1}", nl, str);
+        //  <-- Keep this information secure! -->
+        String query = "My system drive is %SystemDrive% and my system root is %SystemRoot%";
+        str = Environment.ExpandEnvironmentVariables(query);
+        Console.WriteLine("ExpandEnvironmentVariables: {0}  {1}", nl, str);
 
-    Console.WriteLine("GetEnvironmentVariable: {0}  My temporary directory is {1}.", nl,
-                           Environment.GetEnvironmentVariable("TEMP"));
+        Console.WriteLine("GetEnvironmentVariable: {0}  My temporary directory is {1}.", nl,
+                               Environment.GetEnvironmentVariable("TEMP"));
 
-    Console.WriteLine("GetEnvironmentVariables: ");
-    IDictionary	environmentVariables = Environment.GetEnvironmentVariables();
-    foreach (DictionaryEntry de in environmentVariables)
+        Console.WriteLine("GetEnvironmentVariables: ");
+        IDictionary environmentVariables = Environment.GetEnvironmentVariables();
+        foreach (DictionaryEntry de in environmentVariables)
         {
-        Console.WriteLine("  {0} = {1}", de.Key, de.Value);
+            Console.WriteLine("  {0} = {1}", de.Key, de.Value);
         }
 
-    Console.WriteLine("GetFolderPath: {0}", 
-                 Environment.GetFolderPath(Environment.SpecialFolder.System));
+        Console.WriteLine("GetFolderPath: {0}",
+                     Environment.GetFolderPath(Environment.SpecialFolder.System));
 
-    String[] drives = Environment.GetLogicalDrives();
-    Console.WriteLine("GetLogicalDrives: {0}", String.Join(", ", drives));
+        String[] drives = Environment.GetLogicalDrives();
+        Console.WriteLine("GetLogicalDrives: {0}", String.Join(", ", drives));
     }
 }
 /*

--- a/snippets/csharp/VS_Snippets_CLR/environment.class/CS/env0.cs
+++ b/snippets/csharp/VS_Snippets_CLR/environment.class/CS/env0.cs
@@ -7,8 +7,8 @@ class Sample
 {
     public static void Main()
     {
-        String str;
-        String nl = Environment.NewLine;
+        string str;
+        string nl = Environment.NewLine;
         //
         Console.WriteLine();
         Console.WriteLine("-- Environment members --");
@@ -16,7 +16,7 @@ class Sample
         //  Invoke this sample with an arbitrary set of command line arguments.
         Console.WriteLine("CommandLine: {0}", Environment.CommandLine);
 
-        String[] arguments = Environment.GetCommandLineArgs();
+        string[] arguments = Environment.GetCommandLineArgs();
         Console.WriteLine("GetCommandLineArgs: {0}", String.Join(", ", arguments));
 
         //  <-- Keep this information secure! -->
@@ -56,7 +56,7 @@ class Sample
         //  No example for Exit(exitCode) because doing so would terminate this example.
 
         //  <-- Keep this information secure! -->
-        String query = "My system drive is %SystemDrive% and my system root is %SystemRoot%";
+        string query = "My system drive is %SystemDrive% and my system root is %SystemRoot%";
         str = Environment.ExpandEnvironmentVariables(query);
         Console.WriteLine("ExpandEnvironmentVariables: {0}  {1}", nl, str);
 
@@ -73,7 +73,7 @@ class Sample
         Console.WriteLine("GetFolderPath: {0}",
                      Environment.GetFolderPath(Environment.SpecialFolder.System));
 
-        String[] drives = Environment.GetLogicalDrives();
+        string[] drives = Environment.GetLogicalDrives();
         Console.WriteLine("GetLogicalDrives: {0}", String.Join(", ", drives));
     }
 }


### PR DESCRIPTION
## Summary

The indentation was off and the sample used .NET types instead of C# types. 
