### PR TITLE
Add comment with expected output for Uri.Equals

### DIFF
--- a/snippets/cpp/VS_Snippets_Remoting/NCLUriExamples/CPP/uriexamples.cpp
+++ b/snippets/cpp/VS_Snippets_Remoting/NCLUriExamples/CPP/uriexamples.cpp
@@ -67,6 +67,7 @@ namespace Example
          {
             Console::WriteLine( "The two addresses are not equal" );
          }
+         // Will output "The two addresses are equal"
          //</snippet8>
       }
 

--- a/snippets/csharp/VS_Snippets_Remoting/NCLUriExamples/CS/uriexamples.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/NCLUriExamples/CS/uriexamples.cs
@@ -65,6 +65,7 @@ namespace Example
                 Console.WriteLine("The two addresses are equal");
             else
                 Console.WriteLine("The two addresses are not equal");
+            // Will output "The two addresses are equal"
         //</snippet8>
         }
        

--- a/snippets/visualbasic/VS_Snippets_Remoting/NCLUriExamples/VB/uriexamples.vb
+++ b/snippets/visualbasic/VS_Snippets_Remoting/NCLUriExamples/VB/uriexamples.vb
@@ -62,6 +62,7 @@ Public Class Test
         Else
             Console.WriteLine("The two addresses are not equal")
         End If
+        ' Will output "The two addresses are equal"
      '</snippet8>
     End Sub 'SampleEquals
     


### PR DESCRIPTION
## Summary
Fixes dotnet/dotnet-api-docs#1815

Per the issue, the C#, C++, and VB docs did not display what the expected output would be.

This updates the text with the correct output.