### PR TITLE
Code changes to accompany docs PR #10411

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.DataGridViewBoundEditable/CS/datagridviewboundeditable.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.DataGridViewBoundEditable/CS/datagridviewboundeditable.cs
@@ -4,7 +4,17 @@ using System.Data;
 using System.Data.SqlClient;
 using System.Windows.Forms;
 
-public class Form1 : System.Windows.Forms.Form
+namespace WindowsFormsApp
+{
+    public partial class Form1 : Form
+    {
+        public Form1()
+        {
+            InitializeComponent();
+        }
+    }
+}
+public class Form1 : Form
 {
     private DataGridView dataGridView1 = new DataGridView();
     private BindingSource bindingSource1 = new BindingSource();
@@ -12,7 +22,7 @@ public class Form1 : System.Windows.Forms.Form
     private Button reloadButton = new Button();
     private Button submitButton = new Button();
 
-    [STAThreadAttribute()]
+    [STAThread()]
     public static void Main()
     {
         Application.Run(new Form1());
@@ -23,71 +33,51 @@ public class Form1 : System.Windows.Forms.Form
     {
         dataGridView1.Dock = DockStyle.Fill;
 
-        reloadButton.Text = "reload";
-        submitButton.Text = "submit";
-        reloadButton.Click += new System.EventHandler(reloadButton_Click);
-        submitButton.Click += new System.EventHandler(submitButton_Click);
+        reloadButton.Text = "Reload";
+        submitButton.Text = "Submit";
+        reloadButton.Click += new EventHandler(ReloadButton_Click);
+        submitButton.Click += new EventHandler(SubmitButton_Click);
 
-        FlowLayoutPanel panel = new FlowLayoutPanel();
-        panel.Dock = DockStyle.Top;
-        panel.AutoSize = true;
+        FlowLayoutPanel panel = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            AutoSize = true
+        };
         panel.Controls.AddRange(new Control[] { reloadButton, submitButton });
 
-        this.Controls.AddRange(new Control[] { dataGridView1, panel });
-        this.Load += new System.EventHandler(Form1_Load);
-        this.Text = "DataGridView databinding and updating demo";
+        Controls.AddRange(new Control[] { dataGridView1, panel });
+        Load += new EventHandler(Form1_Load);
+        Text = "DataGridView data binding and updating demo";
     }
 
-    //<snippet10>
-    private void Form1_Load(object sender, System.EventArgs e)
-    {
-        // Bind the DataGridView to the BindingSource
-        // and load the data from the database.
-        dataGridView1.DataSource = bindingSource1;
-        GetData("select * from Customers");
-    }
-    //</snippet10>
-
-    private void reloadButton_Click(object sender, System.EventArgs e)
-    {
-        // Reload the data from the database.
-        GetData(dataAdapter.SelectCommand.CommandText);
-    }
-
-    private void submitButton_Click(object sender, System.EventArgs e)
-    {
-        // Update the database with the user's changes.
-        dataAdapter.Update((DataTable)bindingSource1.DataSource);
-    }
-
-    //<snippet20>
     private void GetData(string selectCommand)
     {
         try
         {
-            // Specify a connection string. Replace the given value with a 
-            // valid connection string for a Northwind SQL Server sample
-            // database accessible to your system.
+            // Specify a connection string.  
+            // Replace <SQL Server> with the SQL Server for your Northwind sample database.
+            // Replace "Integrated Security=True" with user login information if necessary.
             String connectionString =
-                "Integrated Security=SSPI;Persist Security Info=False;" +
-                "Initial Catalog=Northwind;Data Source=localhost";
+                "Data Source=<SQL Server>;Initial Catalog=Northwind;" +
+                "Integrated Security=True";
 
             // Create a new data adapter based on the specified query.
             dataAdapter = new SqlDataAdapter(selectCommand, connectionString);
 
             // Create a command builder to generate SQL update, insert, and
-            // delete commands based on selectCommand. These are used to
-            // update the database.
+            // delete commands based on selectCommand. 
             SqlCommandBuilder commandBuilder = new SqlCommandBuilder(dataAdapter);
 
             // Populate a new data table and bind it to the BindingSource.
-            DataTable table = new DataTable();
-            table.Locale = System.Globalization.CultureInfo.InvariantCulture;
+            DataTable table = new DataTable
+            {
+                Locale = Globalization.CultureInfo.InvariantCulture
+            };
             dataAdapter.Fill(table);
             bindingSource1.DataSource = table;
 
             // Resize the DataGridView columns to fit the newly loaded content.
-            dataGridView1.AutoResizeColumns( 
+            dataGridView1.AutoResizeColumns(
                 DataGridViewAutoSizeColumnsMode.AllCellsExceptHeader);
         }
         catch (SqlException)
@@ -97,7 +87,25 @@ public class Form1 : System.Windows.Forms.Form
                 "valid for your system.");
         }
     }
-    //</snippet20>
 
+    private void Form1_Load(object sender, EventArgs e)
+    {
+        // Bind the DataGridView to the BindingSource
+        // and load the data from the database.
+        dataGridView1.DataSource = bindingSource1;
+        GetData("select * from Customers");
+    }
+
+    private void ReloadButton_Click(object sender, EventArgs e)
+    {
+        // Reload the data from the database.
+        GetData(dataAdapter.SelectCommand.CommandText);
+    }
+
+    private void SubmitButton_Click(object sender, EventArgs e)
+    {
+        // Update the database with changes.
+        dataAdapter.Update((DataTable)bindingSource1.DataSource);
+    }
 }
 //</snippet00>

--- a/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.DataGridViewBoundEditable/VB/datagridviewboundeditable.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.DataGridViewBoundEditable/VB/datagridviewboundeditable.vb
@@ -1,19 +1,17 @@
 '<snippet00>
-Imports System
-Imports System.Data
 Imports System.Data.SqlClient
-Imports System.Windows.Forms
+Imports System.Windows
 
 Public Class Form1
-    Inherits System.Windows.Forms.Form
+    Inherits Forms.Form
 
     Private dataGridView1 As New DataGridView()
     Private bindingSource1 As New BindingSource()
     Private dataAdapter As New SqlDataAdapter()
-    Private WithEvents reloadButton As New Button()
-    Private WithEvents submitButton As New Button()
+    Private WithEvents ReloadButton As New Button()
+    Private WithEvents SubmitButton As New Button()
 
-    <STAThreadAttribute()> _
+    <STAThreadAttribute()>
     Public Shared Sub Main()
         Application.Run(New Form1())
     End Sub
@@ -23,83 +21,79 @@ Public Class Form1
 
         Me.dataGridView1.Dock = DockStyle.Fill
 
-        Me.reloadButton.Text = "reload"
-        Me.submitButton.Text = "submit"
+        Me.ReloadButton.Text = "Reload"
+        Me.SubmitButton.Text = "Submit"
 
-        Dim panel As New FlowLayoutPanel()
-        panel.Dock = DockStyle.Top
-        panel.AutoSize = True
-        panel.Controls.AddRange(New Control() {Me.reloadButton, Me.submitButton})
+        Dim panel As New FlowLayoutPanel With {
+            .Dock = DockStyle.Top,
+            .AutoSize = True
+        }
+        panel.Controls.AddRange(New Control() {ReloadButton, SubmitButton})
 
-        Me.Controls.AddRange(New Control() {Me.dataGridView1, panel})
-        Me.Text = "DataGridView databinding and updating demo"
-
-    End Sub
-
-    '<snippet10>
-    Private Sub Form1_Load(ByVal sender As Object, ByVal e As System.EventArgs) _
-        Handles Me.Load
-
-        ' Bind the DataGridView to the BindingSource
-        ' and load the data from the database.
-        Me.dataGridView1.DataSource = Me.bindingSource1
-        GetData("select * from Customers")
-
-    End Sub
-    '</snippet10>
-
-    Private Sub reloadButton_Click(ByVal sender As Object, ByVal e As System.EventArgs) _
-        Handles reloadButton.Click
-
-        ' Reload the data from the database.
-        GetData(Me.dataAdapter.SelectCommand.CommandText)
+        Controls.AddRange(New Control() {dataGridView1, panel})
+        Text = "DataGridView data binding and updating demo"
 
     End Sub
 
-    Private Sub submitButton_Click(ByVal sender As Object, ByVal e As System.EventArgs) _
-        Handles submitButton.Click
-
-        ' Update the database with the user's changes.
-        Me.dataAdapter.Update(CType(Me.bindingSource1.DataSource, DataTable))
-
-    End Sub
-
-    '<snippet20>
     Private Sub GetData(ByVal selectCommand As String)
 
         Try
-            ' Specify a connection string. Replace the given value with a 
-            ' valid connection string for a Northwind SQL Server sample
-            ' database accessible to your system.
-            Dim connectionString As String = _
-                "Integrated Security=SSPI;Persist Security Info=False;" + _
-                "Initial Catalog=Northwind;Data Source=localhost"
+            ' Specify a connection string.  
+            ' Replace <SQL Server> with the SQL Server for your Northwind sample database.
+            ' Replace "Integrated Security=True" with user login information if necessary.
+            Dim connectionString As String =
+                "Data Source=<SQL Server>;Initial Catalog=Northwind;" +
+                "Integrated Security=True;"
 
             ' Create a new data adapter based on the specified query.
-            Me.dataAdapter = New SqlDataAdapter(selectCommand, connectionString)
+            dataAdapter = New SqlDataAdapter(selectCommand, connectionString)
 
             ' Create a command builder to generate SQL update, insert, and
-            ' delete commands based on selectCommand. These are used to
-            ' update the database.
-            Dim commandBuilder As New SqlCommandBuilder(Me.dataAdapter)
+            ' delete commands based on selectCommand. 
+            Dim commandBuilder As New SqlCommandBuilder(dataAdapter)
 
             ' Populate a new data table and bind it to the BindingSource.
-            Dim table As New DataTable()
-            table.Locale = System.Globalization.CultureInfo.InvariantCulture
-            Me.dataAdapter.Fill(table)
-            Me.bindingSource1.DataSource = table
+            Dim table As New DataTable With {
+                .Locale = Globalization.CultureInfo.InvariantCulture
+            }
+            dataAdapter.Fill(table)
+            bindingSource1.DataSource = table
 
             ' Resize the DataGridView columns to fit the newly loaded content.
-            Me.dataGridView1.AutoResizeColumns( _
+            dataGridView1.AutoResizeColumns(
                 DataGridViewAutoSizeColumnsMode.AllCellsExceptHeader)
         Catch ex As SqlException
-            MessageBox.Show("To run this example, replace the value of the " + _
-                "connectionString variable with a connection string that is " + _
+            MessageBox.Show("To run this example, replace the value of the " +
+                "connectionString variable with a connection string that is " +
                 "valid for your system.")
         End Try
 
     End Sub
-    '</snippet20>
+    Private Sub Form1_Load(ByVal sender As Object, ByVal e As EventArgs) _
+        Handles Me.Load
+
+        ' Bind the DataGridView to the BindingSource
+        ' and load the data from the database.
+        dataGridView1.DataSource = bindingSource1
+        GetData("select * from Customers")
+
+    End Sub
+
+    Private Sub ReloadButton_Click(ByVal sender As Object, ByVal e As EventArgs) _
+        Handles ReloadButton.Click
+
+        ' Reload the data from the database.
+        GetData(dataAdapter.SelectCommand.CommandText)
+
+    End Sub
+
+    Private Sub SubmitButton_Click(ByVal sender As Object, ByVal e As EventArgs) _
+        Handles SubmitButton.Click
+
+        ' Update the database with changes.
+        dataAdapter.Update(CType(bindingSource1.DataSource, DataTable))
+
+    End Sub
 
 End Class
 '</snippet00>

--- a/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.DataGridViewBoundEditable/VB/datagridviewboundeditable.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.DataGridViewBoundEditable/VB/datagridviewboundeditable.vb
@@ -19,10 +19,10 @@ Public Class Form1
     ' Initialize the form.
     Public Sub New()
 
-        Me.dataGridView1.Dock = DockStyle.Fill
+        dataGridView1.Dock = DockStyle.Fill
 
-        Me.ReloadButton.Text = "Reload"
-        Me.SubmitButton.Text = "Submit"
+        ReloadButton.Text = "Reload"
+        SubmitButton.Text = "Submit"
 
         Dim panel As New FlowLayoutPanel With {
             .Dock = DockStyle.Top,


### PR DESCRIPTION
## Summary
See PR https://github.com/dotnet/docs/pull/10411

- Rearranged the code to follow the order described in the doc. It isn't intuitive to load table data into the form before connecting to the database. 
- Removed the sub-snippet tags, as the code fragments are being removed from the doc. (No other doc links to this sample.) 
- Implemented a number of suggestions from Visual Studio for simplifying the code. 

Fixes dotnet/docs#Issue_Number (if available)
See https://mseng.visualstudio.com/TechnicalContent/_queries/edit/1409982/?triage=true