### PR TITLE
formatting changes

### DIFF
--- a/csharp/tutorials/patterns/finished/toll-calculator/TollCalculator.cs
+++ b/csharp/tutorials/patterns/finished/toll-calculator/TollCalculator.cs
@@ -34,7 +34,7 @@ namespace toll_calculator
                 DeliveryTruck t when (t.GrossWeightClass < 3000) => 10.00m - 2.00m,
                 DeliveryTruck t => 10.00m,
 
-                { } => throw new ArgumentException(message: "Not a known vehicle type", paramName: nameof(vehicle)),
+                { }  => throw new ArgumentException(message: "Not a known vehicle type", paramName: nameof(vehicle)),
                 null => throw new ArgumentNullException(nameof(vehicle))
             };
 
@@ -42,11 +42,11 @@ namespace toll_calculator
         public decimal PeakTimePremium(DateTime timeOfToll, bool inbound) =>
             (IsWeekDay(timeOfToll), GetTimeBand(timeOfToll), inbound) switch
             {
-                (true, TimeBand.Overnight, _) => 0.75m,
-                (true, TimeBand.Daytime, _) => 1.5m,
-                (true, TimeBand.MorningRush, true) => 2.0m,
+                (true, TimeBand.Overnight,   _)     => 0.75m,
+                (true, TimeBand.Daytime,     _)     => 1.5m,
+                (true, TimeBand.MorningRush, true)  => 2.0m,
                 (true, TimeBand.EveningRush, false) => 2.0m,
-                (_, _, _) => 1.0m,
+                (_,    _,                    _)     => 1.0m,
             };
         // </SnippetFinalTuplePattern>
 
@@ -54,22 +54,22 @@ namespace toll_calculator
         public decimal PeakTimePremiumFull(DateTime timeOfToll, bool inbound) =>
             (IsWeekDay(timeOfToll), GetTimeBand(timeOfToll), inbound) switch
             {
-                (true, TimeBand.MorningRush, true)   => 2.00m,
-                (true, TimeBand.MorningRush, false)  => 1.00m,
-                (true, TimeBand.Daytime, true)       => 1.50m,
-                (true, TimeBand.Daytime, false)      => 1.50m,
-                (true, TimeBand.EveningRush, true)   => 1.00m,
-                (true, TimeBand.EveningRush, false)  => 2.00m,
-                (true, TimeBand.Overnight, true)     => 0.75m,
-                (true, TimeBand.Overnight, false)    => 0.75m,
+                (true,  TimeBand.MorningRush, true)  => 2.00m,
+                (true,  TimeBand.MorningRush, false) => 1.00m,
+                (true,  TimeBand.Daytime,     true)  => 1.50m,
+                (true,  TimeBand.Daytime,     false) => 1.50m,
+                (true,  TimeBand.EveningRush, true)  => 1.00m,
+                (true,  TimeBand.EveningRush, false) => 2.00m,
+                (true,  TimeBand.Overnight,   true)  => 0.75m,
+                (true,  TimeBand.Overnight,   false) => 0.75m,
                 (false, TimeBand.MorningRush, true)  => 1.00m,
                 (false, TimeBand.MorningRush, false) => 1.00m,
-                (false, TimeBand.Daytime, true)      => 1.00m,
-                (false, TimeBand.Daytime, false)     => 1.00m,
+                (false, TimeBand.Daytime,     true)  => 1.00m,
+                (false, TimeBand.Daytime,     false) => 1.00m,
                 (false, TimeBand.EveningRush, true)  => 1.00m,
                 (false, TimeBand.EveningRush, false) => 1.00m,
-                (false, TimeBand.Overnight, true)    => 1.00m,
-                (false, TimeBand.Overnight, false)   => 1.00m,
+                (false, TimeBand.Overnight,   true)  => 1.00m,
+                (false, TimeBand.Overnight,   false) => 1.00m,
             };
         // </SnippetTuplePatternOne>
 
@@ -78,8 +78,9 @@ namespace toll_calculator
         private static bool IsWeekDay(DateTime timeOfToll) =>
             timeOfToll.DayOfWeek switch
             {
-                DayOfWeek.Saturday, DayOfWeek.Sunday => false,
-                _ => true
+                DayOfWeek.Saturday => false,
+                DayOfWeek.Sunday   => false,
+                _                  => true
             };
         // </SnippetIsWeekDay>
 


### PR DESCRIPTION
1. Use "tabular formatting" to make the switch arms more readable.
1. The syntax for multiple patterns in the same switch arm is not in public preview yet.

/cc @MadsTorgersen 