### PR TITLE
Fix method name to get an encoders list

### DIFF
--- a/snippets/visualbasic/VS_Snippets_Winforms/UsingImageEncodersDecoders/VB/Form1.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/UsingImageEncodersDecoders/VB/Form1.vb
@@ -150,7 +150,7 @@ Public Class Form1
     '<snippet6>
     Private Function GetEncoder(ByVal format As ImageFormat) As ImageCodecInfo
 
-        Dim codecs As ImageCodecInfo() = ImageCodecInfo.GetImageDecoders()
+        Dim codecs As ImageCodecInfo() = ImageCodecInfo.GetImageEncoders()
 
         Dim codec As ImageCodecInfo
         For Each codec In codecs


### PR DESCRIPTION
## Summary

I think there was a mistake in the method name, because a list of encoders was expected, not decoders.
