### PR TITLE
Fix typos in snippet comments (#10120)

### DIFF
--- a/snippets/csharp/VS_Snippets_CFX/c_tcpservice/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_tcpservice/cs/source.cs
@@ -62,7 +62,7 @@ namespace TcpService
             // does not have to be issued by a trusted authority, but can be issued
             // by a peer if it is in the Trusted People store. Do not use this setting
             // for production code. The default is PeerTrust, which specifies that 
-            // the certificate must originate from a trusted certifiate authority.
+            // the certificate must originate from a trusted certificate authority.
 
             // sh.Credentials.ClientCertificate.Authentication.CertificateValidationMode =
             // X509CertificateValidationMode.PeerOrChainTrust;
@@ -78,12 +78,12 @@ namespace TcpService
             }
             catch (CommunicationException ce)
             {
-                Console.WriteLine("A commmunication error occurred: {0}", ce.Message);
+                Console.WriteLine("A communication error occurred: {0}", ce.Message);
                 Console.WriteLine();
             }
             catch (System.Exception exc)
             {
-                Console.WriteLine("An unforseen error occurred: {0}", exc.Message);
+                Console.WriteLine("An unforeseen error occurred: {0}", exc.Message);
                 Console.ReadLine();
             }
             //</snippet1>
@@ -142,12 +142,12 @@ namespace TcpService
             }
             catch (CommunicationException ce)
             {
-                Console.WriteLine("A commmunication error occurred: {0}", ce.Message);
+                Console.WriteLine("A communication error occurred: {0}", ce.Message);
                 Console.WriteLine();
             }
             catch (System.Exception exc)
             {
-                Console.WriteLine("An unforseen error occurred: {0}", exc.Message);
+                Console.WriteLine("An unforeseen error occurred: {0}", exc.Message);
                 Console.ReadLine();
             }
 
@@ -185,12 +185,12 @@ namespace TcpService
             }
             catch (CommunicationException ce)
             {
-                Console.WriteLine("A commmunication error occurred: {0}", ce.Message);
+                Console.WriteLine("A communication error occurred: {0}", ce.Message);
                 Console.WriteLine();
             }
             catch (System.Exception exc)
             {
-                Console.WriteLine("An unforseen error occurred: {0}", exc.Message);
+                Console.WriteLine("An unforeseen error occurred: {0}", exc.Message);
                 Console.ReadLine();
             }
             //</snippet3>

--- a/snippets/csharp/VS_Snippets_CFX/c_wshttpservice/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CFX/c_wshttpservice/cs/source.cs
@@ -72,7 +72,7 @@ namespace WsHttp
             // does not have to be issued by a trusted authority, but can be issued
             // by a peer if it is in the Trusted People store. Do not use this setting
             // for production code. The default is PeerTrust, which specifies that 
-            // the certificate must originate from a trusted certifiate authority.
+            // the certificate must originate from a trusted certificate authority.
 
             // sh.Credentials.ClientCertificate.Authentication.CertificateValidationMode =
             // X509CertificateValidationMode.PeerOrChainTrust;
@@ -88,12 +88,12 @@ namespace WsHttp
             }
             catch (CommunicationException ce)
             {
-                Console.WriteLine("A commmunication error occurred: {0}", ce.Message);
+                Console.WriteLine("A communication error occurred: {0}", ce.Message);
                 Console.WriteLine();
             }
             catch (System.Exception exc)
             {
-                Console.WriteLine("An unforseen error occurred: {0}", exc.Message);
+                Console.WriteLine("An unforeseen error occurred: {0}", exc.Message);
                 Console.ReadLine();
             }
             //</snippet3>

--- a/snippets/visualbasic/VS_Snippets_CFX/c_tcpservice/vb/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CFX/c_tcpservice/vb/source.vb
@@ -54,7 +54,7 @@ Class Test
         ' does not have to be issued by a trusted authority, but can be issued
         ' by a peer if it is in the Trusted People store. Do not use this setting
         ' for production code. The default is PeerTrust, which specifies that 
-        ' the certificate must originate from a trusted certifiate authority.
+        ' the certificate must originate from a trusted certificate authority.
         ' sh.Credentials.ClientCertificate.Authentication.CertificateValidationMode =
         ' X509CertificateValidationMode.PeerOrChainTrust
         Try
@@ -66,10 +66,10 @@ Class Test
             Console.ReadLine()
             sh.Close()
         Catch ce As CommunicationException
-            Console.WriteLine("A commmunication error occurred: {0}", ce.Message)
+            Console.WriteLine("A communication error occurred: {0}", ce.Message)
             Console.WriteLine()
         Catch exc As System.Exception
-            Console.WriteLine("An unforseen error occurred: {0}", exc.Message)
+            Console.WriteLine("An unforeseen error occurred: {0}", exc.Message)
             Console.ReadLine()
         End Try
         '</snippet1>
@@ -115,10 +115,10 @@ Class Test
             Console.ReadLine()
             sh.Close()
         Catch ce As CommunicationException
-            Console.WriteLine("A commmunication error occurred: {0}", ce.Message)
+            Console.WriteLine("A communication error occurred: {0}", ce.Message)
             Console.WriteLine()
         Catch exc As System.Exception
-            Console.WriteLine("An unforseen error occurred: {0}", exc.Message)
+            Console.WriteLine("An unforeseen error occurred: {0}", exc.Message)
             Console.ReadLine()
         End Try
         '</snippet2>
@@ -153,10 +153,10 @@ Class Test
             Console.ReadLine()
             sh.Close()
         Catch ce As CommunicationException
-            Console.WriteLine("A commmunication error occurred: {0}", ce.Message)
+            Console.WriteLine("A communication error occurred: {0}", ce.Message)
             Console.WriteLine()
         Catch exc As System.Exception
-            Console.WriteLine("An unforseen error occurred: {0}", exc.Message)
+            Console.WriteLine("An unforeseen error occurred: {0}", exc.Message)
             Console.ReadLine()
         End Try
         '</snippet3>

--- a/snippets/visualbasic/VS_Snippets_CFX/c_wshttpservice/vb/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CFX/c_wshttpservice/vb/source.vb
@@ -66,7 +66,7 @@ Class Service
         ' does not have to be issued by a trusted authority, but can be issued
         ' by a peer if it is in the Trusted People store. Do not use this setting
         ' for production code. The default is PeerTrust, which specifies that 
-        ' the certificate must originate from a trusted certifiate authority.
+        ' the certificate must originate from a trusted certificate authority.
         ' sh.Credentials.ClientCertificate.Authentication.CertificateValidationMode =
         ' X509CertificateValidationMode.PeerOrChainTrust
         Try
@@ -78,10 +78,10 @@ Class Service
             Console.ReadLine()
             sh.Close()
         Catch ce As CommunicationException
-            Console.WriteLine("A commmunication error occurred: {0}", ce.Message)
+            Console.WriteLine("A communication error occurred: {0}", ce.Message)
             Console.WriteLine()
         Catch exc As System.Exception
-            Console.WriteLine("An unforseen error occurred: {0}", exc.Message)
+            Console.WriteLine("An unforeseen error occurred: {0}", exc.Message)
             Console.ReadLine()
         End Try
         '</snippet3>


### PR DESCRIPTION
Fix typos in code snippet comments

- change certifiate to certificate
- change commmunication to communication
- change unforseen to unforeseen

Fixes dotnet/samples#10120
