### PR TITLE
Fixed compiler errors in BlockingCollection example

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.collections.concurrent.blockingcollection/cs/blockingcoll.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.collections.concurrent.blockingcollection/cs/blockingcoll.cs
@@ -137,13 +137,13 @@ class ConsumingEnumerableDemo
     //      BlockingCollection<T>.Add()
     //      BlockingCollection<T>.CompleteAdding()
     //      BlockingCollection<T>.GetConsumingEnumerable()
-    public static void BC_GetConsumingEnumerable()
+    public static async Task BC_GetConsumingEnumerable()
     {
         using (BlockingCollection<int> bc = new BlockingCollection<int>())
         {
 
             // Kick off a producer task
-            Task.Factory.StartNew(async () =>
+            await Task.Factory.StartNew(async () =>
             {
                 for (int i = 0; i < 10; i++)
                 {
@@ -163,6 +163,7 @@ class ConsumingEnumerableDemo
             {
                 Console.WriteLine(item);
             }
+            return;
         }
     }
 }


### PR DESCRIPTION
## Fixed compiler errors in BlockingCollection example

Fixes dotnet/dotnet-api-docs#2289

