### PR TITLE
Updates inline comments to specify correct output.

### DIFF
--- a/snippets/csharp/concepts/structs/literals.cs
+++ b/snippets/csharp/concepts/structs/literals.cs
@@ -8,10 +8,10 @@ Console.WriteLine(type);
 
 var x = 123_456;
 string s2 = "I can use an underscore as a digit separator: " + x;
-// Outputs: "I can use an underscore as a digit separator: 
+// Outputs: "I can use an underscore as a digit separator: 123456"
 Console.WriteLine(s2);
 
 var b = 0b1010_1011_1100_1110_1111;
 string s3 = "I can specify bit patterns: " + b.ToString();
-// Outputs: "I can specify bit patterns: 703727
+// Outputs: "I can specify bit patterns: 703727"
 Console.WriteLine(s3);


### PR DESCRIPTION
## Summary

The inline comments were not 100% correct, this adjusts them.

Fixes dotnet/docs#9326
