### PR TITLE
Fix typo in snippet tag

### DIFF
--- a/snippets/standard/assembly/unloading/simple_example.cs
+++ b/snippets/standard/assembly/unloading/simple_example.cs
@@ -34,7 +34,7 @@ class Test
         int result = (int)a.EntryPoint.Invoke(null, args);
         // </Snippet4>
 
-        // </Snippet5>
+        // <Snippet5>
         alc.Unload();
         // </Snippet5>
 


### PR DESCRIPTION
## Summary

I've found that one of the tags had a leading / in the starting tag.
This change corrects that mistake.