### PR TITLE
Fixed a typo-bug that caused the InitializationSample in "Object and Collection Initializers" to throw a compiler error

### DIFF
--- a/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs
@@ -129,12 +129,19 @@ namespace object_collection_initializers
             // Auto-implemented properties.
             public int Age { get; set; }
             public string Name { get; set; }
+
+            public Cat() { }
+
+            public Cat(string name)
+            {
+                Name = name;
+            }
         }
 
         public static void Main()
         {
             Cat cat = new Cat { Age = 10, Name = "Fluffy" };
-            Cat sameCat = new Cat { Age = 10, Name = "Fluffy" };
+            Cat sameCat = new Cat("Fluffy"){ Age = 10 };
 
             List<Cat> cats = new List<Cat>
             {

--- a/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/BasicObjectInitializers.cs
@@ -134,19 +134,19 @@ namespace object_collection_initializers
         public static void Main()
         {
             Cat cat = new Cat { Age = 10, Name = "Fluffy" };
-            Cat sameCat = new Cat("Fluffy"){ Age = 10 };
+            Cat sameCat = new Cat { Age = 10, Name = "Fluffy" };
 
             List<Cat> cats = new List<Cat>
             {
-                new Cat{ Name = "Sylvester", Age=8 },
-                new Cat{ Name = "Whiskers", Age=2 },
-                new Cat{ Name = "Sasha", Age=14 }
+                new Cat { Name = "Sylvester", Age = 8 },
+                new Cat { Name = "Whiskers", Age = 2 },
+                new Cat { Name = "Sasha", Age = 14 }
             };
 
             List<Cat> moreCats = new List<Cat>
             {
-                new Cat{ Name = "Furrytail", Age=5 },
-                new Cat{ Name = "Peaches", Age=4 },
+                new Cat { Name = "Furrytail", Age = 5 },
+                new Cat { Name = "Peaches", Age = 4 },
                 null
             };
 


### PR DESCRIPTION
## Summary

I changed the line `Cat sameCat = new Cat("Fluffy"){ Age = 10 };` to take full advantage of object initialization and made spacing in the snippet consistent.

Fixes dotnet/docs#11223
