### PR TITLE
Four new samples for winforms openfiledialog doc refresh

### DIFF
--- a/snippets/winforms/open-files/example1/cs/Form1.cs
+++ b/snippets/winforms/open-files/example1/cs/Form1.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Security;
+using System.Windows.Forms;
+
+public class OpenFileDialogForm : Form
+{
+    [STAThread]
+    public static void Main()
+    {
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.EnableVisualStyles();
+        Application.Run(new OpenFileDialogForm());
+    }
+
+    private Button selectButton;
+    private OpenFileDialog openFileDialog1;
+    private TextBox textBox1;
+
+    public OpenFileDialogForm()
+    {
+        openFileDialog1 = new OpenFileDialog();
+        selectButton = new Button
+        {
+            Size = new Size(100, 20),
+            Location = new Point(15, 15),
+            Text = "Select file"
+        };
+        selectButton.Click += new EventHandler(SelectButton_Click);
+        textBox1 = new TextBox
+        {
+            Size = new Size(300, 300),
+            Location = new Point(15, 40),
+            Multiline = true,
+            ScrollBars = ScrollBars.Vertical
+        };
+        ClientSize = new Size(330, 360);
+        Controls.Add(selectButton);
+        Controls.Add(textBox1);
+    }
+    private void SetText(string text)
+    {
+        textBox1.Text = text;
+    }
+    private void SelectButton_Click(object sender, EventArgs e)
+    {
+        if (openFileDialog1.ShowDialog() == DialogResult.OK)
+        {
+            try
+            {
+                var sr = new StreamReader(openFileDialog1.FileName);
+                SetText(sr.ReadToEnd());
+            }
+            catch (SecurityException ex)
+            {
+                MessageBox.Show($"Security error.\n\nError message: {ex.Message}\n\n" +
+                $"Details:\n\n{ex.StackTrace}");
+            }
+        }
+    }
+}

--- a/snippets/winforms/open-files/example1/vb/Form1.vb
+++ b/snippets/winforms/open-files/example1/vb/Form1.vb
@@ -1,0 +1,55 @@
+Imports System.Drawing
+Imports System.IO
+Imports System.Security
+Imports System.Windows.Forms
+
+Public Class OpenFileDialogForm : Inherits Form
+
+    Public Shared Sub Main()
+        Application.SetCompatibleTextRenderingDefault(False)
+        Application.EnableVisualStyles()
+        Dim frm As New OpenFileDialogForm()
+        Application.Run(frm)
+    End Sub
+
+    Dim WithEvents SelectButton As Button
+    Dim openFileDialog1 As OpenFileDialog
+    Dim TextBox1 As TextBox
+
+    Private Sub New()
+        ClientSize = New Size(400, 400)
+        openFileDialog1 = New OpenFileDialog()
+        SelectButton = New Button()
+        With SelectButton
+            .Text = "Select file"
+            .Location = New Point(15, 15)
+            .Size = New Size(100, 25)
+        End With
+        TextBox1 = New TextBox()
+        With TextBox1
+            .Size = New Size(300, 300)
+            .Location = New Point(15, 50)
+            .Multiline = True
+            .ScrollBars = ScrollBars.Vertical
+        End With
+        Controls.Add(SelectButton)
+        Controls.Add(TextBox1)
+    End Sub
+
+    Private Sub SetText(text)
+        TextBox1.Text = text
+    End Sub
+
+    Public Sub SelectButton_Click(sender As Object, e As EventArgs) _
+              Handles SelectButton.Click
+        If openFileDialog1.ShowDialog() = DialogResult.OK Then
+            Try
+                Dim sr As New StreamReader(openFileDialog1.FileName)
+                SetText(sr.ReadToEnd())
+            Catch SecEx As SecurityException
+                MessageBox.Show($"Security error:{vbCrLf}{vbCrLf}{SecEx.Message}{vbCrLf}{vbCrLf}" &
+                $"Details:{vbCrLf}{vbCrLf}{SecEx.StackTrace}")
+            End Try
+        End If
+    End Sub
+End Class

--- a/snippets/winforms/open-files/example2/cs/Form1.cs
+++ b/snippets/winforms/open-files/example2/cs/Form1.cs
@@ -1,0 +1,60 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Security;
+using System.Windows.Forms;
+
+public class OpenFileDialogForm : Form
+{
+    [STAThread]
+    public static void Main()
+    {
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.EnableVisualStyles();
+        Application.Run(new OpenFileDialogForm());
+    }
+
+    private Button selectButton;
+    private OpenFileDialog openFileDialog1;
+    private BackgroundWorker backgroundWorker1;
+
+    public OpenFileDialogForm()
+    {
+        openFileDialog1 = new OpenFileDialog();
+        {
+            Filename = "Select a text file",
+            Filter = "Text files (*.txt)|*.txt",
+            Title = "Open text file"
+        };
+
+        selectButton = new Button
+        {
+            Size = new Size(100, 20),
+            Location = new Point(15, 15),
+            Text = "Select file"
+        };
+        selectButton.Click += new EventHandler(selectButton_Click);
+        Controls.Add(selectButton);
+    }
+
+    private void selectButton_Click(object sender, EventArgs e)
+    {
+        if (openFileDialog1.ShowDialog() == DialogResult.OK)
+        {
+            try
+            {
+                var filePath = openFileDialog1.FileName;
+                using (FileStream fs = File.Open(filePath, FileMode.Open))
+                {
+                    Process.Start("notepad.exe", filePath);
+                }
+            }
+            catch (SecurityException ex)
+            {
+                MessageBox.Show($"Security error.\n\nError message: {ex.Message}\n\n" +
+                $"Details:\n\n{ex.StackTrace}");
+            }
+        }
+    }
+}

--- a/snippets/winforms/open-files/example2/vb/Form1.vb
+++ b/snippets/winforms/open-files/example2/vb/Form1.vb
@@ -1,0 +1,47 @@
+Imports System.ComponentModel
+Imports System.Diagnostics
+Imports System.IO
+Imports System.Security
+Imports System.Windows.Forms
+
+Public Class OpenFileDialogForm : Inherits Form 
+    Dim WithEvents selectButton As Button
+    Dim openFileDialog1 As OpenFileDialog
+    Dim backgroundWorker1 As BackgroundWorker
+
+    Public Shared Sub Main()
+      Application.SetCompatibleTextRenderingDefault(false)
+      Application.EnableVisualStyles()
+      Dim frm As New OpenFileDialogForm()
+      Application.Run(frm)
+    End Sub
+
+    Private Sub New()
+        backgroundWorker1 = New BackgroundWorker()
+        openFileDialog1 = New OpenFileDialog()
+        With openFileDialog1
+           .FileName = "Select a text file"
+           .Filter = "Text files (*.txt)|*.txt"
+           .Title = "Open text file"
+        End With
+        selectButton = New Button()
+        With selectButton
+           .Text = "Select file"
+        End With
+        Controls.Add(selectButton)
+    End Sub
+    
+    Public Sub selectButton_Click(sender As Object, e As EventArgs) _ 
+            Handles selectButton.Click
+        If OpenFileDialog1.ShowDialog() = DialogResult.OK Then
+            Try
+                Dim filePath = OpenFileDialog1.FileName
+                Dim fs As FileStream = New FileStream(filePath, FileMode.Open)
+                Process.Start("notepad.exe", filePath)
+            Catch SecEx As SecurityException
+                MessageBox.Show($"Security error:{vbCrLf}{vbCrLf}{SecEx.Message}{vbCrLf}{vbCrLf}" &
+                $"Details:{vbCrLf}{vbCrLf}{SecEx.StackTrace}")
+            End Try
+        End If
+    End Sub
+End Class


### PR DESCRIPTION
## Summary

Four new runnable samples showing how to open and read files with openfiledialog. (Original code is embedded in the doc, at https://docs.microsoft.com/en-us/dotnet/framework/winforms/controls/how-to-open-files-using-the-openfiledialog-component.)

For PR https://github.com/dotnet/docs/pull/10522 - details and instructions are there. 

See Azure DevOps Task https://mseng.visualstudio.com/TechnicalContent/_queries/edit/1409952/?triage=true. 
