### PR TITLE
Fix closing xml for sample node

### DIFF
--- a/snippets/csharp/new-in-7/Program.cs
+++ b/snippets/csharp/new-in-7/Program.cs
@@ -54,7 +54,7 @@ namespace new_in_7
             Console.WriteLine(item);
             item = 24;
             Console.WriteLine(matrix[4, 2]);
-            // <SnippetAssignRefReturn>
+            // </SnippetAssignRefReturn>
 
             Iterator.IteratorTest();
             Iterator.IteratorTestLocal();


### PR DESCRIPTION
Fixes dotnet/docs#11967

