### PR TITLE
Clarify the termination event code

### DIFF
--- a/csharp/getting-started/console-teleprompter/Program.cs
+++ b/csharp/getting-started/console-teleprompter/Program.cs
@@ -45,6 +45,8 @@ namespace TeleprompterConsole
                         config.UpdateDelay(-10);
                     else if (key.KeyChar == '<')
                         config.UpdateDelay(10);
+                    else if (key.KeyChar == 'X' || key.KeyChar == 'x')
+                        config.SetDone();
                 } while (!config.Done);
             };
             await Task.Run(work);


### PR DESCRIPTION
Add code that allow GetInput() method to finish when user presses certain keys. This helps better demonstrate usage of Task.WhenAny(Task[]) method.

## Summary

Check whether user pressed 'X' or 'x' keys and finish GetInput() method.

Fixes dotnet/docs#6960
