### PR TITLE
Fixed typo

### DIFF
--- a/snippets/cpp/VS_Snippets_Winforms/TreeNode_ForeColor/CPP/treenode_forecolor.cpp
+++ b/snippets/cpp/VS_Snippets_Winforms/TreeNode_ForeColor/CPP/treenode_forecolor.cpp
@@ -82,7 +82,7 @@ public:
 private:
    void FillMyTreeView()
    {
-      
+
       // Add customers to the ArrayList of 'Customer' objects.
       for ( int iIndex = 1; iIndex <= 10; iIndex++ )
       {
@@ -100,15 +100,15 @@ private:
          }
       }
 
-      
+
       // Suppress repainting the TreeView until it is fully created.
       myTreeView->BeginUpdate();
-      
+
       // Clear the TreeView each time the method is called.
       myTreeView->Nodes->Clear();
       TreeNode^ myMainNode = gcnew TreeNode( "CustomerList" );
       myTreeView->Nodes->Add( myMainNode );
-      
+
       // Add a root treenode for each 'Customer' in the ArrayList.
       while ( myEnum->MoveNext() )
       {
@@ -116,7 +116,7 @@ private:
          TreeNode^ myTreeNode1 = gcnew TreeNode( myCustomer2->CustomerName );
          myTreeNode1->ForeColor = Color::Orange;
          myTreeView->Nodes[ 0 ]->Nodes->Add( myTreeNode1 );
-         
+
          // Add a child for each 'Order' in the current 'Customer'.
          IEnumerator^ myEnum = myCustomer2->CustomerOrders->GetEnumerator();
          while ( myEnum->MoveNext() )
@@ -126,10 +126,10 @@ private:
          }
       }
 
-      
+
       // Reset the cursor back to the default for all controls.
       ::Cursor::Current = Cursors::Default;
-      
+
       // Begin repainting the TreeView.
       myTreeView->EndUpdate();
       if ( myTreeView->Nodes[ 0 ]->IsExpanded == false )
@@ -194,7 +194,7 @@ private:
    // <Snippet1>
    void myCheckBox_CheckedChanged( Object^ /*sender*/, System::EventArgs^ /*e*/ )
    {
-      
+
       // If the check box is checked, expand all the tree nodes.
       if ( myCheckBox->Checked == true )
       {
@@ -202,10 +202,10 @@ private:
       }
       else
       {
-         
-         // If the check box is not cheked, collapse the first tree node.
+
+         // If the check box is not checked, collapse the first tree node.
          myTreeView->Nodes[ 0 ]->FirstNode->Collapse();
-         MessageBox::Show( "The first and last  node of CutomerList root node is collapsed" );
+         MessageBox::Show( "The first node of CustomerList root node is collapsed" );
       }
    }
    // </Snippet1>
@@ -213,14 +213,14 @@ private:
    // <Snippet2>
    void myButton_Click( Object^ /*sender*/, System::EventArgs^ /*e*/ )
    {
-      
+
       // Set the tree view's PathSeparator property.
       myTreeView->PathSeparator = ".";
-      
+
       // Get the count of the child tree nodes contained in the SelectedNode.
       int myNodeCount = myTreeView->SelectedNode->GetNodeCount( true );
       Decimal myChildPercentage = ((Decimal)myNodeCount / (Decimal)myTreeView->GetNodeCount( true )) * 100;
-      
+
       // Display the tree node path and the number of child nodes it and the tree view have.
       MessageBox::Show( String::Concat( "The '", myTreeView->SelectedNode->FullPath, "' node has ", myNodeCount, " child nodes.\nThat is ", String::Format( "{0:###.##}", myChildPercentage ), "% of the total tree nodes in the tree view control." ) );
    }
@@ -258,13 +258,13 @@ private:
             array<Char>^temp3 = {'@','->',',','!'};
             if ( e->Label->IndexOfAny( temp3 ) == -1 )
             {
-               
+
                // Stop editing without cancelling the label change.
                e->Node->EndEdit( false );
             }
             else
             {
-               
+
                // Cancel the label edit action, place it in edit mode.
                e->CancelEdit = true;
                MessageBox::Show( "Invalid tree node label.\n The invalid characters are: '@', '.', ', ', '!'", "Node Label Edit" );
@@ -273,7 +273,7 @@ private:
          }
          else
          {
-            
+
             // Cancel the label edit action, place it in edit mode.
             e->CancelEdit = true;
             MessageBox::Show( "Invalid tree node label. The label cannot be blank", "Node Label Edit" );

--- a/snippets/csharp/VS_Snippets_Winforms/TreeNode_ForeColor/CS/treenode_forecolor.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/TreeNode_ForeColor/CS/treenode_forecolor.cs
@@ -179,9 +179,9 @@ private void myCheckBox_CheckedChanged(object sender, System.EventArgs e)
    }
    else
    {
-      // If the check box is not cheked, collapse the first tree node.
+      // If the check box is not checked, collapse the first tree node.
       myTreeView.Nodes[0].FirstNode.Collapse();
-      MessageBox.Show("The first and last  node of CutomerList root node is collapsed");
+      MessageBox.Show("The first node of CustomerList root node is collapsed");
    }
 }
 // </Snippet1>
@@ -198,9 +198,9 @@ private void myButton_Click(object sender, System.EventArgs e)
      (decimal)myTreeView.GetNodeCount(true)) * 100;
 
    // Display the tree node path and the number of child nodes it and the tree view have.
-   MessageBox.Show("The '" + myTreeView.SelectedNode.FullPath + "' node has " 
-     + myNodeCount.ToString() + " child nodes.\nThat is " 
-     + string.Format("{0:###.##}", myChildPercentage) 
+   MessageBox.Show("The '" + myTreeView.SelectedNode.FullPath + "' node has "
+     + myNodeCount.ToString() + " child nodes.\nThat is "
+     + string.Format("{0:###.##}", myChildPercentage)
      + "% of the total tree nodes in the tree view control.");
 }
 // </Snippet2>

--- a/snippets/visualbasic/VS_Snippets_Winforms/TreeNode_ForeColor/VB/treenode_forecolor.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/TreeNode_ForeColor/VB/treenode_forecolor.vb
@@ -39,17 +39,17 @@ Public Class MyTreeNode_FirstNode
    Private WithEvents myContextMenu As ContextMenu
    Private WithEvents myMenuItem As MenuItem
    Private mySelectedNode As TreeNode
-   
-   
+
+
    Public Sub New()
       InitializeComponent()
       FillMyTreeView()
    End Sub 'New
-   
+
    ' ArrayList object to hold the 'Customer' objects.
    Private myCustomerArrayList As New ArrayList()
-   
-   
+
+
    Private Sub FillMyTreeView()
       ' Add customers to the ArrayList of 'Customer' objects.
       Dim iIndex As Integer
@@ -64,14 +64,14 @@ Public Class MyTreeNode_FirstNode
             myCustomer1.CustomerOrders.Add(New Order("Order" + jIndex.ToString()))
          Next jIndex
       Next myCustomer1
-      
+
       ' Suppress repainting the TreeView until it is fully created.
       myTreeView.BeginUpdate()
       ' Clear the TreeView each time the method is called.
       myTreeView.Nodes.Clear()
       Dim myMainNode As New TreeNode("CustomerList")
       myTreeView.Nodes.Add(myMainNode)
-      
+
       ' Add a root treenode for each 'Customer' in the ArrayList.
       Dim myCustomer2 As Customer
       For Each myCustomer2 In  myCustomerArrayList
@@ -84,7 +84,7 @@ Public Class MyTreeNode_FirstNode
             myTreeView.Nodes(0).Nodes(myCustomerArrayList.IndexOf(myCustomer2)).Nodes.Add(New TreeNode(myOrder1.OrderID))
          Next myOrder1
       Next myCustomer2
-      
+
       ' Reset the cursor back to the default for all controls.
       Cursor.Current = Cursors.Default
       ' Begin repainting the TreeView.
@@ -93,7 +93,7 @@ Public Class MyTreeNode_FirstNode
          myTreeView.Nodes(0).Expand()
       End If
    End Sub 'FillMyTreeView
-    
+
    Private Sub InitializeComponent()
       Me.myMenuItem = New MenuItem()
       Me.myCheckBox = New CheckBox()
@@ -104,22 +104,22 @@ Public Class MyTreeNode_FirstNode
       Me.myGroupBox = New GroupBox()
       Me.myGroupBox.SuspendLayout()
       Me.SuspendLayout()
-      
+
       Me.myMenuItem.Checked = True
       Me.myMenuItem.DefaultItem = True
       Me.myMenuItem.Index = 0
       Me.myMenuItem.Text = "Edit"
-      
+
       Me.myCheckBox.Location = New System.Drawing.Point(24, 24)
       Me.myCheckBox.Name = "myCheckBox"
       Me.myCheckBox.TabIndex = 0
       Me.myCheckBox.Text = "Expand All"
-      
+
       Me.myButton.Location = New System.Drawing.Point(136, 24)
       Me.myButton.Name = "myCheckBox2"
       Me.myButton.TabIndex = 1
       Me.myButton.Text = "Child Nodes"
-      
+
       Me.myTreeView.ContextMenu = Me.myContextMenu
       Me.myTreeView.ImageIndex = - 1
       Me.myTreeView.LabelEdit = True
@@ -128,10 +128,10 @@ Public Class MyTreeNode_FirstNode
       Me.myTreeView.SelectedImageIndex = - 1
       Me.myTreeView.Size = New System.Drawing.Size(280, 152)
       Me.myTreeView.TabIndex = 0
-      
+
       Me.myContextMenu.MenuItems.AddRange(New MenuItem() {Me.myMenuItem})
-      
-      
+
+
       Me.myGroupBox.Controls.AddRange(New Control() {Me.myButton, Me.myCheckBox})
       Me.myGroupBox.Location = New System.Drawing.Point(8, 168)
       Me.myGroupBox.Name = "myGroupBox"
@@ -139,7 +139,7 @@ Public Class MyTreeNode_FirstNode
       Me.myGroupBox.TabIndex = 1
       Me.myGroupBox.TabStop = False
       Me.myGroupBox.Text = "myGroupBox"
-      
+
       Me.ClientSize = New System.Drawing.Size(292, 273)
       Me.Controls.AddRange(New Control() {Me.myGroupBox, Me.myTreeView})
       Me.Name = "Form1"
@@ -147,13 +147,13 @@ Public Class MyTreeNode_FirstNode
       Me.myGroupBox.ResumeLayout(False)
       Me.ResumeLayout(False)
    End Sub 'InitializeComponent
-    
-   
+
+
    Shared Sub Main()
       Application.Run(New MyTreeNode_FirstNode())
    End Sub 'Main
-   
-   
+
+
 ' <Snippet1>
 Private Sub myCheckBox_CheckedChanged(ByVal sender As Object, _
    ByVal e As System.EventArgs) Handles myCheckBox.CheckedChanged
@@ -161,9 +161,9 @@ Private Sub myCheckBox_CheckedChanged(ByVal sender As Object, _
    If myCheckBox.Checked = True Then
       myTreeView.ExpandAll()
    Else
-      ' If the check box is not cheked, collapse the first tree node.
+      ' If the check box is not checked, collapse the first tree node.
       myTreeView.Nodes(0).FirstNode.Collapse()
-      MessageBox.Show("The first and last node of CutomerList root node is collapsed")
+      MessageBox.Show("The first node of CustomerList root node is collapsed")
    End If
 End Sub
 ' </Snippet1>
@@ -239,18 +239,18 @@ End Class 'MyTreeNode_FirstNode
 Public Class Customer
    Public CustomerOrders As ArrayList
    Public CustomerName As String
-   
+
    Public Sub New(myName As String)
       CustomerName = myName
       CustomerOrders = New ArrayList()
    End Sub 'New
 End Class 'Customer
- 
+
 
 
 Public Class Order
    Public OrderID As String
-   
+
    Public Sub New(myOrderID As String)
       Me.OrderID = myOrderID
    End Sub 'New


### PR DESCRIPTION
## Summary
Fixed typos mentioned in <a href="https://github.com/dotnet/dotnet-api-docs/issues/1370">#1370</a>

### Describe your changes here.
Changed typo "cheked" to "checked"
Change printout from "The first and last node of CutomerList root node is collapsed"
to "The first node of CustomerList root node is collapsed"