### PR TITLE
Fix method name to get an encoders list

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/UsingImageEncodersDecoders/CS/Form1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/UsingImageEncodersDecoders/CS/Form1.cs
@@ -177,8 +177,7 @@ namespace GDIPlusPort
         //<snippet6>
         private ImageCodecInfo GetEncoder(ImageFormat format)
         {
-
-            ImageCodecInfo[] codecs = ImageCodecInfo.GetImageDecoders();
+            ImageCodecInfo[] codecs = ImageCodecInfo.GetImageEncoders();
 
             foreach (ImageCodecInfo codec in codecs)
             {
@@ -187,6 +186,7 @@ namespace GDIPlusPort
                     return codec;
                 }
             }
+            
             return null;
         }
         //</snippet6>


### PR DESCRIPTION
## Summary

I think there was a mistake in the method name, because a list of encoders was expected, not decoders.