### PR TITLE
Removed double extern "C" declaration

### DIFF
--- a/core/extensions/DllMapDemo/NewLib.cpp
+++ b/core/extensions/DllMapDemo/NewLib.cpp
@@ -1,12 +1,10 @@
-#include <stdio.h>
-
 #if defined(__GNUC__)
 #define EXPORT extern "C" __attribute__((visibility("default")))
 #elif defined(_MSC_VER)
 #define EXPORT extern "C" __declspec(dllexport)
 #endif 
 
-extern "C" EXPORT int NativeSum(int a, int b)
+EXPORT int NativeSum(int a, int b)
 {
     return a + b;
 }


### PR DESCRIPTION
Follow up to https://github.com/dotnet/samples/pull/668 (missed the review there).

`extern "C"` is already part of the macro `EXPORT`, so after expansion it would be

```c++
extern "C" extern "C" __declspec(dllexport) int NativeSum(int a, int b)
```
(for VC++).

Also removed the unneeded header `stdio.h`.