### PR TITLE
Update run.ps1

### DIFF
--- a/framework/docker/MVCRandomAnswerGenerator/run.ps1
+++ b/framework/docker/MVCRandomAnswerGenerator/run.ps1
@@ -2,5 +2,4 @@ docker build -t mvcrandomanswers .
 
 docker images
 docker run -d -p 8000:8000 --name randomanswers mvcrandomanswers
-docker inspect -f "{{ .NetworkSettings.Networks.nat.IPAddress }}" randomanswers
 


### PR DESCRIPTION
The current windows container releases appear to have fixed the "localhost" issue that was previously mentioned in the readme that referenced this ps1 script.  I've created a separate pull request in the article to also remove the `docker inspect`