### PR TITLE
Four new samples for winforms thread-safe-calls doc refresh

### DIFF
--- a/snippets/winforms/thread-safe/example1/cs/form1.cs
+++ b/snippets/winforms/thread-safe/example1/cs/form1.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Drawing;
+using System.Threading;
+using System.Windows.Forms;
+
+public class InvokeThreadSafeForm : Form
+{
+    private delegate void SafeCallDelegate(string text);
+    private Button button1;
+    private TextBox textBox1;
+    private Thread thread2 = null;
+
+    [STAThread]
+    static void Main()
+    {
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.EnableVisualStyles();
+        Application.Run(new InvokeThreadSafeForm());
+    }
+    public InvokeThreadSafeForm()
+    {
+        button1 = new Button
+        {
+            Location = new Point(15, 55),
+            Size = new Size(240, 20),
+            Text = "Set text safely"
+        };
+        button1.Click += new EventHandler(Button1_Click);
+        textBox1 = new TextBox
+        {
+            Location = new Point(15, 15),
+            Size = new Size(240, 20)
+        };
+        Controls.Add(button1);
+        Controls.Add(textBox1);
+    }
+
+    private void Button1_Click(object sender, EventArgs e)
+    {
+        thread2 = new Thread(new ThreadStart(SetText));
+        thread2.Start();
+        Thread.Sleep(1000);
+    }
+
+    private void SafeText(string text)
+    {
+        if (textBox1.InvokeRequired)
+        {
+            var d = new SafeCallDelegate(SafeText);
+            Invoke(d, new object[] { text });
+        }
+        else
+        {
+            textBox1.Text = text;
+        }
+    }
+
+    private void SetText()
+    {
+        SafeText("This text was set safely.");
+    }
+}

--- a/snippets/winforms/thread-safe/example1/cs/form1.cs
+++ b/snippets/winforms/thread-safe/example1/cs/form1.cs
@@ -42,11 +42,11 @@ public class InvokeThreadSafeForm : Form
         Thread.Sleep(1000);
     }
 
-    private void SafeText(string text)
+    private void WriteTextSafe(string text)
     {
         if (textBox1.InvokeRequired)
         {
-            var d = new SafeCallDelegate(SafeText);
+            var d = new SafeCallDelegate(WriteTextSafe);
             Invoke(d, new object[] { text });
         }
         else
@@ -57,6 +57,6 @@ public class InvokeThreadSafeForm : Form
 
     private void SetText()
     {
-        SafeText("This text was set safely.");
+        WriteTextSafe("This text was set safely.");
     }
 }

--- a/snippets/winforms/thread-safe/example1/vb/form1.vb
+++ b/snippets/winforms/thread-safe/example1/vb/form1.vb
@@ -1,0 +1,53 @@
+Imports System.Drawing
+Imports System.Threading
+Imports System.Windows.Forms
+
+Public Class InvokeThreadSafeForm : Inherits Form
+
+    Public Shared Sub Main()
+        Application.SetCompatibleTextRenderingDefault(False)
+        Application.EnableVisualStyles()
+        Dim frm As New InvokeThreadSafeForm()
+        Application.Run(frm)
+    End Sub
+
+    Dim WithEvents Button1 As Button
+    Dim TextBox1 As TextBox
+    Dim Thread2 as Thread = Nothing
+
+    Delegate Sub SafeCallDelegate(text As String)
+
+    Private Sub New()
+        Button1 = New Button()
+        With Button1
+            .Text = "Set text safely"
+            .Location = New Point(15, 55)
+        End With
+        TextBox1 = New TextBox()
+        With TextBox1
+            .Location = New Point(15, 15)
+            .Size = New Size(240, 20)
+        End With
+        Controls.Add(Button1)
+        Controls.Add(TextBox1)
+    End Sub
+
+    Private Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click
+        thread2 = New Thread(New ThreadStart(AddressOf SetText))
+        thread2.Start()
+        Thread.Sleep(1000)
+    End Sub
+
+    Private Sub SafeText(text As String)
+        If TextBox1.InvokeRequired Then
+            Dim d As New SafeCallDelegate(AddressOf SetText)
+            Invoke(d, New Object() {text})
+        Else
+            TextBox1.Text = text
+        End If
+    End Sub
+
+    Private Sub SetText()
+        SafeText("This text was set safely.")
+    End Sub
+End Class

--- a/snippets/winforms/thread-safe/example1/vb/form1.vb
+++ b/snippets/winforms/thread-safe/example1/vb/form1.vb
@@ -20,8 +20,9 @@ Public Class InvokeThreadSafeForm : Inherits Form
     Private Sub New()
         Button1 = New Button()
         With Button1
-            .Text = "Set text safely"
             .Location = New Point(15, 55)
+            .Size = New Size(240, 20)
+            .Text = "Set text safely"
         End With
         TextBox1 = New TextBox()
         With TextBox1
@@ -33,12 +34,12 @@ Public Class InvokeThreadSafeForm : Inherits Form
     End Sub
 
     Private Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click
-        thread2 = New Thread(New ThreadStart(AddressOf SetText))
-        thread2.Start()
+        Thread2 = New Thread(New ThreadStart(AddressOf SetText))
+        Thread2.Start()
         Thread.Sleep(1000)
     End Sub
 
-    Private Sub SafeText(text As String)
+    Private Sub WriteTextSafe(text As String)
         If TextBox1.InvokeRequired Then
             Dim d As New SafeCallDelegate(AddressOf SetText)
             Invoke(d, New Object() {text})
@@ -48,6 +49,6 @@ Public Class InvokeThreadSafeForm : Inherits Form
     End Sub
 
     Private Sub SetText()
-        SafeText("This text was set safely.")
+        WriteTextSafe("This text was set safely.")
     End Sub
 End Class

--- a/snippets/winforms/thread-safe/example2/cs/form1.cs
+++ b/snippets/winforms/thread-safe/example2/cs/form1.cs
@@ -1,0 +1,56 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Threading;
+using System.Windows.Forms;
+
+public class BackgroundWorkerForm : Form
+{
+    private BackgroundWorker backgroundWorker1;
+    private Button button1;
+    private TextBox textBox1;
+    private Thread thread2 = null;
+
+    [STAThread]
+    static void Main()
+    {
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.EnableVisualStyles();
+        Application.Run(new BackgroundWorkerForm());
+    }
+    public BackgroundWorkerForm()
+    {
+        backgroundWorker1 = new BackgroundWorker();
+        backgroundWorker1.DoWork += new DoWorkEventHandler(BackgroundWorker1_DoWork);
+        backgroundWorker1.RunWorkerCompleted += new RunWorkerCompletedEventHandler(BackgroundWorker1_RunWorkerCompleted);
+        button1 = new Button
+        {
+            Location = new Point(15, 55),
+            Size = new Size(240, 20),
+            Text = "Set text safely with BackgroundWorker"
+        };
+        button1.Click += new EventHandler(Button1_Click);
+        textBox1 = new TextBox
+        {
+            Location = new Point(15, 15),
+            Size = new Size(240, 20)
+        };
+        Controls.Add(button1);
+        Controls.Add(textBox1);
+    }
+    private void Button1_Click(object sender, EventArgs e)
+    {
+        backgroundWorker1.RunWorkerAsync();
+    }
+
+    private void BackgroundWorker1_DoWork(object sender, DoWorkEventArgs e)
+    {
+        thread2 = new Thread(new ThreadStart(backgroundWorker1.RunWorkerAsync));
+        Thread.Sleep(1000);
+    }
+
+    private void BackgroundWorker1_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
+    {
+        textBox1.Text = "This text was set safely by BackgroundWorker.";
+    }
+}

--- a/snippets/winforms/thread-safe/example2/vb/form1.vb
+++ b/snippets/winforms/thread-safe/example2/vb/form1.vb
@@ -1,0 +1,51 @@
+Imports System.ComponentModel
+Imports System.Drawing
+Imports System.Threading
+Imports System.Windows.Forms
+
+Public Class BackgroundWorkerForm : Inherits Form
+
+    Public Shared Sub Main()
+        Application.SetCompatibleTextRenderingDefault(False)
+        Application.EnableVisualStyles()
+        Dim frm As New BackgroundWorkerForm()
+        Application.Run(frm)
+    End Sub
+
+    Dim WithEvents BackgroundWorker1 As BackgroundWorker
+    Dim WithEvents Button1 As Button
+    Dim TextBox1 As TextBox
+    Dim Thread2 as Thread = Nothing
+
+    Private Sub New()
+        BackgroundWorker1 = New BackgroundWorker()
+        Button1 = New Button()
+        With Button1
+            .Text = "Set text safely with BackgroundWorker"
+            .Location = New Point(15, 55)
+            .Size = New Size(240, 20)
+        End With
+        TextBox1 = New TextBox()
+        With TextBox1
+            .Location = New Point(15, 15)
+            .Size = New Size(240, 20)
+        End With
+        Controls.Add(Button1)
+        Controls.Add(TextBox1)
+    End Sub
+
+    Private Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click
+        BackgroundWorker1.RunWorkerAsync()
+    End Sub
+
+    Private Sub BackgroundWorker1_DoWork(sender As Object, e As DoWorkEventArgs) _
+     Handles BackgroundWorker1.DoWork
+        thread2 = new Thread(new ThreadStart(AddressOf backgroundWorker1.RunWorkerAsync))
+        Thread.Sleep(1000)
+    End Sub
+
+    Private Sub BackgroundWorker1_RunWorkerCompleted(sender As Object, e As RunWorkerCompletedEventArgs) _
+     Handles BackgroundWorker1.RunWorkerCompleted
+        textBox1.Text = "This text was set safely by BackgroundWorker."
+    End Sub
+End Class


### PR DESCRIPTION
## Summary

Four new runnable samples showing how to make thread-safe calls to windows forms controls. (Original code is embedded in the doc, at https://docs.microsoft.com/en-us/dotnet/framework/winforms/controls/how-to-make-thread-safe-calls-to-windows-forms-controls.)

For PR [dotnet/docs#10761](https://github.com/dotnet/docs/pull/10761) - details are there.

See Azure DevOps Task https://mseng.visualstudio.com/TechnicalContent/_queries/edit/1409990/?triage=true.