### PR TITLE
Expression bodied definition example: use C# 6

### DIFF
--- a/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-readonly.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-readonly.cs
@@ -5,7 +5,10 @@ public class Location
 {
    private string locationName;
    
-   public Location(string name) => locationName = name;
+   public Location(string name)
+   {
+      locationName = name;
+   }
 
    public string Name => locationName;
 }


### PR DESCRIPTION
Updated snippet is used in the following section:
https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members#read-only-properties

As it's about C# 6 (and later), I've removed the constructor expression body definition, as it's available only in C# 7.0 and later.
