### PR TITLE
fixes dotnet/docs#8941

### DIFF
--- a/snippets/csharp/programming-guide/classes-and-structs/properties-1.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/properties-1.cs
@@ -2,17 +2,17 @@ using System;
 
 class TimePeriod
 {
-   private double seconds;
+   private double _seconds;
 
    public double Hours
    {
-       get { return seconds / 3600; }
+       get { return _seconds / 3600; }
        set { 
           if (value < 0 || value > 24)
              throw new ArgumentOutOfRangeException(
                    $"{nameof(value)} must be between 0 and 24.");
 
-          seconds = value * 3600; 
+          _seconds = value * 3600; 
        }
    }
 }

--- a/snippets/csharp/programming-guide/classes-and-structs/properties-2.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/properties-2.cs
@@ -2,16 +2,16 @@ using System;
 
 public class Person
 {
-   private string firstName;
-   private string lastName;
+   private string _firstName;
+   private string _lastName;
    
    public Person(string first, string last)
    {
-      firstName = first;
-      lastName = last;
+      _firstName = first;
+      _lastName = last;
    }
 
-   public string Name => $"{firstName} {lastName}";   
+   public string Name => $"{_firstName} {_lastName}";   
 }
 
 public class Example

--- a/snippets/csharp/programming-guide/classes-and-structs/properties-3.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/properties-3.cs
@@ -2,25 +2,25 @@ using System;
 
 public class SaleItem
 {
-   string name;
-   decimal cost;
+   string _name;
+   decimal _cost;
    
    public SaleItem(string name, decimal cost)
    {
-      this.name = name;
-      this.cost = cost;
+      _name = name;
+      _cost = cost;
    }
 
    public string Name 
    {
-      get => name;
-      set => name = value;
+      get => _name;
+      set => _name = value;
    }
 
    public decimal Price
    {
-      get => cost;
-      set => cost = value; 
+      get => _cost;
+      set => _cost = value; 
    }
 }
 


### PR DESCRIPTION
## Summary

This change updates the backing fields on the properties documentation page samples to use an `_` so it's easier to differentiate between the actual property and its backing field.

Since the name of the backing fields in the third sample are now different, the `this.` qualifier can be removed.

Fixes dotnet/docs#8941
