### PR TITLE
Use async Task Main and await task

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.threading.tasks.task.run/cs/run4.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.threading.tasks.task.run/cs/run4.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 public class Example
 {
-   public static void Main()
+   public static async Task Main()
    {
       var tokenSource = new CancellationTokenSource();
       var token = tokenSource.Token;
@@ -30,9 +30,10 @@ public class Example
                                  }
                               }
                         , token);
+      await Task.Yield();
       tokenSource.Cancel();
       try {
-         t.Wait(); 
+         await t;
          Console.WriteLine("Retrieved information for {0} files.", files.Count);
       }
       catch (AggregateException e) {
@@ -50,6 +51,8 @@ public class Example
 // The example displays the following output:
 //       Exception messages:
 //          TaskCanceledException: A task was canceled.
+//          TaskCanceledException: A task was canceled.
+//          ...
 //       
 //       Task status: Canceled
 // </Snippet4>


### PR DESCRIPTION
Without `await Task.Delay()`, the task would throw `TaskCanceledException`, but this seems to be caused by the task being not allocated time slices, not by `ThrowIfCancellationRequested`.

Fixes https://github.com/dotnet/dotnet-api-docs/issues/1341

And I have another question. Why the sample code in [docs.microsoft.com](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.-ctor?view=netframework-4.7.2#System_Threading_Tasks_Task__ctor_System_Action_System_Threading_CancellationToken_) is different from source file:question: It is already `async Task Main`.

![50041695-d5e11000-0093-11e9-8e2d-a39cfc465e58](https://user-images.githubusercontent.com/24759802/50042084-d54b7800-0099-11e9-8020-48523f8bd7fd.png)
