### PR TITLE
Close stream

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using1.cs
@@ -15,7 +15,6 @@ public class Example
             // Process characters read.
             //   
          }
-         s.Close();    
       }
 
    }

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using2.cs
@@ -17,7 +17,6 @@ public class Example
             // Process characters read.
             //   
          }
-         s.Close();    
       }
       finally {
          // If non-null, call the object's Dispose method.

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using3.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using3.cs
@@ -17,7 +17,6 @@ public class Example
                // Process characters read.
                //   
             }
-            s.Close();
          }
          finally {
             if (s != null)

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using4.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using4.cs
@@ -18,8 +18,6 @@ public class Example
             // Process characters read.
             //
          }
-         version1.Close();
-         version2.Close();
       }
    }
 }

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using5.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using5.cs
@@ -10,8 +10,7 @@ public class Example
       StreamReader sr = null;
       try {
          sr = new StreamReader("file1.txt");
-         String contents = sr.ReadToEnd();
-         sr.Close();
+         String c();
          Console.WriteLine("The file has {0} text elements.", 
                            new StringInfo(contents).LengthInTextElements);    
       }      

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using5.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/using5.cs
@@ -10,7 +10,7 @@ public class Example
       StreamReader sr = null;
       try {
          sr = new StreamReader("file1.txt");
-         String c();
+         String contents = sr.ReadToEnd();
          Console.WriteLine("The file has {0} text elements.", 
                            new StringInfo(contents).LengthInTextElements);    
       }      

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/using1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/using1.vb
@@ -15,7 +15,6 @@ Module Example
             ' Process characters read.
             '
          Loop
-         s.Close()
       End Using
    End Sub
 End Module

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/using2.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/using2.vb
@@ -18,7 +18,6 @@ Module Example
             ' Process characters read.
             '
          Loop
-         s.Close()
       Finally
          ' If non-null, call the object's Dispose method.
          If s IsNot Nothing

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/using3.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/using3.vb
@@ -17,7 +17,6 @@ With s As New StreamReader("File1.txt")
             ' Process characters read.
             '
          Loop
-         s.Close()
       Finally
          If s IsNot Nothing Then DirectCast(s, IDisposable).Dispose()
       End Try

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/using5.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/using5.vb
@@ -11,7 +11,6 @@ Module Example
       Try 
          sr = New StreamReader("file1.txt")
          Dim contents As String = sr.ReadToEnd()
-         sr.Close()
          Console.WriteLine("The file has {0} text elements.", 
                            New StringInfo(contents).LengthInTextElements)    
       Catch e As FileNotFoundException


### PR DESCRIPTION
## Removed calls to stream Close method

StreamReader.Dispose calls Close, which makes an explicit call to Close redundant.

Fixes dotnet/docs#10067


