### PR TITLE
Whitespace - new cases in additionExamples

### DIFF
--- a/snippets/csharp/language-reference/operators/AdditionExamples.cs
+++ b/snippets/csharp/language-reference/operators/AdditionExamples.cs
@@ -24,10 +24,10 @@ namespace operators
         private static void StringConcatenation()
         {
             // <SnippetAddStrings>
-            Console.WriteLine("Forgot" + "whitespace");
+            Console.WriteLine("Forgot " + " white space");
             Console.WriteLine("Probably the oldest constant: " + Math.PI);
             // Output:
-            // Forgotwhitespace
+            // Forgot white space
             // Probably the oldest constant: 3.14159265358979
             // </SnippetAddStrings>
 


### PR DESCRIPTION
Hello @rpetrusha and @mairaw . I was curious if this error came back after our treatment and apparently it did.  :/

## Fix "whitespace" words - docs/samples.

This PR came out from this [issue](https://github.com/dotnet/docs/issues/4439) on docs/samples. 

## Brief explanation
We should use **white-space** for adjectives and **white space** for nouns.

## Suggested Reviewers
@mairaw @rpetrusha 