### PR TITLE
Correctly dispose HttpClient in its example

### DIFF
--- a/snippets/csharp/VS_Snippets_Misc/system.net.http.httpclient/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_Misc/system.net.http.httpclient/cs/source.cs
@@ -9,29 +9,26 @@ class HttpClient_Example
 // <Snippet1>
    static async Task Main()
    {
-      // Create a New HttpClient object.
-      HttpClient client = new HttpClient();
-    
-      // Call asynchronous network methods in a try/catch block to handle exceptions
-      try	
+      // Create a New HttpClient object and dispose it when done, so the app doesn't leak resources
+      using (HttpClient client = new HttpClient())
       {
-         HttpResponseMessage response = await client.GetAsync("http://www.contoso.com/");
-         response.EnsureSuccessStatusCode();
-         string responseBody = await response.Content.ReadAsStringAsync();
-         // Above three lines can be replaced with new helper method below
-         // string responseBody = await client.GetStringAsync(uri);
+         // Call asynchronous network methods in a try/catch block to handle exceptions
+         try	
+         {
+            HttpResponseMessage response = await client.GetAsync("http://www.contoso.com/");
+            response.EnsureSuccessStatusCode();
+            string responseBody = await response.Content.ReadAsStringAsync();
+            // Above three lines can be replaced with new helper method below
+            // string responseBody = await client.GetStringAsync(uri);
 
-         Console.WriteLine(responseBody);
-      }  
-      catch(HttpRequestException e)
-      {
-         Console.WriteLine("\nException Caught!");	
-         Console.WriteLine("Message :{0} ",e.Message);
+            Console.WriteLine(responseBody);
+         }  
+         catch(HttpRequestException e)
+         {
+            Console.WriteLine("\nException Caught!");	
+            Console.WriteLine("Message :{0} ",e.Message);
+         }
       }
-
-      // Need to call dispose on the HttpClient object
-      // when done using it, so the app doesn't leak resources
-      client.Dispose(true);
    }
 // </Snippet1>			
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-api-docs/issues/1045.

Also switches from explicitly calling `Dispose` to `using`, because I think that's a better practice.

In the process of testing this change, I used the following csproj:

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFrameworks>net45;netcoreapp1.0</TargetFrameworks>
    <LangVersion>7.1</LangVersion>
  </PropertyGroup>

  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
    <Reference Include="System.Net.Http" />
  </ItemGroup>

</Project>
```

Would it be useful if I included it in this PR?