### PR TITLE
Make threading issue easier to reproduce

### DIFF
--- a/snippets/csharp/language-reference/keywords/volatile/Program.cs
+++ b/snippets/csharp/language-reference/keywords/volatile/Program.cs
@@ -21,9 +21,10 @@ namespace VolatileTests
         // This method is called when the thread is started.
         public void DoWork()
         {
+            bool work = false;
             while (!_shouldStop)
             {
-                Console.WriteLine("Worker thread: working...");
+                work = !work; // simulate some work
             }
             Console.WriteLine("Worker thread: terminating gracefully.");
         }
@@ -54,7 +55,7 @@ namespace VolatileTests
 
             // Put the main thread to sleep for 1 millisecond to
             // allow the worker thread to do some work.
-            Thread.Sleep(1);
+            Thread.Sleep(500);
 
             // Request that the worker thread stop itself.
             workerObject.RequestStop();
@@ -66,12 +67,6 @@ namespace VolatileTests
         }
         // Sample output:
         // Main thread: starting worker thread...
-        // Worker thread: working...
-        // Worker thread: working...
-        // Worker thread: working...
-        // Worker thread: working...
-        // Worker thread: working...
-        // Worker thread: working...
         // Worker thread: terminating gracefully.
         // Main thread: worker thread has terminated.
     }

--- a/snippets/csharp/language-reference/keywords/volatile/Program.cs
+++ b/snippets/csharp/language-reference/keywords/volatile/Program.cs
@@ -53,7 +53,7 @@ namespace VolatileTests
             while (!workerThread.IsAlive)
                 ;
 
-            // Put the main thread to sleep for 1 millisecond to
+            // Put the main thread to sleep for 500 millisecond to
             // allow the worker thread to do some work.
             Thread.Sleep(500);
 


### PR DESCRIPTION
Change DoWork method and Thread.Sleep time to have a working example of why volatile is needed that will hopefully be reproducible on a wider range of systems.

To understand why volatile is needed, we must do the following:
- Run the program in both debug and release. Everything works as expected. :)
- Now remove the volatile keyword:
  - In Debug mode  (`dotnet run`) the program still works.
  - In Release mode  (`dotnet run -c Release`) it hangs forever.

As an interesting bonus:
When asking a friend to run this code he ran it as part of our unit testing system and the issue was triggered in debug and with a thread sleep of only 1. This confirms that some variation is possible and to be expected.

Hopefully this example helps trigger the behavior for the most number of people.

Closes  #10436

## Summary

In both the previous and this version of the code the volatile keyword are necessary to make the code correct.
Unfortunately in the previous version removing the volatile keyword would have no observable effect (for most people).
This is just because threading behavior is naturally hard to reliably reproduce.

With this new version we should have more systems where removing the volatile keyword would cause a noticeable difference (program hangs forever).

Closes  dotnet/docs#10436
