### PR TITLE
Corrected buffer index in FileStream.Read calls

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/x509certificate2/cs/program.cs
+++ b/snippets/csharp/VS_Snippets_CLR/x509certificate2/cs/program.cs
@@ -258,10 +258,9 @@ namespace X509CertEncrypt
                             {
                                 do
                                 {
-                                    count = inFs.Read(data, 0, blockSizeBytes);
+                                    count = inFs.Read(data, offset, blockSizeBytes);
                                     offset += count;
                                     outStreamDecrypted.Write(data, 0, count);
-
                                 }
                                 while (count > 0);
 

--- a/snippets/csharp/VS_Snippets_CLR/x509certificate2/cs/program.cs
+++ b/snippets/csharp/VS_Snippets_CLR/x509certificate2/cs/program.cs
@@ -147,10 +147,10 @@ namespace X509CertEncrypt
                             {
                                 do
                                 {
-                                    count = inFs.Read(data, 0, blockSizeBytes);
+                                    count = inFs.Read(data, offset, blockSizeBytes);
                                     offset += count;
                                     outStreamEncrypted.Write(data, 0, count);
-                                    bytesRead += blockSizeBytes;
+                                    bytesRead += count;
                                 }
                                 while (count > 0);
                                 inFs.Close();

--- a/snippets/visualbasic/VS_Snippets_CLR/x509certificate2/vb/program.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/x509certificate2/vb/program.vb
@@ -139,10 +139,10 @@ Class Program
                         Dim inFs As New FileStream(inFile, FileMode.Open)
                         Try
                             Do
-                                count = inFs.Read(data, 0, blockSizeBytes)
+                                count = inFs.Read(data, offset, blockSizeBytes)
                                 offset += count
                                 outStreamEncrypted.Write(data, 0, count)
-                                bytesRead += blockSizeBytes
+                                bytesRead += count
                             Loop While count > 0
                             inFs.Close()
                         Finally
@@ -259,7 +259,7 @@ Class Program
                     Dim outStreamDecrypted As New CryptoStream(outFs, transform, CryptoStreamMode.Write)
                     Try
                         Do
-                            count = inFs.Read(data, 0, blockSizeBytes)
+                            count = inFs.Read(data, offset, blockSizeBytes)
                             offset += count
                             outStreamDecrypted.Write(data, 0, count)
                         Loop While count > 0


### PR DESCRIPTION
## Corrected buffer index in FileStream.Read calls

Fixes dotnet/dotnet-api-docs#1941


