### PR TITLE
Make it clear that overridden methods may be overriden again

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -46,7 +46,17 @@ namespace csrefKeywordsModifiers
         }
         //</snippet2>
 
+    class More_Square : Square
+    {
+        // Area method is overridden again to show
+        // it is possible to override the virtual method
+        // in derived classes.
+        public override int Area()
+        {
+            return side * side;
+        }
     }
+    
     // Output: Area of the square = 144
     //</snippet1>
 

--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -46,14 +46,14 @@ namespace csrefKeywordsModifiers
         }
         //</snippet2>
 
-    class More_Square : Square
+    class Cube : Square
     {
         // Area method is overridden again to show
         // it is possible to override the virtual method
         // in derived classes.
         public override int Area()
         {
-            return side * side;
+            return 6 * side * side;
         }
     }
     


### PR DESCRIPTION
To make it clear why the 'override' word used in "virtual, abstract, or override" phrases in the text.

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
