### PR TITLE
Fix compile

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.Reflection.Assembly/CS/getcallingassembly1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Reflection.Assembly/CS/getcallingassembly1.cs
@@ -22,18 +22,20 @@ namespace FirstAssembly
 }
 
 // Assembly SecondAssembly
-//using System;
-//using System.Reflection;
-//using System.Runtime.CompilerServices;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace SecondAssembly
 {
-    class InSecondAssembly () {
-  [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void OtherMethod()
+    class InSecondAssembly
     {
-        Console.WriteLine("OtherMehod executing assembly: " + Assembly.GetExecutingAssembly().FullName);
-        Console.WriteLine("OtherMethod called from: " + Assembly.GetCallingAssembly().FullName);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void OtherMethod()
+        {
+            Console.WriteLine("OtherMehod executing assembly: " + Assembly.GetExecutingAssembly().FullName);
+            Console.WriteLine("OtherMethod called from: " + Assembly.GetCallingAssembly().FullName);
+        }
     }
 }
 // The example produces output like the following:

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Reflection.Assembly/CS/getcallingassembly1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Reflection.Assembly/CS/getcallingassembly1.cs
@@ -3,32 +3,38 @@
 using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-namespace FirstAssembly {
-public class InFirstAssembly {
-  public static void Main () {
-     FistMethod ();
-     SecondAssembly.InSecondAssembly.OtherMethod ();
-  }
+namespace FirstAssembly
+{
+    public class InFirstAssembly
+    {
+        public static void Main()
+        {
+            FistMethod();
+            SecondAssembly.InSecondAssembly.OtherMethod();
+        }
 
-  [MethodImpl(MethodImplOptions.NoInlining)]
-  public static void FirstMethod () {
-    Console.WriteLine ("FirstMethod called from: " + Assembly.GetCallingAssembly ().FullName);
-  }
-}
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void FirstMethod()
+        {
+            Console.WriteLine("FirstMethod called from: " + Assembly.GetCallingAssembly().FullName);
+        }
+    }
 }
 
 // Assembly SecondAssembly
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
+//using System;
+//using System.Reflection;
+//using System.Runtime.CompilerServices;
 
-namespace SecondAssembly {
-class InSecondAssembly () {
-  [MethodImpl (MethodImplOptions.NoInlining)]
-  public static void OtherMethod () {
-    Console.WriteLine ("OtherMehod executing assembly: " + Assembly.GetExecutingAssembly ().FullName);
-    Console.WriteLine ("OtherMethod called from: " + Assembly.GetCallingAssembly ().FullName);
-  }
+namespace SecondAssembly
+{
+    class InSecondAssembly () {
+  [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void OtherMethod()
+    {
+        Console.WriteLine("OtherMehod executing assembly: " + Assembly.GetExecutingAssembly().FullName);
+        Console.WriteLine("OtherMethod called from: " + Assembly.GetCallingAssembly().FullName);
+    }
 }
 // The example produces output like the following:
 // "FirstMethod called from: FirstAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"


### PR DESCRIPTION
## Summary

The bracket can not be added after the class name.

[Assembly.GetCallingAssembly Method (System.Reflection)](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getcallingassembly?view=netframework-4.7.2#System_Reflection_Assembly_GetCallingAssembly )

![](https://user-images.githubusercontent.com/16054566/54859463-6cceff80-4d48-11e9-8e03-1c16269be270.png)

