### PR TITLE
Update Program.cs

### DIFF
--- a/snippets/csharp/tour/statements/Program.cs
+++ b/snippets/csharp/tour/statements/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Statements


### PR DESCRIPTION
Reintroduced using to make references using line numbers work again.

Fixes dotnet/docs#8935