### PR TITLE
Use correct value keyword in set property accessor

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/conceptual.conversion/cs/iconvertible2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.conversion/cs/iconvertible2.cs
@@ -13,7 +13,7 @@ public abstract class Temperature : IConvertible
    public decimal Value
    { 
       get { return this.temp; } 
-      set { this.temp = Value; }        
+      set { this.temp = value; }        
    }
 
    public override string ToString()


### PR DESCRIPTION
Currently the property's value cannot be changed as it uses its own current value within the set property accessor. By using the appropriate keyword the set accessor will behave as expected.