### PR TITLE
Made a namespace example less confusing

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs
@@ -1,11 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Drawing;
 
 //<snippet1>
-
 namespace SampleNamespace
 {
     class SampleClass { }
@@ -18,7 +17,7 @@ namespace SampleNamespace
 
     delegate void SampleDelegate(int i);
 
-    namespace SampleNamespace.Nested
+    namespace Nested
     {
         class SampleClass2 { }
     }


### PR DESCRIPTION
Updated snippet is used in the [namespace](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/namespace) keyword article.

Made the full name of the nested namespace `SampleNamespace.Nested` instead of `SampleNamespace.SampleNamespace.Nested`

