### PR TITLE
Examples for redirecting process output

### DIFF
--- a/snippets/csharp/api/system.diagnostics/process/standarderror/stderror-sync.cs
+++ b/snippets/csharp/api/system.diagnostics/process/standarderror/stderror-sync.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Diagnostics;
+
+public class Example
+{
+   public static void Main()
+   {
+      var p = new Process();  
+      p.StartInfo.UseShellExecute = false;  
+      p.StartInfo.RedirectStandardError = true;  
+      p.StartInfo.FileName = "Write500Lines.exe";  
+      p.Start();  
+
+      // To avoid deadlocks, always read the output stream first and then wait.  
+      string output = p.StandardError.ReadToEnd();  
+      p.WaitForExit();
+
+      Console.WriteLine($"\nError stream: {output}");
+   }
+}
+// The end of the output produced by the example includes the following:
+//      Error stream:
+//      Successfully wrote 500 lines.

--- a/snippets/csharp/api/system.diagnostics/process/standardoutput/stdoutput-async.cs
+++ b/snippets/csharp/api/system.diagnostics/process/standardoutput/stdoutput-async.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Diagnostics;
+
+public class Example
+{
+   public static void Main()
+   {
+      var p = new Process();  
+      p.StartInfo.UseShellExecute = false;  
+      p.StartInfo.RedirectStandardOutput = true;  
+      string eOut = null;
+      p.StartInfo.RedirectStandardError = true;
+      p.ErrorDataReceived += new DataReceivedEventHandler((sender, e) => 
+                                 { eOut += e.Data; });
+      p.StartInfo.FileName = "Write500Lines.exe";  
+      p.Start();  
+
+      // To avoid deadlocks, use an asynchronous read operation on at least one of the streams.  
+      p.BeginErrorReadLine();
+      string output = p.StandardOutput.ReadToEnd();  
+      p.WaitForExit();
+
+      Console.WriteLine($"The last 50 characters in the output stream are:\n'{output.Substring(output.Length - 50)}'");
+      Console.WriteLine($"\nError stream: {eOut}");
+   }
+}
+// The example displays the following output:
+//      The last 50 characters in the output stream are:
+//      ' 49,800.20%
+//      Line 500 of 500 written: 49,900.20%
+//      '
+//
+//      Error stream: Successfully wrote 500 lines.
+

--- a/snippets/csharp/api/system.diagnostics/process/standardoutput/stdoutput-sync.cs
+++ b/snippets/csharp/api/system.diagnostics/process/standardoutput/stdoutput-sync.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Diagnostics;
+
+public class Example
+{
+   public static void Main()
+   {
+      var p = new Process();  
+      p.StartInfo.UseShellExecute = false;  
+      p.StartInfo.RedirectStandardOutput = true;  
+      p.StartInfo.FileName = "Write500Lines.exe";  
+      p.Start();  
+
+      // To avoid deadlocks, always read the output stream first and then wait.  
+      string output = p.StandardOutput.ReadToEnd();  
+      p.WaitForExit();
+
+      Console.WriteLine($"The last 50 characters in the output stream are:\n'{output.Substring(output.Length - 50)}'");
+   }
+}
+// The example displays the following output:
+//      Successfully wrote 500 lines.
+//
+//      The last 50 characters in the output stream are:
+//      ' 49,800.20%
+//      Line 500 of 500 written: 49,900.20%
+//      '

--- a/snippets/csharp/api/system.diagnostics/process/standardoutput/write500lines.cs
+++ b/snippets/csharp/api/system.diagnostics/process/standardoutput/write500lines.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+
+public class Example
+{
+   public static void Main()
+   {
+      for (int ctr = 0; ctr < 500; ctr++)
+         Console.WriteLine($"Line {ctr + 1} of 500 written: {ctr + 1/500.0:P2}");
+
+      Console.Error.WriteLine("\nSuccessfully wrote 500 lines.\n");
+   }
+}
+// The example displays the following output:
+//      The last 50 characters in the output stream are:
+//      ' 49,800.20%
+//      Line 500 of 500 written: 49,900.20%
+//'
+//
+//      Error stream: Successfully wrote 500 lines.

--- a/snippets/visualbasic/api/system.diagnostics/process/standarderror/stderror-sync.vb
+++ b/snippets/visualbasic/api/system.diagnostics/process/standarderror/stderror-sync.vb
@@ -1,0 +1,20 @@
+Imports System.Diagnostics'
+
+Public Module Example
+   Public Sub Main()
+      Dim p As New Process()
+      p.StartInfo.UseShellExecute = False  
+      p.StartInfo.RedirectStandardError = True  
+      p.StartInfo.FileName = "Write500Lines.exe"  
+      p.Start() 
+
+      ' To avoid deadlocks, always read the output stream first and then wait.  
+      Dim output As String = p.StandardError.ReadToEnd()  
+      p.WaitForExit()
+
+      Console.WriteLine($"\nError stream: {output}");
+   End Sub
+End Module
+' The end of the output produced by the example includes the following:
+'      Error stream:
+'      Successfully wrote 500 lines.

--- a/snippets/visualbasic/api/system.diagnostics/process/standardoutput/Write500Lines.vb
+++ b/snippets/visualbasic/api/system.diagnostics/process/standardoutput/Write500Lines.vb
@@ -1,0 +1,18 @@
+Imports System.IO
+
+Public Module Example
+   Public Sub Main()
+      For ctr As Integer = 0 To 499
+         Console.WriteLine($"Line {ctr + 1} of 500 written: {ctr + 1/500.0:P2}")
+      Next
+
+      Console.Error.WriteLine($"{vbCrLf}Successfully wrote 500 lines.{vbCrLf}")
+   End Sub
+End Module
+' The example displays the following output:
+'      The last 50 characters in the output stream are:
+'      ' 49,800.20%
+'      Line 500 of 500 written: 49,900.20%
+'
+'
+'      Error stream: Successfully wrote 500 lines.

--- a/snippets/visualbasic/api/system.diagnostics/process/standardoutput/stdoutput-async.vb
+++ b/snippets/visualbasic/api/system.diagnostics/process/standardoutput/stdoutput-async.vb
@@ -1,0 +1,29 @@
+Imports System.Diagnostics
+
+Public Module Example
+   Public Sub Main()
+      Dim p As New Process()  
+      p.StartInfo.UseShellExecute = False  
+      p.StartInfo.RedirectStandardOutput = True  
+      Dim eOut As String = Nothing
+      p.StartInfo.RedirectStandardError = True
+      AddHandler p.ErrorDataReceived, Sub(sender, e) eOut += e.Data 
+      p.StartInfo.FileName = "Write500Lines.exe"  
+      p.Start()  
+
+      ' To avoid deadlocks, use an asynchronous read operation on at least one of the streams.  
+      p.BeginErrorReadLine()
+      Dim output As String = p.StandardOutput.ReadToEnd()  
+      p.WaitForExit()
+
+      Console.WriteLine($"The last 50 characters in the output stream are:{vbCrLf}'{output.Substring(output.Length - 50)}'")
+      Console.WriteLine($"{vbCrLf}Error stream: {eOut}")
+   End Sub
+End Module
+' The example displays the following output:
+'      The last 50 characters in the output stream are:
+'      ' 49,800.20%
+'      Line 500 of 500 written: 49,900.20%
+'      '
+'
+'      Error stream: Successfully wrote 500 lines.

--- a/snippets/visualbasic/api/system.diagnostics/process/standardoutput/stdoutput-sync.vb
+++ b/snippets/visualbasic/api/system.diagnostics/process/standardoutput/stdoutput-sync.vb
@@ -1,0 +1,24 @@
+Imports System.Diagnostics'
+
+Public Module Example
+   Public Sub Main()
+      Dim p As New Process()
+      p.StartInfo.UseShellExecute = False  
+      p.StartInfo.RedirectStandardOutput = True  
+      p.StartInfo.FileName = "Write500Lines.exe"  
+      p.Start() 
+
+      ' To avoid deadlocks, always read the output stream first and then wait.  
+      Dim output As String = p.StandardOutput.ReadToEnd()  
+      p.WaitForExit()
+
+      Console.WriteLine($"The last 50 characters in the output stream are:\n'{output.Substring(output.Length - 50)}'")
+   End Sub
+End Module
+' The example displays the following output:
+'      Successfully wrote 500 lines.
+'
+'      The last 50 characters in the output stream are:
+'      ' 49,800.20%
+'      Line 500 of 500 written: 49,900.20%
+'      '


### PR DESCRIPTION
## Examples for redirecting process output

Related to dotnet/docs#2048

This PR:
- Moves inline samples to the dotnet/samples repo.
- Provides a simple example that Process.Start can launch.
- Corrects a code error (standard output rather than standard input was redirected).

