### PR TITLE
Sample output from 2007 to 2006

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.Conversions/cs/System.TimeZone2.Conversions.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.Conversions/cs/System.TimeZone2.Conversions.cs
@@ -63,8 +63,8 @@ public class TimeZoneConversion
       //    Converting 8/31/2007 9:26:28 PM, Kind Utc
       //       ConvertTimeToUtc: 8/31/2007 9:26:28 PM, Kind Utc
       //    
-      //    Converting 10/26/2007 1:32:00 PM, Kind Unspecified
-      //       ConvertTimeToUtc: 10/26/2007 8:32:00 PM, Kind Utc
+      //    Converting 10/26/2006 1:32:00 PM, Kind Unspecified
+      //       ConvertTimeToUtc: 10/26/2006 8:32:00 PM, Kind Utc
       //    
       //    Converting 11/4/2007 1:30:00 AM, Kind Unspecified, Ambiguous True
       //       ConvertTimeToUtc: 11/4/2007 9:30:00 AM, Kind Utc


### PR DESCRIPTION
## Summary

The ConvertTimeToUtc(DateTime) example contains a typo #1693
Changed the sample output shown for the third conversion from 2007 to 2006.