### PR TITLE
Migrated GitHubLabeler to v0.11

### DIFF
--- a/machine-learning/tutorials/GitHubIssueClassification/GitHubIssueClassification.csproj
+++ b/machine-learning/tutorials/GitHubIssueClassification/GitHubIssueClassification.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.11.0-preview-27428-4" />
+    <PackageReference Include="Microsoft.ML" Version="0.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/machine-learning/tutorials/GitHubIssueClassification/GitHubIssueClassification.csproj
+++ b/machine-learning/tutorials/GitHubIssueClassification/GitHubIssueClassification.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.10.0" />
+    <PackageReference Include="Microsoft.ML" Version="0.11.0-preview-27428-4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/machine-learning/tutorials/GitHubIssueClassification/Program.cs
+++ b/machine-learning/tutorials/GitHubIssueClassification/Program.cs
@@ -1,16 +1,11 @@
 // <SnippetAddUsings>
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Data.DataView;
 using Microsoft.ML;
-using Microsoft.ML.Core.Data;
 using Microsoft.ML.Data;
-using Microsoft.ML.Trainers;
 using Microsoft.ML.Transforms.Conversions;
-using Microsoft.ML.Transforms.Normalizers;
 // </SnippetAddUsings>
 
 namespace GitHubIssueClassification
@@ -42,7 +37,7 @@ namespace GitHubIssueClassification
             Console.WriteLine($"=============== Loading Dataset  ===============");
             
             // <SnippetLoadTrainData>
-            _trainingDataView = _mlContext.Data.CreateTextLoader<GitHubIssue>(hasHeader: true).Read(_trainDataPath);
+            _trainingDataView = _mlContext.Data.LoadFromTextFile<GitHubIssue>(_trainDataPath,hasHeader: true);
             // </SnippetLoadTrainData>
 
             Console.WriteLine($"=============== Finished Loading Dataset  ===============");
@@ -68,7 +63,7 @@ namespace GitHubIssueClassification
             // </SnippetCallPredictIssue>
         }
 
-        public static EstimatorChain<ITransformer> ProcessData()
+        public static EstimatorChain<ColumnConcatenatingTransformer> ProcessData()
         {
             Console.WriteLine($"=============== Processing Data ===============");
             // STEP 2: Common data process configuration with pipeline data transformations
@@ -94,7 +89,7 @@ namespace GitHubIssueClassification
             // </SnippetReturnPipeline>
         }
 
-        public static EstimatorChain<KeyToValueMappingTransformer> BuildAndTrainModel(IDataView trainingDataView, EstimatorChain<ITransformer> pipeline)
+        public static EstimatorChain<KeyToValueMappingTransformer> BuildAndTrainModel(IDataView trainingDataView, EstimatorChain<ColumnConcatenatingTransformer> pipeline)
         {
             // STEP 3: Create the training algorithm/trainer
             // Use the multi-class SDCA algorithm to predict the label using features.
@@ -147,7 +142,7 @@ namespace GitHubIssueClassification
 
             //Load the test dataset into the IDataView
             // <SnippetLoadTestDataset>
-            var testDataView = _mlContext.Data.CreateTextLoader<GitHubIssue>(hasHeader: true).Read(_testDataPath);
+            var testDataView = _mlContext.Data.LoadFromTextFile<GitHubIssue>(_testDataPath,hasHeader: true);
             // </SnippetLoadTestDataset>
 
             //Evaluate the model on a test dataset and calculate metrics of the model on the test data.

--- a/machine-learning/tutorials/GitHubIssueClassification/Program.cs
+++ b/machine-learning/tutorials/GitHubIssueClassification/Program.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Microsoft.Data.DataView;
 using Microsoft.ML;
 using Microsoft.ML.Data;
-using Microsoft.ML.Transforms.Conversions;
+using Microsoft.ML.Transforms;
 // </SnippetAddUsings>
 
 namespace GitHubIssueClassification
@@ -63,7 +63,7 @@ namespace GitHubIssueClassification
             // </SnippetCallPredictIssue>
         }
 
-        public static EstimatorChain<ColumnConcatenatingTransformer> ProcessData()
+        public static IEstimator<ITransformer> ProcessData()
         {
             Console.WriteLine($"=============== Processing Data ===============");
             // STEP 2: Common data process configuration with pipeline data transformations
@@ -89,7 +89,7 @@ namespace GitHubIssueClassification
             // </SnippetReturnPipeline>
         }
 
-        public static EstimatorChain<KeyToValueMappingTransformer> BuildAndTrainModel(IDataView trainingDataView, EstimatorChain<ColumnConcatenatingTransformer> pipeline)
+        public static IEstimator<ITransformer> BuildAndTrainModel(IDataView trainingDataView, IEstimator<ITransformer> pipeline)
         {
             // STEP 3: Create the training algorithm/trainer
             // Use the multi-class SDCA algorithm to predict the label using features.


### PR DESCRIPTION
## Summary
Migrated GItHubLabeler solution to v0.11 with the below changes.
1. Replaced data loading  by using LaodFromTextFile
2.Removed unnecessary namespace using statements.

