### PR TITLE
Use the appropriate loop and bracket on newline

### DIFF
--- a/snippets/csharp/language-reference/keywords/await/await2.cs
+++ b/snippets/csharp/language-reference/keywords/await/await2.cs
@@ -20,11 +20,13 @@ class Example
       var client = new HttpClient();
       long pageLengths = 0;
 
-      for (int ctr = 1; ctr < args.Length; ctr++) {
-         var uri = new Uri(Uri.EscapeUriString(args[ctr]));
+      foreach (var arg in args)
+      {
+         var uri = new Uri(Uri.EscapeUriString(arg));
          string pageContents = await client.GetStringAsync(uri);
          Interlocked.Add(ref pageLengths, pageContents.Length);
       }
+      
       return pageLengths;
    }
 }

--- a/snippets/csharp/language-reference/keywords/await/await2.cs
+++ b/snippets/csharp/language-reference/keywords/await/await2.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 class Example
 {
-   static void Main()
+   static async Task Main()
    {
       string[] args = Environment.GetCommandLineArgs();
       if (args.Length < 2)
@@ -15,7 +15,7 @@ class Example
       // Don't pass the executable file name
       var uris = args.Skip(1).ToArray();
 
-      long characters = GetPageLengthsAsync(uris).Result;
+      long characters = await GetPageLengthsAsync(uris);
       Console.WriteLine($"{uris.Length} pages, {characters:N0} characters");
    }
 

--- a/snippets/csharp/language-reference/keywords/await/await2.cs
+++ b/snippets/csharp/language-reference/keywords/await/await2.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,21 +10,24 @@ class Example
    {
       string[] args = Environment.GetCommandLineArgs();
       if (args.Length < 2)
-         throw new ArgumentNullException("No URLs specified on the command line.");
-      
-      long characters = GetPageLengthsAsync(args).Result;
-      Console.WriteLine($"{args.Length - 1} pages, {characters:N0} characters");
+         throw new ArgumentNullException("No URIs specified on the command line.");
+
+      // Don't pass the executable file name
+      var uris = args.Skip(1).ToArray();
+
+      long characters = GetPageLengthsAsync(uris).Result;
+      Console.WriteLine($"{uris.Length} pages, {characters:N0} characters");
    }
 
-   private static async Task<long> GetPageLengthsAsync(string[] args)
+   private static async Task<long> GetPageLengthsAsync(string[] uris)
    {
       var client = new HttpClient();
       long pageLengths = 0;
 
-      foreach (var arg in args)
+      foreach (var uri in uris)
       {
-         var uri = new Uri(Uri.EscapeUriString(arg));
-         string pageContents = await client.GetStringAsync(uri);
+         var escapedUri = new Uri(Uri.EscapeUriString(uri));
+         string pageContents = await client.GetStringAsync(escapedUri);
          Interlocked.Add(ref pageLengths, pageContents.Length);
       }
       


### PR DESCRIPTION
The code didn't follow C# coding conventions by using bracket on the same line, also, `foreach` fit better in this case.
