### PR TITLE
Fixes dotnet/docs#2249

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/Classic OpenFileDialog Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/Classic OpenFileDialog Example/CS/source.cs
@@ -12,31 +12,31 @@ namespace WindowsFormsApp1
 
         //<Snippet1>
         var fileContent = string.Empty;
-            var filePath = string.Empty;
+        var filePath = string.Empty;
 
-            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+        using (OpenFileDialog openFileDialog = new OpenFileDialog())
+        {
+            openFileDialog.InitialDirectory = "c:\\";
+            openFileDialog.Filter = "txt files (*.txt)|*.txt|All files (*.*)|*.*";
+            openFileDialog.FilterIndex = 2;
+            openFileDialog.RestoreDirectory = true;
+
+            if (openFileDialog.ShowDialog() == DialogResult.OK)
             {
-                openFileDialog.InitialDirectory = "c:\\";
-                openFileDialog.Filter = "txt files (*.txt)|*.txt|All files (*.*)|*.*";
-                openFileDialog.FilterIndex = 2;
-                openFileDialog.RestoreDirectory = true;
+                //Get the path of specified file
+                filePath = openFileDialog.FileName;
 
-                if (openFileDialog.ShowDialog() == DialogResult.OK)
+                //Read the contents of the file into a stream
+                var fileStream = openFileDialog.OpenFile();
+
+                using (StreamReader reader = new StreamReader(fileStream))
                 {
-                    //Get the path of specified file
-                    filePath = openFileDialog.FileName;
-
-                    //Read the contents of the file into a stream
-                    var fileStream = openFileDialog.OpenFile();
-                    
-                    using (StreamReader reader = new StreamReader(fileStream))
-                    {
-                        fileContent = reader.ReadToEnd();
-                    }
+                    fileContent = reader.ReadToEnd();
                 }
             }
+        }
 
-            MessageBox.Show(fileContent, "File Content at path: " + filePath, MessageBoxButtons.OK);
+        MessageBox.Show(fileContent, "File Content at path: " + filePath, MessageBoxButtons.OK);
         //</Snippet1>
     }
 }


### PR DESCRIPTION
## Summary

Corrected the formatting for OpenFileDialog Class and OpenFileDialog.OpenFile Method.

Fixes dotnet/dotnet-api-docs#2249

edit by @mairaw: fixed the repo name
