### PR TITLE
Fix data marshaling

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/conceptual.interop.marshaling/cs/msgbox.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.interop.marshaling/cs/msgbox.cs
@@ -9,20 +9,20 @@ public class LibWrap
     [DllImport("User32.dll", EntryPoint = "MessageBox",
         CharSet = CharSet.Auto)]
     public static extern int MsgBox(
-        IntPtr hWnd, string text, string caption, uint type);
+        IntPtr hWnd, string lpText, string lpCaption, uint uType);
 
     // Causes incorrect output in the message window.
     [DllImport("User32.dll", EntryPoint = "MessageBoxW",
         CharSet = CharSet.Ansi)]
     public static extern int MsgBox2(
-        IntPtr hWnd, string text, string caption, uint type);
+        IntPtr hWnd, string lpText, string lpCaption, uint uType);
 
     // Causes an exception to be thrown. EntryPoint, CharSet, and
     // ExactSpelling fields are mismatched.
     [DllImport("User32.dll", EntryPoint = "MessageBox",
         CharSet = CharSet.Ansi, ExactSpelling = true)]
     public static extern int MsgBox3(
-        IntPtr hWnd, string text, string caption, uint type);
+        IntPtr hWnd, string lpText, string lpCaption, uint uType);
 }
 //</snippet5>
 

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.interop.marshaling/cs/msgbox.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.interop.marshaling/cs/msgbox.cs
@@ -9,20 +9,20 @@ public class LibWrap
     [DllImport("User32.dll", EntryPoint = "MessageBox",
         CharSet = CharSet.Auto)]
     public static extern int MsgBox(
-        int hWnd, string text, string caption, uint type);
+        IntPtr hWnd, string text, string caption, uint type);
 
     // Causes incorrect output in the message window.
     [DllImport("User32.dll", EntryPoint = "MessageBoxW",
         CharSet = CharSet.Ansi)]
     public static extern int MsgBox2(
-        int hWnd, string text, string caption, uint type);
+        IntPtr hWnd, string text, string caption, uint type);
 
     // Causes an exception to be thrown. EntryPoint, CharSet, and
     // ExactSpelling fields are mismatched.
     [DllImport("User32.dll", EntryPoint = "MessageBox",
         CharSet = CharSet.Ansi, ExactSpelling = true)]
     public static extern int MsgBox3(
-        int hWnd, string text, string caption, uint type);
+        IntPtr hWnd, string text, string caption, uint type);
 }
 //</snippet5>
 


### PR DESCRIPTION
Contributes to dotnet/docs#11396
Continued from dotnet/docs#11450

It's a common mistake to marshal pointers as `int` type.

Related to dotnet/csharplang#2324. Is there anyone to review the PRs there?