### PR TITLE
Format the code. We use Allman style braces, where each brace begins …

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/Classic BrowsableAttribute Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/Classic BrowsableAttribute Example/CS/source.cs
@@ -3,53 +3,64 @@ using System.Data;
 using System.ComponentModel;
 using System.Windows.Forms;
 
-public class Form1: Form
+public class Form1 : Form
 {
-// <Snippet1>
-[Browsable(true)]
- public int MyProperty {
-    get {
-       // Insert code here.
-       return 0;
-    }
-    set {
-       // Insert code here.
-    }
- }
-   // </Snippet1>
- public int MyProperty2 {
-    get {
-        // <Snippet2>
-        // Gets the attributes for the property.
-         AttributeCollection attributes = 
-            TypeDescriptor.GetProperties(this)["MyProperty"].Attributes;
-         
-         // Checks to see if the value of the BrowsableAttribute is Yes.
-         if(attributes[typeof(BrowsableAttribute)].Equals(BrowsableAttribute.Yes)) {
+    // <Snippet1>
+    [Browsable(true)]
+    public int MyProperty
+    {
+        get
+        {
             // Insert code here.
-         }
-         
-         // This is another way to see whether the property is browsable.
-         BrowsableAttribute myAttribute = 
-            (BrowsableAttribute)attributes[typeof(BrowsableAttribute)];
-         if(myAttribute.Browsable) {
+            return 0;
+        }
+        set
+        {
             // Insert code here.
-         }
-        // </Snippet2>
-       return 0;
-    }
+        }
     }
 
- public int MyProperty3 {
-    get {
-        // <Snippet3>
-        AttributeCollection attributes = 
-            TypeDescriptor.GetAttributes(MyProperty);
-         if(attributes[typeof(BrowsableAttribute)].Equals(BrowsableAttribute.Yes)) {
-            // Insert code here.
-         }
-        // </Snippet3>
-        return 0;
+    // </Snippet1>
+    public int MyProperty2
+    {
+        get
+        {
+            // <Snippet2>
+            // Gets the attributes for the property.
+            AttributeCollection attributes =
+               TypeDescriptor.GetProperties(this)["MyProperty"].Attributes;
+
+            // Checks to see if the value of the BrowsableAttribute is Yes.
+            if (attributes[typeof(BrowsableAttribute)].Equals(BrowsableAttribute.Yes))
+            {
+                // Insert code here.
+            }
+
+            // This is another way to see whether the property is browsable.
+            BrowsableAttribute myAttribute =
+               (BrowsableAttribute)attributes[typeof(BrowsableAttribute)];
+            if (myAttribute.Browsable)
+            {
+                // Insert code here.
+            }
+            // </Snippet2>
+            return 0;
+        }
+    }
+
+    public int MyProperty3
+    {
+        get
+        {
+            // <Snippet3>
+            AttributeCollection attributes =
+                TypeDescriptor.GetAttributes(MyProperty);
+            if (attributes[typeof(BrowsableAttribute)].Equals(BrowsableAttribute.Yes))
+            {
+                // Insert code here.
+            }
+            // </Snippet3>
+            return 0;
         }
     }
 }


### PR DESCRIPTION
## Summary

Format the code.

In [corefx/coding-style.md at master · dotnet/corefx](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md ) NO.1, we use Allman style braces, where each brace begins on a new line. A single line statement block can go without braces but the block must be properly indented on its own line and must not be nested in other statement blocks that use braces (See issue 381 for examples). One exception is that a using statement is permitted to be nested within another using statement by starting on the following line at the same indentation level, even if the nested using contains a controlled block. 