### PR TITLE
Adding a link to WPF Samples repo

### DIFF
--- a/wpf/README.md
+++ b/wpf/README.md
@@ -12,6 +12,9 @@ If you're new to .NET Core, here are a few resources to help you understand the 
 ## Samples in this repo
 Coming soon!
 
+## Additional Samples
+Please visit [WPF Samples](https://www.github.com/Microsoft/wpf-samples) repo for additional WPF Samples that have been updated to target .NET Core 3.0. 
+
 ## Getting Started
 
 ### Prerequisites and getting the tools

--- a/wpf/README.md
+++ b/wpf/README.md
@@ -13,7 +13,7 @@ If you're new to .NET Core, here are a few resources to help you understand the 
 Coming soon!
 
 ## Additional Samples
-Please visit [WPF Samples](https://www.github.com/Microsoft/wpf-samples) repo for additional WPF Samples that have been updated to target .NET Core 3.0. 
+See [WPF Samples](https://www.github.com/Microsoft/wpf-samples) repo for additional WPF samples that have been updated to target .NET Core 3.0. 
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

Adding a link to WPF Samples repo, where all samples have been updated to target .NET Core 3.0 (along with .NET 4.7.2). 

