### PR TITLE
Fix code format

### DIFF
--- a/snippets/csharp/tutorials/inheritance/simpleclass.cs
+++ b/snippets/csharp/tutorials/inheritance/simpleclass.cs
@@ -4,36 +4,38 @@ using System.Reflection;
 
 public class Example
 {
-   public static void Main()
-   {
-      Type t = typeof(SimpleClass);
-      BindingFlags flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | 
-                           BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
-      MemberInfo[] members = t.GetMembers(flags);
-      Console.WriteLine($"Type {t.Name} has {members.Length} members: ");
-      foreach (var member in members) {
-         string access = "";
-         string stat = ""; 
-         var method = member as MethodBase;
-         if (method != null) {
-            if (method.IsPublic) 
-               access = " Public";
-            else if (method.IsPrivate)
-               access = " Private";
-            else if (method.IsFamily)  
-               access = " Protected";
-            else if (method.IsAssembly)
-               access = " Internal";
-            else if (method.IsFamilyOrAssembly)
-               access = " Protected Internal ";
-            if (method.IsStatic)
-               stat = " Static";
-         }
-         var output = $"{member.Name} ({member.MemberType}): {access}{stat}, Declared by {member.DeclaringType}";
-         Console.WriteLine(output); 
+    public static void Main()
+    {
+        Type t = typeof(SimpleClass);
+        BindingFlags flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                             BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
+        MemberInfo[] members = t.GetMembers(flags);
+        Console.WriteLine($"Type {t.Name} has {members.Length} members: ");
+        foreach (var member in members)
+        {
+            string access = "";
+            string stat = "";
+            var method = member as MethodBase;
+            if (method != null)
+            {
+                if (method.IsPublic)
+                    access = " Public";
+                else if (method.IsPrivate)
+                    access = " Private";
+                else if (method.IsFamily)
+                    access = " Protected";
+                else if (method.IsAssembly)
+                    access = " Internal";
+                else if (method.IsFamilyOrAssembly)
+                    access = " Protected Internal ";
+                if (method.IsStatic)
+                    stat = " Static";
+            }
+            var output = $"{member.Name} ({member.MemberType}): {access}{stat}, Declared by {member.DeclaringType}";
+            Console.WriteLine(output);
 
-      }
-   }
+        }
+    }
 }
 // The example displays the following output:
 //	Type SimpleClass has 9 members:
@@ -50,6 +52,6 @@ public class Example
 
 // <Snippet1>
 public class SimpleClass
-{}
+{ }
 // </Snippet1>
 


### PR DESCRIPTION
In [corefx/coding-style.md at master · dotnet/corefx](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md ) NO.1, we use Allman style braces, where each brace begins on a new line. A single line statement block can go without braces but the block must be properly indented on its own line and must not be nested in other statement blocks that use braces (See issue 381 for examples). One exception is that a using statement is permitted to be nested within another using statement by starting on the following line at the same indentation level, even if the nested using contains a controlled block.

The document: https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/inheritance
