### PR TITLE
Update to escape1.cs

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.escapes/cs/escape1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.escapes/cs/escape1.cs
@@ -21,7 +21,7 @@ public class Example
                                             match.Groups[2].Value);
    }
 }
-// The example displyas the following output:
+// The example displays the following output:
 //       Population of the World's Largest Cities, 2009
 //       
 //       City                 Population


### PR DESCRIPTION
"The example displyas" should read "The example displays"


Fixes dotnet/docs#10145
