### PR TITLE
Including the 0 element in the iteration

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/EventLogEntry_Source/CS/eventlogentry_source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/EventLogEntry_Source/CS/eventlogentry_source.cs
@@ -38,7 +38,7 @@ using System.Diagnostics;
             EventLogEntryCollection myLogEntryCollection=myEventLog.Entries;
             int myCount =myLogEntryCollection.Count;
             // Iterate through all 'EventLogEntry' instances in 'EventLog'.
-            for(int i=myCount-1;i>0;i--)
+            for(int i=myCount-1;i>-1;i--)
             {
                EventLogEntry myLogEntry = myLogEntryCollection[i];
                // Select the entry having desired EventType.


### PR DESCRIPTION
When iterating a collection in a reverse order the 0 index should be included.

## Summary

This bit of code does not include the element at the position 0
`for(int i=myCount-1;i>0;i--)`
The proposed change is
`for(int i=myCount-1;i>-1;i--)`
