### PR TITLE
Use simplified `float` syntax.

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR_System/system.Collections.Hashtable_ctorDictionaryFloat/CPP/hashtable_ctordictionaryfloat.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.Collections.Hashtable_ctorDictionaryFloat/CPP/hashtable_ctordictionaryfloat.cpp
@@ -59,16 +59,16 @@ public:
 	   mySL->Add( "THIRD", "!" );
 	   
 	   // Create a hash table using the default hash code provider and the default comparer.
-	   Hashtable^ myHT1 = gcnew Hashtable( mySL,(float).8 );
+	   Hashtable^ myHT1 = gcnew Hashtable( mySL, .8f );
 	   
 	   // Create a hash table using the specified case-insensitive hash code provider and case-insensitive comparer.
-	   Hashtable^ myHT2 = gcnew Hashtable( mySL,(float).8,gcnew myCultureComparer() );
+	   Hashtable^ myHT2 = gcnew Hashtable( mySL, .8f, gcnew myCultureComparer() );
 	   
 	   // Create a hash table using the specified KeyComparer.
 	   // The KeyComparer uses a case-insensitive hash code provider and a case-insensitive comparer,
 	   // which are based on the Turkish culture (tr-TR), where "I" is not the uppercase version of "i".
 	   CultureInfo^ myCul = gcnew CultureInfo( "tr-TR" );
-	   Hashtable^ myHT3 = gcnew Hashtable( mySL,(float).8, gcnew myCultureComparer( myCul ) );
+	   Hashtable^ myHT3 = gcnew Hashtable( mySL, .8f, gcnew myCultureComparer( myCul ) );
 	   
 	   // Search for a key in each hash table.
 	   Console::WriteLine( "first is in myHT1: {0}", myHT1->ContainsKey( "first" ) );

--- a/snippets/cpp/VS_Snippets_CLR_System/system.Collections.Hashtable_ctorIntFloat/CPP/hashtable_ctorintfloat.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.Collections.Hashtable_ctorIntFloat/CPP/hashtable_ctorintfloat.cpp
@@ -52,14 +52,14 @@ public:
 	static void Main()
 	{
         // Create a hash table using the default comparer.
-        Hashtable^ myHT1 = gcnew Hashtable(3, (float).8);
+        Hashtable^ myHT1 = gcnew Hashtable(3, .8f);
         myHT1->Add("FIRST", "Hello");
         myHT1->Add("SECOND", "World");
         myHT1->Add("THIRD", "!");
 
         // Create a hash table using the specified IEqualityComparer that uses
         // the CaseInsensitiveComparer.DefaultInvariant to determine equality.
-        Hashtable^ myHT2 = gcnew Hashtable(3, (float).8, gcnew myCultureComparer());
+        Hashtable^ myHT2 = gcnew Hashtable(3, .8f, gcnew myCultureComparer());
         myHT2->Add("FIRST", "Hello");
         myHT2->Add("SECOND", "World");
         myHT2->Add("THIRD", "!");
@@ -68,7 +68,7 @@ public:
         // the Turkish culture (tr-TR) where "I" is not the uppercase
         // version of "i".
         CultureInfo^ myCul = gcnew CultureInfo("tr-TR");
-        Hashtable^ myHT3 = gcnew Hashtable(3, (float).8, gcnew myCultureComparer(myCul));
+        Hashtable^ myHT3 = gcnew Hashtable(3, .8f, gcnew myCultureComparer(myCul));
         myHT3->Add("FIRST", "Hello");
         myHT3->Add("SECOND", "World");
         myHT3->Add("THIRD", "!");

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Hashtable_ctorDictionaryFloat/CS/hashtable_ctordictionaryfloat.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Hashtable_ctorDictionaryFloat/CS/hashtable_ctordictionaryfloat.cs
@@ -53,19 +53,18 @@ public class SamplesHashtable
         mySL.Add("THIRD", "!");
 
         // Create a hash table using the default comparer.
-        Hashtable myHT1 = new Hashtable(mySL, (float).8);
+        Hashtable myHT1 = new Hashtable(mySL, .8f);
 
         // Create a hash table using the specified IEqualityComparer that uses
         // the CaseInsensitiveComparer.DefaultInvariant to determine equality.
-        Hashtable myHT2 = new Hashtable(mySL, (float).8, 
+        Hashtable myHT2 = new Hashtable(mySL, .8f, 
             new myCultureComparer());
 
         // Create a hash table using an IEqualityComparer that is based on
         // the Turkish culture (tr-TR) where "I" is not the uppercase
         // version of "i".
         CultureInfo myCul = new CultureInfo("tr-TR");
-        Hashtable myHT3 = new Hashtable(mySL, (float).8, 
-            new myCultureComparer(myCul));
+        Hashtable myHT3 = new Hashtable(mySL, .8f, new myCultureComparer(myCul));
 
         // Search for a key in each hash table.
         Console.WriteLine("first is in myHT1: {0}", myHT1.ContainsKey("first"));

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Hashtable_ctorIntFloat/CS/hashtable_ctorintfloat.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Hashtable_ctorIntFloat/CS/hashtable_ctorintfloat.cs
@@ -47,14 +47,14 @@ public class SamplesHashtable
     {
 
         // Create a hash table using the default comparer.
-        Hashtable myHT1 = new Hashtable(3, (float).8);
+        Hashtable myHT1 = new Hashtable(3, .8f);
         myHT1.Add("FIRST", "Hello");
         myHT1.Add("SECOND", "World");
         myHT1.Add("THIRD", "!");
 
         // Create a hash table using the specified IEqualityComparer that uses
         // the CaseInsensitiveComparer.DefaultInvariant to determine equality.
-        Hashtable myHT2 = new Hashtable(3, (float).8, new myCultureComparer());
+        Hashtable myHT2 = new Hashtable(3, .8f, new myCultureComparer());
         myHT2.Add("FIRST", "Hello");
         myHT2.Add("SECOND", "World");
         myHT2.Add("THIRD", "!");
@@ -63,8 +63,7 @@ public class SamplesHashtable
         // the Turkish culture (tr-TR) where "I" is not the uppercase
         // version of "i".
         CultureInfo myCul = new CultureInfo("tr-TR");
-        Hashtable myHT3 = new Hashtable(3, (float).8, 
-            new myCultureComparer(myCul));
+        Hashtable myHT3 = new Hashtable(3, .8f, new myCultureComparer(myCul));
 
         myHT3.Add("FIRST", "Hello");
         myHT3.Add("SECOND", "World");

--- a/snippets/csharp/VS_Snippets_Misc/astoria northwind service/cs/northwind2.svc.cs
+++ b/snippets/csharp/VS_Snippets_Misc/astoria northwind service/cs/northwind2.svc.cs
@@ -71,7 +71,7 @@ namespace NorthwindDataService
 
             //    Order_Detail item = (Order_Detail)entity;
 
-            //    item.Discount = (float)0.5;
+            //    item.Discount = 0.5f;
 
             //    this.CurrentDataSource.SaveChanges();
 

--- a/snippets/csharp/VS_Snippets_VBCSharp/VbPowerPacksShapeScale/CS/ShapeScale.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/VbPowerPacksShapeScale/CS/ShapeScale.cs
@@ -27,7 +27,7 @@ namespace VbPowerPacksShapeScaleCS
             }
             else
             {
-                ovalShape1.Scale(new SizeF((float)0.5, ((float)0.333)));
+                ovalShape1.Scale(new SizeF(0.5f, 0.333f));
                 state = false;
             }
         }

--- a/snippets/csharp/VS_Snippets_Winforms/TabControl.RightAlignedTabs/CS/Form1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/TabControl.RightAlignedTabs/CS/Form1.cs
@@ -44,7 +44,7 @@ namespace TestVerticalTabsCS
             }
 
             // Use our own font.
-            Font _tabFont = new Font("Arial", (float)10.0, FontStyle.Bold, GraphicsUnit.Pixel);
+            Font _tabFont = new Font("Arial", 10.0f, FontStyle.Bold, GraphicsUnit.Pixel);
 
             // Draw string. Center the text.
             StringFormat _stringFlags = new StringFormat();


### PR DESCRIPTION
## Summary

Changes statements of the form `\(float\)\d{0,}\.\d{1,}` to `\d{0,}\.\d{1,}f`