### PR TITLE
Correction to the definition of Force in the example

### DIFF
--- a/snippets/fsharp/lang-ref-2/snippet6901.fs
+++ b/snippets/fsharp/lang-ref-2/snippet6901.fs
@@ -19,7 +19,7 @@
 [<Measure>] type s
 
 // Force, Newtons.
-[<Measure>] type N = kg m / s
+[<Measure>] type N = kg m / s^2
 
 // Pressure, bar.
 [<Measure>] type bar


### PR DESCRIPTION
The correct conversion for units of force it N = Kg m / s^2 based on the physics formula F = ma.

https://en.wikipedia.org/wiki/Newton_(unit)#Definition

