### PR TITLE
Fix align

### DIFF
--- a/snippets/csharp/VS_Snippets_Remoting/NCLNetInfo2/CS/networkexamples.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/NCLNetInfo2/CS/networkexamples.cs
@@ -905,7 +905,7 @@ using System.Net.Sockets;
  //</Snippet50> 
 
  //<Snippet51> 
-         public static void DisplayTypeAndAddress()
+        public static void DisplayTypeAndAddress()
         {
             IPGlobalProperties computerProperties = IPGlobalProperties.GetIPGlobalProperties();
             NetworkInterface[] nics = NetworkInterface.GetAllNetworkInterfaces();


### PR DESCRIPTION
[NetworkInterface.GetPhysicalAddress Method (System.Net.NetworkInformation) | Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/api/system.net.networkinformation.networkinterface.getphysicaladdress?view=netframework-4.7.2 )

![image](https://user-images.githubusercontent.com/16054566/52831986-aa20eb80-3111-11e9-89c6-ebe0729335c1.png)
