### PR TITLE
Fix example word

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.string.equals/cs/equalsex1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.string.equals/cs/equalsex1.cs
@@ -7,7 +7,7 @@ public class Example
    {
       Console.OutputEncoding = System.Text.Encoding.UTF8;
       string word = "File";
-      string[] others = { word.ToLower(), word, word.ToUpper(), "fıle" };
+      string[] others = { word.ToLower(), word, word.ToUpper(), "Fıle" };
       foreach (string other in others)
       {
          if (word.Equals(other)) 
@@ -21,6 +21,6 @@ public class Example
 //       File ≠ file
 //       File = File
 //       File ≠ FILE
-//       File ≠ fıle
+//       File ≠ Fıle
 // </Snippet2>
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.string.equals/vb/equalsex1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.string.equals/vb/equalsex1.vb
@@ -7,7 +7,7 @@ Module Example
       
       Dim word As String = "File"
       Dim others() As String = { word.ToLower(), word, word.ToUpper(), _
-                                 "fıle" }
+                                 "Fıle" }
       For Each other As String In others
          If word.Equals(other) Then 
             Console.WriteLine("{0} = {1}", word, other)
@@ -21,6 +21,6 @@ End Module
 '       File ≠ file
 '       File = File
 '       File ≠ FILE
-'       File ≠ fıle
+'       File ≠ Fıle
 ' </Snippet2>
 


### PR DESCRIPTION
## Summary

In the example the title-cased word "File" is compared with an equivalent word, its lowercase equivalent, its uppercase equivalent, and the word "fıle" (LATIN SMALL LETTER DOTLESS I (U+0131) instead of LATIN SMALL LETTER I (U+0069).  The comparison of "File" and "fıle" will already fail because of the case of the letter "F".

Hereby the lowercase "f" in the word "fıle" is changed to uppercase "F".

Fixes dotnet/dotnet-api-docs#1291
