### PR TITLE
Update snippet to use simper AND syntax

### DIFF
--- a/snippets/fsharp/lang-ref-2/snippet5005.fs
+++ b/snippets/fsharp/lang-ref-2/snippet5005.fs
@@ -19,14 +19,10 @@ let examineNumber x =
       | _ -> ()
 
 let findSquareCubes x =
-   if (match x with
-       | Cube x -> true
-       | _ -> false
-       &&
-       match x with
-       | Square x -> true
-       | _ -> false
-      )
-   then printf "%d \n" x
+   match x with
+       | Cube x & Square _ -> printfn "%d is a cube and a square" x
+       | Cube x -> printfn "%d is a cube" x
+       | _ -> ()
+         
 
-[ 1 .. 1000000 ] |> List.iter (fun elem -> findSquareCubes elem)
+[ 1 .. 1000 ] |> List.iter (fun elem -> findSquareCubes elem)


### PR DESCRIPTION
## Summary

Hello, I am updating this snippet to simplify the match expression and show that & matching could be used to combine active patterns. There is an accompanying pull on the docs repository, which I will link to this. 

Fixes dotnet/docs#Issue_Number (if available)
