### PR TITLE
Including the 0 element in the iteration

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR/EventLogEntry_Source/CPP/eventlogentry_source.cpp
+++ b/snippets/cpp/VS_Snippets_CLR/EventLogEntry_Source/CPP/eventlogentry_source.cpp
@@ -48,7 +48,7 @@ int main()
    int myCount = myLogEntryCollection->Count;
    
    // Iterate through all 'EventLogEntry' instances in 'EventLog'.
-   for ( int i = myCount - 1; i > 0; i-- )
+   for ( int i = myCount - 1; i > -1; i-- )
    {
       EventLogEntry^ myLogEntry = myLogEntryCollection[ i ];
       


### PR DESCRIPTION
When iterating a collection in a reverse order the 0 index should be included.

## Summary

This bit of code does not include the element at the position 0
`for(int i=myCount-1;i>0;i--)`
The proposed change is
`for(int i=myCount-1;i>-1;i--)`