### PR TITLE
Move embedded code example in articles to code repo

### DIFF
--- a/snippets/csharp/VS_Snippets_Network/RequestDataUsingWebRequest/cs/WebRequestGetExample.cs
+++ b/snippets/csharp/VS_Snippets_Network/RequestDataUsingWebRequest/cs/WebRequestGetExample.cs
@@ -1,34 +1,35 @@
 using System;  
 using System.IO;  
 using System.Net;  
-using System.Text;  
   
-namespace Examples.System.Net  
-{  
-    public class WebRequestGetExample  
-    {  
-        public static void Main()  
-        {  
+namespace Examples.System.Net
+{
+    public class WebRequestGetExample
+    {
+        public static void Main()
+        {
             // Create a request for the URL.   
-            WebRequest request = WebRequest.Create(  
-              "http://www.contoso.com/default.html");  
+            WebRequest request = WebRequest.Create(
+              "http://www.contoso.com/default.html");
             // If required by the server, set the credentials.  
-            request.Credentials = CredentialCache.DefaultCredentials;  
+            request.Credentials = CredentialCache.DefaultCredentials;
             // Get the response.  
-            WebResponse response = request.GetResponse();  
+            WebResponse response = request.GetResponse();
             // Display the status.  
-            Console.WriteLine (((HttpWebResponse)response).StatusDescription);  
-            // Get the stream containing content returned by the server.  
-            Stream dataStream = response.GetResponseStream();  
-            // Open the stream using a StreamReader for easy access.  
-            StreamReader reader = new StreamReader(dataStream);  
-            // Read the content.  
-            string responseFromServer = reader.ReadToEnd();  
-            // Display the content.  
-            Console.WriteLine(responseFromServer);  
-            // Clean up the streams and the response.  
-            reader.Close();  
-            response.Close();  
-        }  
-    }  
-}  
+            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
+            // Get the stream containing content returned by the server. 
+            // The using block ensures the stream is automatically closed. 
+            using (Stream dataStream = response.GetResponseStream())
+            {
+                // Open the stream using a StreamReader for easy access.  
+                StreamReader reader = new StreamReader(dataStream);
+                // Read the content.  
+                string responseFromServer = reader.ReadToEnd();
+                // Display the content.  
+                Console.WriteLine(responseFromServer);
+            }
+            // Close the response.  
+            response.Close();
+        }
+    }
+}

--- a/snippets/csharp/VS_Snippets_Network/RequestDataUsingWebRequest/cs/WebRequestGetExample.cs
+++ b/snippets/csharp/VS_Snippets_Network/RequestDataUsingWebRequest/cs/WebRequestGetExample.cs
@@ -1,0 +1,34 @@
+using System;  
+using System.IO;  
+using System.Net;  
+using System.Text;  
+  
+namespace Examples.System.Net  
+{  
+    public class WebRequestGetExample  
+    {  
+        public static void Main()  
+        {  
+            // Create a request for the URL.   
+            WebRequest request = WebRequest.Create(  
+              "http://www.contoso.com/default.html");  
+            // If required by the server, set the credentials.  
+            request.Credentials = CredentialCache.DefaultCredentials;  
+            // Get the response.  
+            WebResponse response = request.GetResponse();  
+            // Display the status.  
+            Console.WriteLine (((HttpWebResponse)response).StatusDescription);  
+            // Get the stream containing content returned by the server.  
+            Stream dataStream = response.GetResponseStream();  
+            // Open the stream using a StreamReader for easy access.  
+            StreamReader reader = new StreamReader(dataStream);  
+            // Read the content.  
+            string responseFromServer = reader.ReadToEnd();  
+            // Display the content.  
+            Console.WriteLine(responseFromServer);  
+            // Clean up the streams and the response.  
+            reader.Close();  
+            response.Close();  
+        }  
+    }  
+}  

--- a/snippets/csharp/VS_Snippets_Network/SendDataUsingWebRequest/cs/WebRequestPostExample.cs
+++ b/snippets/csharp/VS_Snippets_Network/SendDataUsingWebRequest/cs/WebRequestPostExample.cs
@@ -1,47 +1,48 @@
-using System;  
-using System.IO;  
-using System.Net;  
-using System.Text;  
-  
-namespace Examples.System.Net  
-{  
-    public class WebRequestPostExample  
-    {  
-        public static void Main ()  
-        {  
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace Examples.System.Net
+{
+    public class WebRequestPostExample
+    {
+        public static void Main()
+        {
             // Create a request using a URL that can receive a post.   
-            WebRequest request = WebRequest.Create ("http://www.contoso.com/PostAccepter.aspx ");  
+            WebRequest request = WebRequest.Create("http://www.contoso.com/PostAccepter.aspx ");
             // Set the Method property of the request to POST.  
-            request.Method = "POST";  
+            request.Method = "POST";
             // Create POST data and convert it to a byte array.  
-            string postData = "This is a test that posts this string to a Web server.";  
-            byte[] byteArray = Encoding.UTF8.GetBytes (postData);  
+            string postData = "This is a test that posts this string to a Web server.";
+            byte[] byteArray = Encoding.UTF8.GetBytes(postData);
             // Set the ContentType property of the WebRequest.  
-            request.ContentType = "application/x-www-form-urlencoded";  
+            request.ContentType = "application/x-www-form-urlencoded";
             // Set the ContentLength property of the WebRequest.  
-            request.ContentLength = byteArray.Length;  
+            request.ContentLength = byteArray.Length;
             // Get the request stream.  
-            Stream dataStream = request.GetRequestStream ();  
+            Stream dataStream = request.GetRequestStream();
             // Write the data to the request stream.  
-            dataStream.Write (byteArray, 0, byteArray.Length);  
+            dataStream.Write(byteArray, 0, byteArray.Length);
             // Close the Stream object.  
-            dataStream.Close ();  
+            dataStream.Close();
             // Get the response.  
-            WebResponse response = request.GetResponse ();  
+            WebResponse response = request.GetResponse();
             // Display the status.  
-            Console.WriteLine (((HttpWebResponse)response).StatusDescription);  
+            Console.WriteLine(((HttpWebResponse)response).StatusDescription);
             // Get the stream containing content returned by the server.  
-            dataStream = response.GetResponseStream ();  
-            // Open the stream using a StreamReader for easy access.  
-            StreamReader reader = new StreamReader (dataStream);  
-            // Read the content.  
-            string responseFromServer = reader.ReadToEnd ();  
-            // Display the content.  
-            Console.WriteLine (responseFromServer);  
-            // Clean up the streams.  
-            reader.Close ();  
-            dataStream.Close ();  
-            response.Close ();  
-        }  
-    }  
-}  
+            // The using block ensures the stream is automatically closed.
+            using (dataStream = response.GetResponseStream())
+            {
+                // Open the stream using a StreamReader for easy access.  
+                StreamReader reader = new StreamReader(dataStream);
+                // Read the content.  
+                string responseFromServer = reader.ReadToEnd();
+                // Display the content.  
+                Console.WriteLine(responseFromServer);
+            }
+            // Close the response.  
+            response.Close();
+        }
+    }
+}

--- a/snippets/csharp/VS_Snippets_Network/SendDataUsingWebRequest/cs/WebRequestPostExample.cs
+++ b/snippets/csharp/VS_Snippets_Network/SendDataUsingWebRequest/cs/WebRequestPostExample.cs
@@ -1,0 +1,47 @@
+using System;  
+using System.IO;  
+using System.Net;  
+using System.Text;  
+  
+namespace Examples.System.Net  
+{  
+    public class WebRequestPostExample  
+    {  
+        public static void Main ()  
+        {  
+            // Create a request using a URL that can receive a post.   
+            WebRequest request = WebRequest.Create ("http://www.contoso.com/PostAccepter.aspx ");  
+            // Set the Method property of the request to POST.  
+            request.Method = "POST";  
+            // Create POST data and convert it to a byte array.  
+            string postData = "This is a test that posts this string to a Web server.";  
+            byte[] byteArray = Encoding.UTF8.GetBytes (postData);  
+            // Set the ContentType property of the WebRequest.  
+            request.ContentType = "application/x-www-form-urlencoded";  
+            // Set the ContentLength property of the WebRequest.  
+            request.ContentLength = byteArray.Length;  
+            // Get the request stream.  
+            Stream dataStream = request.GetRequestStream ();  
+            // Write the data to the request stream.  
+            dataStream.Write (byteArray, 0, byteArray.Length);  
+            // Close the Stream object.  
+            dataStream.Close ();  
+            // Get the response.  
+            WebResponse response = request.GetResponse ();  
+            // Display the status.  
+            Console.WriteLine (((HttpWebResponse)response).StatusDescription);  
+            // Get the stream containing content returned by the server.  
+            dataStream = response.GetResponseStream ();  
+            // Open the stream using a StreamReader for easy access.  
+            StreamReader reader = new StreamReader (dataStream);  
+            // Read the content.  
+            string responseFromServer = reader.ReadToEnd ();  
+            // Display the content.  
+            Console.WriteLine (responseFromServer);  
+            // Clean up the streams.  
+            reader.Close ();  
+            dataStream.Close ();  
+            response.Close ();  
+        }  
+    }  
+}  

--- a/snippets/visualbasic/VS_Snippets_Network/RequestDataUsingWebRequest/vb/WebRequestGetExample.vb
+++ b/snippets/visualbasic/VS_Snippets_Network/RequestDataUsingWebRequest/vb/WebRequestGetExample.vb
@@ -1,31 +1,30 @@
-Imports System  
-Imports System.IO  
-Imports System.Net  
-Imports System.Text  
+Imports System.IO
+Imports System.Net
 
-Namespace Examples.System.Net  
-    Public Class WebRequestGetExample  
-        Public Shared Sub Main()  
+Namespace Examples.System.Net
+    Public Class WebRequestGetExample
+        Public Shared Sub Main()
             ' Create a request for the URL.   
-            Dim request As WebRequest = _  
-              WebRequest.Create("http://www.contoso.com/default.html")  
+            Dim request As WebRequest =
+              WebRequest.Create("http://www.contoso.com/default.html")
             ' If required by the server, set the credentials.  
-            request.Credentials = CredentialCache.DefaultCredentials  
+            request.Credentials = CredentialCache.DefaultCredentials
             ' Get the response.  
-            Dim response As WebResponse = request.GetResponse()  
+            Dim response As WebResponse = request.GetResponse()
             ' Display the status.  
-            Console.WriteLine(CType(response,HttpWebResponse).StatusDescription)  
-            ' Get the stream containing content returned by the server.  
-            Dim dataStream As Stream = response.GetResponseStream()  
-            ' Open the stream using a StreamReader for easy access.  
-            Dim reader As New StreamReader(dataStream)  
-            ' Read the content.  
-            Dim responseFromServer As String = reader.ReadToEnd()  
-            ' Display the content.  
-            Console.WriteLine(responseFromServer)  
-            ' Clean up the streams and the response.  
-            reader.Close()  
-            response.Close()  
-        End Sub   
-    End Class   
-End Namespace  
+            Console.WriteLine(CType(response, HttpWebResponse).StatusDescription)
+            ' Get the stream containing content returned by the server. 
+            ' The using block ensures the stream is automatically closed.
+            Using dataStream As Stream = response.GetResponseStream()
+                ' Open the stream using a StreamReader for easy access.  
+                Dim reader As New StreamReader(dataStream)
+                ' Read the content.  
+                Dim responseFromServer As String = reader.ReadToEnd()
+                ' Display the content.  
+                Console.WriteLine(responseFromServer)
+            End Using
+            ' Clean up the response.  
+            response.Close()
+        End Sub
+    End Class
+End Namespace

--- a/snippets/visualbasic/VS_Snippets_Network/RequestDataUsingWebRequest/vb/WebRequestGetExample.vb
+++ b/snippets/visualbasic/VS_Snippets_Network/RequestDataUsingWebRequest/vb/WebRequestGetExample.vb
@@ -1,0 +1,31 @@
+Imports System  
+Imports System.IO  
+Imports System.Net  
+Imports System.Text  
+
+Namespace Examples.System.Net  
+    Public Class WebRequestGetExample  
+        Public Shared Sub Main()  
+            ' Create a request for the URL.   
+            Dim request As WebRequest = _  
+              WebRequest.Create("http://www.contoso.com/default.html")  
+            ' If required by the server, set the credentials.  
+            request.Credentials = CredentialCache.DefaultCredentials  
+            ' Get the response.  
+            Dim response As WebResponse = request.GetResponse()  
+            ' Display the status.  
+            Console.WriteLine(CType(response,HttpWebResponse).StatusDescription)  
+            ' Get the stream containing content returned by the server.  
+            Dim dataStream As Stream = response.GetResponseStream()  
+            ' Open the stream using a StreamReader for easy access.  
+            Dim reader As New StreamReader(dataStream)  
+            ' Read the content.  
+            Dim responseFromServer As String = reader.ReadToEnd()  
+            ' Display the content.  
+            Console.WriteLine(responseFromServer)  
+            ' Clean up the streams and the response.  
+            reader.Close()  
+            response.Close()  
+        End Sub   
+    End Class   
+End Namespace  

--- a/snippets/visualbasic/VS_Snippets_Network/SendDataUsingWebRequest/vb/WebRequestPostExample.vb
+++ b/snippets/visualbasic/VS_Snippets_Network/SendDataUsingWebRequest/vb/WebRequestPostExample.vb
@@ -1,0 +1,44 @@
+Imports System  
+Imports System.IO  
+Imports System.Net  
+Imports System.Text  
+
+Namespace Examples.System.Net  
+    Public Class WebRequestPostExample  
+        Public Shared Sub Main()  
+            ' Create a request using a URL that can receive a post.   
+            Dim request As WebRequest = WebRequest.Create("http://www.contoso.com/PostAccepter.aspx ")  
+            ' Set the Method property of the request to POST.  
+            request.Method = "POST"  
+            ' Create POST data and convert it to a byte array.  
+            Dim postData As String = "This is a test that posts this string to a Web server."  
+            Dim byteArray As Byte() = Encoding.UTF8.GetBytes(postData)  
+            ' Set the ContentType property of the WebRequest.  
+            request.ContentType = "application/x-www-form-urlencoded"  
+            ' Set the ContentLength property of the WebRequest.  
+            request.ContentLength = byteArray.Length  
+            ' Get the request stream.  
+            Dim dataStream As Stream = request.GetRequestStream()  
+            ' Write the data to the request stream.  
+            dataStream.Write(byteArray, 0, byteArray.Length)  
+            ' Close the Stream object.  
+            dataStream.Close()  
+            ' Get the response.  
+            Dim response As WebResponse = request.GetResponse()  
+            ' Display the status.  
+            Console.WriteLine(CType(response, HttpWebResponse).StatusDescription)  
+            ' Get the stream containing content returned by the server.  
+            dataStream = response.GetResponseStream()  
+            ' Open the stream using a StreamReader for easy access.  
+            Dim reader As New StreamReader(dataStream)  
+            ' Read the content.  
+            Dim responseFromServer As String = reader.ReadToEnd()  
+            ' Display the content.  
+            Console.WriteLine(responseFromServer)  
+            ' Clean up the streams.  
+            reader.Close()  
+            dataStream.Close()  
+            response.Close()  
+        End Sub  
+    End Class  
+End Namespace  

--- a/snippets/visualbasic/VS_Snippets_Network/SendDataUsingWebRequest/vb/WebRequestPostExample.vb
+++ b/snippets/visualbasic/VS_Snippets_Network/SendDataUsingWebRequest/vb/WebRequestPostExample.vb
@@ -1,44 +1,43 @@
-Imports System  
-Imports System.IO  
-Imports System.Net  
-Imports System.Text  
+Imports System.IO
+Imports System.Net
+Imports System.Text
 
-Namespace Examples.System.Net  
-    Public Class WebRequestPostExample  
-        Public Shared Sub Main()  
+Namespace Examples.System.Net
+    Public Class WebRequestPostExample
+        Public Shared Sub Main()
             ' Create a request using a URL that can receive a post.   
-            Dim request As WebRequest = WebRequest.Create("http://www.contoso.com/PostAccepter.aspx ")  
+            Dim request As WebRequest = WebRequest.Create("http://www.contoso.com/PostAccepter.aspx ")
             ' Set the Method property of the request to POST.  
-            request.Method = "POST"  
+            request.Method = "POST"
             ' Create POST data and convert it to a byte array.  
-            Dim postData As String = "This is a test that posts this string to a Web server."  
-            Dim byteArray As Byte() = Encoding.UTF8.GetBytes(postData)  
+            Dim postData As String = "This is a test that posts this string to a Web server."
+            Dim byteArray As Byte() = Encoding.UTF8.GetBytes(postData)
             ' Set the ContentType property of the WebRequest.  
-            request.ContentType = "application/x-www-form-urlencoded"  
+            request.ContentType = "application/x-www-form-urlencoded"
             ' Set the ContentLength property of the WebRequest.  
-            request.ContentLength = byteArray.Length  
+            request.ContentLength = byteArray.Length
             ' Get the request stream.  
-            Dim dataStream As Stream = request.GetRequestStream()  
+            Dim dataStream As Stream = request.GetRequestStream()
             ' Write the data to the request stream.  
-            dataStream.Write(byteArray, 0, byteArray.Length)  
+            dataStream.Write(byteArray, 0, byteArray.Length)
             ' Close the Stream object.  
-            dataStream.Close()  
+            dataStream.Close()
             ' Get the response.  
-            Dim response As WebResponse = request.GetResponse()  
+            Dim response As WebResponse = request.GetResponse()
             ' Display the status.  
-            Console.WriteLine(CType(response, HttpWebResponse).StatusDescription)  
+            Console.WriteLine(CType(response, HttpWebResponse).StatusDescription)
             ' Get the stream containing content returned by the server.  
-            dataStream = response.GetResponseStream()  
-            ' Open the stream using a StreamReader for easy access.  
-            Dim reader As New StreamReader(dataStream)  
-            ' Read the content.  
-            Dim responseFromServer As String = reader.ReadToEnd()  
-            ' Display the content.  
-            Console.WriteLine(responseFromServer)  
-            ' Clean up the streams.  
-            reader.Close()  
-            dataStream.Close()  
-            response.Close()  
-        End Sub  
-    End Class  
-End Namespace  
+            ' The using block ensures the stream is automatically closed.
+            Using dataStream1 As Stream = response.GetResponseStream()
+                ' Open the stream using a StreamReader for easy access.  
+                Dim reader As New StreamReader(dataStream1)
+                ' Read the content.  
+                Dim responseFromServer As String = reader.ReadToEnd()
+                ' Display the content.  
+                Console.WriteLine(responseFromServer)
+            End Using
+            ' Clean up the response.  
+            response.Close()
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
## Summary

Related to .NET refresh work for task 1409972: https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1409972/ and 
1409954: https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1409954/
See PRs #https://github.com/dotnet/docs/pull/11447, #https://github.com/dotnet/docs/pull/11461

As a best practice, move the C# and VB complete code example from the following articles to the samples repo:
https://docs.microsoft.com/en-us/dotnet/framework/network-programming/how-to-request-data-using-the-webrequest-class
https://docs.microsoft.com/en-us/dotnet/framework/network-programming/how-to-send-data-using-the-webrequest-class
