### PR TITLE
Code changes requested in https://github.com/dotnet/docs/pull/10001

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/IO.Compression.GZip1/CS/gziptest.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.Compression.GZip1/CS/gziptest.cs
@@ -35,9 +35,8 @@ public class Program
 
                         }
                     }
-                    FileInfo info = new FileInfo(directoryPath + "\\" + fileToCompress.Name + ".gz");
-                    Console.WriteLine("Compressed {0} from {1} to {2} bytes.",
-                    fileToCompress.Name, fileToCompress.Length.ToString(), info.Length.ToString());
+                    FileInfo info = new FileInfo(directoryPath + Path.DirectorySeparatorChar + fileToCompress.Name + ".gz");
+                    Console.WriteLine($"Compressed {fileToCompress.Name} from {fileToCompress.Length.ToString()} to {info.Length.ToString()} bytes.");
                 }
 
             }

--- a/snippets/csharp/VS_Snippets_CLR/IO.Compression.GZip1/CS/gziptest.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.Compression.GZip1/CS/gziptest.cs
@@ -55,7 +55,7 @@ public class Program
                 using (GZipStream decompressionStream = new GZipStream(originalFileStream, CompressionMode.Decompress))
                 {
                     decompressionStream.CopyTo(decompressedFileStream);
-                    Console.WriteLine("Decompressed: {0}", fileToDecompress.Name);
+                    Console.WriteLine($"Decompressed: {fileToDecompress.Name}");
                 }
             }
         }

--- a/snippets/csharp/VS_Snippets_CLR/IO.Compression.GZip1/CS/gziptest.cs
+++ b/snippets/csharp/VS_Snippets_CLR/IO.Compression.GZip1/CS/gziptest.cs
@@ -3,63 +3,60 @@ using System;
 using System.IO;
 using System.IO.Compression;
 
-namespace zip
+public class Program
 {
-    public class Program
+    private static string directoryPath = @".\temp";
+    public static void Main()
     {
-        private static string directoryPath = @"c:\temp";
-        public static void Main()
-        {
-            DirectoryInfo directorySelected = new DirectoryInfo(directoryPath);
-            Compress(directorySelected);
+        DirectoryInfo directorySelected = new DirectoryInfo(directoryPath);
+        Compress(directorySelected);
 
-            foreach (FileInfo fileToDecompress in directorySelected.GetFiles("*.gz"))
-            {
-                Decompress(fileToDecompress);
-            }
+        foreach (FileInfo fileToDecompress in directorySelected.GetFiles("*.gz"))
+        {
+            Decompress(fileToDecompress);
         }
+    }
 
-        public static void Compress(DirectoryInfo directorySelected)
+    public static void Compress(DirectoryInfo directorySelected)
+    {
+        foreach (FileInfo fileToCompress in directorySelected.GetFiles())
         {
-            foreach (FileInfo fileToCompress in directorySelected.GetFiles())
+            using (FileStream originalFileStream = fileToCompress.OpenRead())
             {
-                using (FileStream originalFileStream = fileToCompress.OpenRead())
+                if ((File.GetAttributes(fileToCompress.FullName) & 
+                   FileAttributes.Hidden) != FileAttributes.Hidden & fileToCompress.Extension != ".gz")
                 {
-                    if ((File.GetAttributes(fileToCompress.FullName) & 
-                       FileAttributes.Hidden) != FileAttributes.Hidden & fileToCompress.Extension != ".gz")
+                    using (FileStream compressedFileStream = File.Create(fileToCompress.FullName + ".gz"))
                     {
-                        using (FileStream compressedFileStream = File.Create(fileToCompress.FullName + ".gz"))
+                        using (GZipStream compressionStream = new GZipStream(compressedFileStream, 
+                           CompressionMode.Compress))
                         {
-                            using (GZipStream compressionStream = new GZipStream(compressedFileStream, 
-                               CompressionMode.Compress))
-                            {
-                                originalFileStream.CopyTo(compressionStream);
+                            originalFileStream.CopyTo(compressionStream);
 
-                            }
                         }
-                        FileInfo info = new FileInfo(directoryPath + "\\" + fileToCompress.Name + ".gz");
-                        Console.WriteLine("Compressed {0} from {1} to {2} bytes.",
-                        fileToCompress.Name, fileToCompress.Length.ToString(), info.Length.ToString());
                     }
-
+                    FileInfo info = new FileInfo(directoryPath + "\\" + fileToCompress.Name + ".gz");
+                    Console.WriteLine("Compressed {0} from {1} to {2} bytes.",
+                    fileToCompress.Name, fileToCompress.Length.ToString(), info.Length.ToString());
                 }
+
             }
         }
+    }
 
-        public static void Decompress(FileInfo fileToDecompress)
+    public static void Decompress(FileInfo fileToDecompress)
+    {
+        using (FileStream originalFileStream = fileToDecompress.OpenRead())
         {
-            using (FileStream originalFileStream = fileToDecompress.OpenRead())
-            {
-                string currentFileName = fileToDecompress.FullName;
-                string newFileName = currentFileName.Remove(currentFileName.Length - fileToDecompress.Extension.Length);
+            string currentFileName = fileToDecompress.FullName;
+            string newFileName = currentFileName.Remove(currentFileName.Length - fileToDecompress.Extension.Length);
 
-                using (FileStream decompressedFileStream = File.Create(newFileName))
+            using (FileStream decompressedFileStream = File.Create(newFileName))
+            {
+                using (GZipStream decompressionStream = new GZipStream(originalFileStream, CompressionMode.Decompress))
                 {
-                    using (GZipStream decompressionStream = new GZipStream(originalFileStream, CompressionMode.Decompress))
-                    {
-                        decompressionStream.CopyTo(decompressedFileStream);
-                        Console.WriteLine("Decompressed: {0}", fileToDecompress.Name);
-                    }
+                    decompressionStream.CopyTo(decompressedFileStream);
+                    Console.WriteLine("Decompressed: {0}", fileToDecompress.Name);
                 }
             }
         }

--- a/snippets/csharp/VS_Snippets_CLR_System/system.io.compression.ziparchive/cs/program1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.io.compression.ziparchive/cs/program1.cs
@@ -3,41 +3,38 @@ using System;
 using System.IO;
 using System.IO.Compression;
 
-namespace ConsoleApplication1
+class Program
 {
-    class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
+        string zipPath = @".\result.zip";
+
+        Console.WriteLine("Provide path where to extract the zip file:");
+        string extractPath = Console.ReadLine();
+
+        // Normalizes the path.
+        extractPath = Path.GetFullPath(extractPath);
+
+        // Ensures that the last character on the extraction path
+        // is the directory separator char. 
+        // Without this, a malicious zip file could try to traverse outside of the expected
+        // extraction path.
+        if (!extractPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            extractPath += Path.DirectorySeparatorChar;
+
+        using (ZipArchive archive = ZipFile.OpenRead(zipPath))
         {
-            string zipPath = @"c:\example\start.zip";
-
-            Console.WriteLine("Provide path where to extract the zip file:");
-            string extractPath = Console.ReadLine();
-            
-            // Normalizes the path.
-            extractPath = Path.GetFullPath(extractPath);
-
-            // Ensures that the last character on the extraction path
-            // is the directory separator char. 
-            // Without this, a malicious zip file could try to traverse outside of the expected
-            // extraction path.
-            if (!extractPath.EndsWith(Path.DirectorySeparatorChar))
-                extractPath += Path.DirectorySeparatorChar;
-
-            using (ZipArchive archive = ZipFile.OpenRead(zipPath))
+            foreach (ZipArchiveEntry entry in archive.Entries)
             {
-                foreach (ZipArchiveEntry entry in archive.Entries)
+                if (entry.FullName.EndsWith(".txt", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (entry.FullName.EndsWith(".txt", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Gets the full path to ensure that relative segments are removed.
-                        string destinationPath = Path.GetFullPath(Path.Combine(extractPath, entry.FullName));
- 
-                        // Ordinal match is safest, case-sensitive volumes can be mounted within volumes that
-                        // are case-insensitive.
-                        if (destinationPath.StartsWith(extractPath, StringComparison.Ordinal))
-                            entry.ExtractToFile(destinationPath);                        
-                    }
+                    // Gets the full path to ensure that relative segments are removed.
+                    string destinationPath = Path.GetFullPath(Path.Combine(extractPath, entry.FullName));
+
+                    // Ordinal match is safest, case-sensitive volumes can be mounted within volumes that
+                    // are case-insensitive.
+                    if (destinationPath.StartsWith(extractPath, StringComparison.Ordinal))
+                        entry.ExtractToFile(destinationPath);
                 }
             }
         }

--- a/snippets/csharp/VS_Snippets_CLR_System/system.io.compression.ziparchive/cs/program1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.io.compression.ziparchive/cs/program1.cs
@@ -19,7 +19,7 @@ class Program
         // is the directory separator char. 
         // Without this, a malicious zip file could try to traverse outside of the expected
         // extraction path.
-        if (!extractPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+        if (!extractPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
             extractPath += Path.DirectorySeparatorChar;
 
         using (ZipArchive archive = ZipFile.OpenRead(zipPath))

--- a/snippets/csharp/VS_Snippets_CLR_System/system.io.compression.zipfile/cs/program1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.io.compression.zipfile/cs/program1.cs
@@ -1,22 +1,18 @@
 // <snippet1>
 using System;
-using System.IO;
 using System.IO.Compression;
 
-namespace ConsoleApplication
+class Program
 {
-    class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            string startPath = @"c:\example\start";
-            string zipPath = @"c:\example\result.zip";
-            string extractPath = @"c:\example\extract";
+        string startPath = @".\start";
+        string zipPath = @".\result.zip";
+        string extractPath = @".\extract";
 
-            ZipFile.CreateFromDirectory(startPath, zipPath);
+        ZipFile.CreateFromDirectory(startPath, zipPath);
 
-            ZipFile.ExtractToDirectory(zipPath, extractPath);
-        }
+        ZipFile.ExtractToDirectory(zipPath, extractPath);
     }
 }
 // </snippet1>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/cs/mainpage.xaml.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/cs/mainpage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//<snippetImports>
+﻿// <snippetImports>
 using System;
 using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -8,87 +8,77 @@ using Windows.UI.Xaml.Media.Imaging;
 using Windows.Storage;
 using System.Net.Http;
 using Windows.Storage.Pickers;
-//</snippetImports>
+// </snippetImports>
 
-namespace TextFile
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class MainPage : Page
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class MainPage : Page
+    public MainPage()
     {
-        public MainPage()
-        {
-            this.InitializeComponent();
-        }
-
-
-        //<snippet1>
-        private async void button1_Click(object sender, RoutedEventArgs e)
-        {
-            // Create a file picker.
-            FileOpenPicker picker = new FileOpenPicker();
-
-            // Set properties on the file picker such as start location and the type
-            // of files to display.
-            picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
-            picker.ViewMode = PickerViewMode.List;
-            picker.FileTypeFilter.Add(".txt");
-
-            // Show picker enabling user to pick one file.
-            StorageFile result = await picker.PickSingleFileAsync();
-
-            if (result != null)
-            {
-                try
-                {
-                    // Retrieve the stream. This method returns a IRandomAccessStreamWithContentType.
-                    var stream = await result.OpenReadAsync();
-
-                    // Convert the stream to a .NET stream using AsStream, pass to a 
-                    // StreamReader and read the stream.
-                    using (StreamReader sr = new StreamReader(stream.AsStream()))
-                    {
-                        TextBlock1.Text = sr.ReadToEnd();
-                    }
-                }
-                catch (Exception ex)
-                {
-                    TextBlock1.Text = "Error occurred reading the file. " + ex.Message;
-                }
-            }
-            else
-            {
-                TextBlock1.Text = "User did not pick a file";
-            }
-        }
-        //</snippet1>
-
-        //<snippet2>
-        private async void button2_Click(object sender, RoutedEventArgs e)
-        {
-
-            // Create an HttpClient and access an image as a stream.
-            var client = new HttpClient();
-            Stream stream = await client.GetStreamAsync("https://docs.microsoft.com/en-us/dotnet/images/hub/featured-1.png");
-            // Create a .NET memory stream.
-            var memStream = new MemoryStream();
-
-            // Convert the stream to the memory stream, because a memory stream supports seeking.
-            await stream.CopyToAsync(memStream);
-
-            // Set the start position.
-            memStream.Position = 0;
-
-            // Create a new bitmap image.
-            var bitmap = new BitmapImage();
-
-            // Set the bitmap source to the stream, which is converted to a IRandomAccessStream.
-            bitmap.SetSource(memStream.AsRandomAccessStream());
-
-            // Set the image control source to the bitmap.
-            image1.Source = bitmap;
-        }
-        //</snippet2>
+        this.InitializeComponent();
     }
+
+ // <snippet1>
+        private async void button1_Click(object sender, RoutedEventArgs e)
+    {
+        // Create a file picker.
+        FileOpenPicker picker = new FileOpenPicker();
+
+        // Set properties on the file picker such as start location and the type
+        // of files to display.
+        picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        picker.ViewMode = PickerViewMode.List;
+        picker.FileTypeFilter.Add(".txt");
+
+        // Show picker enabling user to pick one file.
+        StorageFile result = await picker.PickSingleFileAsync();
+
+        if (result != null)
+        {
+            try
+            {
+                // Retrieve the stream. This method returns a IRandomAccessStreamWithContentType.
+                var stream = await result.OpenReadAsync();
+
+                // Convert the stream to a .NET stream using AsStream, pass to a 
+                // StreamReader and read the stream.
+                using (StreamReader sr = new StreamReader(stream.AsStream()))
+                {
+                    TextBlock1.Text = sr.ReadToEnd();
+                }
+            }
+            catch (Exception ex)
+            {
+                TextBlock1.Text = "Error occurred reading the file. " + ex.Message;
+            }
+        }
+        else
+        {
+            TextBlock1.Text = "User did not pick a file";
+        }
+    }
+    // </snippet1>
+
+    // <snippet2>
+    private async void button2_Click(object sender, RoutedEventArgs e)
+    {
+         // Create an HttpClient and access an image as a stream.
+        var client = new HttpClient();
+        Stream stream = await client.GetStreamAsync("https://docs.microsoft.com/en-us/dotnet/images/hub/featured-1.png");
+        // Create a .NET memory stream.
+        var memStream = new MemoryStream();
+         // Convert the stream to the memory stream, because a memory stream supports seeking.
+        await stream.CopyToAsync(memStream);
+         // Set the start position.
+        memStream.Position = 0;
+         // Create a new bitmap image.
+        var bitmap = new BitmapImage();
+         // Set the bitmap source to the stream, which is converted to a IRandomAccessStream.
+        bitmap.SetSource(memStream.AsRandomAccessStream());
+         // Set the image control source to the bitmap.
+        image1.Source = bitmap;
+    }
+    // </snippet2>
 }

--- a/snippets/csharp/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/cs/mainpage1.xaml.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/cs/mainpage1.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+using Windows.Storage;
+using System.Net.Http;
+using Windows.Storage.Pickers;
+
+private async void button1_Click(object sender, RoutedEventArgs e)
+{
+    // Create a file picker.
+    FileOpenPicker picker = new FileOpenPicker();
+
+    // Set properties on the file picker such as start location and the type
+    // of files to display.
+    picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+    picker.ViewMode = PickerViewMode.List;
+    picker.FileTypeFilter.Add(".txt");
+
+    // Show picker enabling user to pick one file.
+    StorageFile result = await picker.PickSingleFileAsync();
+
+    if (result != null)
+    {
+        try
+        {
+            // Retrieve the stream. This method returns a IRandomAccessStreamWithContentType.
+            var stream = await result.OpenReadAsync();
+
+            // Convert the stream to a .NET stream using AsStream, pass to a 
+            // StreamReader and read the stream.
+            using (StreamReader sr = new StreamReader(stream.AsStream()))
+            {
+                TextBlock1.Text = sr.ReadToEnd();
+            }
+        }
+        catch (Exception ex)
+        {
+            TextBlock1.Text = "Error occurred reading the file. " + ex.Message;
+        }
+    }
+    else
+    {
+        TextBlock1.Text = "User did not pick a file";
+    }
+}

--- a/snippets/csharp/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/cs/mainpage2.xaml.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/cs/mainpage2.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+using Windows.Storage;
+using System.Net.Http;
+using Windows.Storage.Pickers;
+
+private async void button2_Click(object sender, RoutedEventArgs e)
+{
+    // Create an HttpClient and access an image as a stream.
+    var client = new HttpClient();
+    Stream stream = await client.GetStreamAsync("https://docs.microsoft.com/en-us/dotnet/images/hub/featured-1.png");
+    // Create a .NET memory stream.
+    var memStream = new MemoryStream();
+    // Convert the stream to the memory stream, because a memory stream supports seeking.
+    await stream.CopyToAsync(memStream);
+    // Set the start position.
+    memStream.Position = 0;
+    // Create a new bitmap image.
+    var bitmap = new BitmapImage();
+    // Set the bitmap source to the stream, which is converted to a IRandomAccessStream.
+    bitmap.SetSource(memStream.AsRandomAccessStream());
+    // Set the image control source to the bitmap.
+    image1.Source = bitmap;
+}

--- a/snippets/visualbasic/VS_Snippets_CLR/IO.Compression.GZip1/VB/gziptest.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/IO.Compression.GZip1/VB/gziptest.vb
@@ -41,7 +41,7 @@ Module Module1
             Using decompressedFileStream As FileStream = File.Create(newFileName)
                 Using decompressionStream As GZipStream = New GZipStream(originalFileStream, CompressionMode.Decompress)
                     decompressionStream.CopyTo(decompressedFileStream)
-                    Console.WriteLine("Decompressed: {0}", fileToDecompress.Name)
+                    Console.WriteLine($"Decompressed: {fileToDecompress.Name}")
                 End Using
             End Using
         End Using

--- a/snippets/visualbasic/VS_Snippets_CLR/IO.Compression.GZip1/VB/gziptest.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/IO.Compression.GZip1/VB/gziptest.vb
@@ -1,9 +1,10 @@
 ' <Snippet1>
 Imports System.IO
 Imports System.IO.Compression
+
 Module Module1
 
-    Private directoryPath As String = "c:\temp"
+    Private directoryPath As String = ".\temp"
     Public Sub Main()
         Dim directorySelected As New DirectoryInfo(directoryPath)
         Compress(directorySelected)

--- a/snippets/visualbasic/VS_Snippets_CLR/IO.Compression.GZip1/VB/gziptest.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/IO.Compression.GZip1/VB/gziptest.vb
@@ -24,9 +24,8 @@ Module Module1
                             originalFileStream.CopyTo(compressionStream)
                         End Using
                     End Using
-                    Dim info As New FileInfo(directoryPath & "\" & fileToCompress.Name & ".gz")
-                    Console.WriteLine("Compressed {0} from {1} to {2} bytes.", fileToCompress.Name,
-                                      fileToCompress.Length.ToString(), info.Length.ToString())
+                    Dim info As New FileInfo(directoryPath & Path.DirectorySeparatorChar & fileToCompress.Name & ".gz")
+                    Console.WriteLine($"Compressed {fileToCompress.Name} from {fileToCompress.Length.ToString()} to {info.Length.ToString()} bytes.")
 
                 End If
             End Using

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.io.compression.ziparchive/vb/program1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.io.compression.ziparchive/vb/program1.vb
@@ -5,7 +5,7 @@ Imports System.IO.Compression
 Module Module1
 
     Sub Main()
-        Dim zipPath As String = "c:\example\start.zip"
+        Dim zipPath As String = ".\result.zip"
 
         Console.WriteLine("Provide path where to extract the zip file:")
         Dim extractPath As String = Console.ReadLine()
@@ -17,7 +17,7 @@ Module Module1
         ' is the directory separator char. 
         ' Without this, a malicious zip file could try to traverse outside of the expected
         ' extraction path.
-        If Not extractPath.EndsWith(Path.DirectorySeparatorChar) Then
+        If Not extractPath.EndsWith(Path.DirectorySeparatorChar.ToString()) Then
             extractPath += Path.DirectorySeparatorChar
         End If
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.io.compression.ziparchive/vb/program1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.io.compression.ziparchive/vb/program1.vb
@@ -17,7 +17,7 @@ Module Module1
         ' is the directory separator char. 
         ' Without this, a malicious zip file could try to traverse outside of the expected
         ' extraction path.
-        If Not extractPath.EndsWith(Path.DirectorySeparatorChar.ToString()) Then
+        If Not extractPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) Then
             extractPath += Path.DirectorySeparatorChar
         End If
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.io.compression.zipfile/vb/program1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.io.compression.zipfile/vb/program1.vb
@@ -1,13 +1,12 @@
 ' <snippet1>
-Imports System.IO
 Imports System.IO.Compression
 
 Module Module1
 
     Sub Main()
-        Dim startPath As String = "c:\example\start"
-        Dim zipPath As String = "c:\example\result.zip"
-        Dim extractPath As String = "c:\example\extract"
+        Dim startPath As String = ".\start"
+        Dim zipPath As String = ".\result.zip"
+        Dim extractPath As String = ".\extract"
 
         ZipFile.CreateFromDirectory(startPath, zipPath)
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/vb/mainpage1.xaml.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/vb/mainpage1.xaml.vb
@@ -1,0 +1,38 @@
+﻿Imports System.IO
+Imports System.Runtime.InteropServices.WindowsRuntime
+Imports Windows.UI.Xaml
+Imports Windows.UI.Xaml.Controls
+Imports Windows.UI.Xaml.Media.Imaging
+Imports Windows.Storage
+Imports System.Net.Http
+Imports Windows.Storage.Pickers
+
+Private Async Sub button1_Click(sender As Object, e As RoutedEventArgs)
+    ' Create a file picker.
+    Dim picker As New FileOpenPicker()
+
+    ' Set properties on the file picker such as start location and the type of files to display.
+    picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+    picker.ViewMode = PickerViewMode.List
+    picker.FileTypeFilter.Add(".txt")
+
+    ' Show picker that enable user to pick one file.
+    Dim result As StorageFile = Await picker.PickSingleFileAsync()
+
+    If result IsNot Nothing Then
+        Try
+            ' Retrieve the stream. This method returns a IRandomAccessStreamWithContentType.
+            Dim stream = Await result.OpenReadAsync()
+
+            ' Convert the stream to a .NET stream using AsStreamForRead, pass to a 
+            ' StreamReader and read the stream.
+            Using sr As New StreamReader(stream.AsStream())
+                TextBlock1.Text = sr.ReadToEnd()
+            End Using
+        Catch ex As Exception
+            TextBlock1.Text = "Error occurred reading the file. " + ex.Message
+        End Try
+    Else
+        TextBlock1.Text = "User did not pick a file"
+    End If
+End Sub

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/vb/mainpage2.xaml.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/vb/mainpage2.xaml.vb
@@ -1,0 +1,33 @@
+﻿Imports System.IO
+Imports System.Runtime.InteropServices.WindowsRuntime
+Imports Windows.UI.Xaml
+Imports Windows.UI.Xaml.Controls
+Imports Windows.UI.Xaml.Media.Imaging
+Imports Windows.Storage
+Imports System.Net.Http
+Imports Windows.Storage.Pickers
+
+Private Async Sub button2_Click(sender As Object, e As RoutedEventArgs)
+
+
+    ' Create an HttpClient and access an image as a stream.
+    Dim client = New HttpClient()
+    Dim stream As Stream = Await client.GetStreamAsync("https://docs.microsoft.com/en-us/dotnet/images/hub/featured-1.png")
+    ' Create a .NET memory stream.
+    Dim memStream = New MemoryStream()
+
+    ' Convert the stream to the memory stream, because a memory stream supports seeking.
+    Await stream.CopyToAsync(memStream)
+
+    ' Set the start position.
+    memStream.Position = 0
+
+    ' Create a new bitmap image.
+    Dim bitmap = New BitmapImage()
+
+    ' Set the bitmap source to the stream, which is converted to a IRandomAccessStream.
+    bitmap.SetSource(memStream.AsRandomAccessStream())
+
+    ' Set the image control source to the bitmap.
+    image1.Source = bitmap
+End Sub


### PR DESCRIPTION
## Summary

Review comments in PR https://github.com/dotnet/docs/pull/10001 requested several changes in the code examples. (Original comments and requested content changes are in that PR.) The requested code changes:

(../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.io.compression.zipfile/cs/program1.cs#1)]
- rpetrusha: In program1.cs and program1.vb, the Imports/using statement for System.IO is unnecessary.
- rpetrusha: Also, the namepace constructs could be eliminated from the examples -- particularly for deeply nested examples, they add an unnecessary level of nesting that makes the example less readable.
- v-thepet: I also made the paths platform-agnostic.

(../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.io.compression.ziparchive/cs/program1.cs#1)]
- rpetrusha: The example fails to compile. On line 24: add a call to the Char.ToString() method
if (!extractPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
- v-thepet: Actually per an email this should be
if (!extractPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
- v-thepet: Strangely, this only fails to compile in Visual Studio/.NET Framework 4.7.2. It works fine as is in Visual Studio Code/.NET Core 2.1/2.2. But adding the Char.ToString() certainly does not hurt anything. 
- v-thepet: Also made the path platform-agnostic.

(../../../samples/snippets/csharp/VS_Snippets_CLR/IO.Compression.GZip1/CS/gziptest.cs#1)]
- rpetrusha: In the VB example, add a blank line between the Imports statements and the Module statement.
- v-thepet: Also made path platform agnostic, and removed namespace declaration from CS.

(~/samples/snippets/csharp/VS_Snippets_CLR_System/system.io.windowsruntimestreamextensionsex/cs/mainpage.xaml.cs#imports)]
- rpetrusha: The code here is awkward, since it's broken into two blocks, one for imports and one for the event handler. I'd use line highlighting. I'd remove all snippet tags from the file, remove the snippet number references from here and the next code reference, and highlight the line numbers of the event handler. For example, for the C# file (after an unnecessary blank line is also removed), it should be:
	[!code-csharpSystem.IO.WindowsRuntimeStreamExtensionsEx#1]
- v-thepet: Actually the imports snippet, snippet 1, and snippet 2 were all in one file, so it does not work to put them together. I created two new files, each containing the imports statements and the relevant other snippet. Not sure which lines to highlight, or if this is necessary?
Once this PR is merged, I'll need to update the code links in the doc. 

Part of User Story https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1374049/?triage=true. 