### PR TITLE
Remove unnecessary and wrong locking code

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsContextual/CS/csrefKeywordsContextual.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsContextual/CS/csrefKeywordsContextual.cs
@@ -225,30 +225,16 @@ namespace csrefKeywordsContextual
     }
 
 
-    //<Snippet15>    
-
+    //<Snippet15>
     class Events : IDrawingObject
     {
         event EventHandler PreDrawEvent;
 
         event EventHandler IDrawingObject.OnDraw
         {
-            add
-            {
-                lock (PreDrawEvent)
-                {
-                    PreDrawEvent += value;
-                }
-            }
-            remove
-            {
-                lock (PreDrawEvent)
-                {
-                    PreDrawEvent -= value;
-                }
-            }
+            add => PreDrawEvent += value;
+            remove => PreDrawEvent -= value;
         }
-
     }
     //</Snippet15>
     interface IDrawingObject


### PR DESCRIPTION
Fixes dotnet/docs#6472

Note: The second comment about registering `OnDraw`if `PreDrawEvent` is emtpy is not correct. The code works as checked in.

