### PR TITLE
Remove "recursive" from comment

### DIFF
--- a/csharp/events/Program.cs
+++ b/csharp/events/Program.cs
@@ -96,7 +96,7 @@ namespace EventSampleCode
                 {
                     directoryChanged?.Invoke(this,
                         new SearchDirectoryArgs(dir, totalDirs, completedDirs++));
-                    // Search each sub-directory for files that match the search pattern:
+                    // Search 'dir' and its subdirectories for files that match the search pattern:
                     SearchDirectory(dir, searchPattern);
                 }
                 // Include the Current Directory:

--- a/csharp/events/Program.cs
+++ b/csharp/events/Program.cs
@@ -96,7 +96,7 @@ namespace EventSampleCode
                 {
                     directoryChanged?.Invoke(this,
                         new SearchDirectoryArgs(dir, totalDirs, completedDirs++));
-                    // Recursively search this child directory:
+                    // Search each sub-directory for files that match the search pattern:
                     SearchDirectory(dir, searchPattern);
                 }
                 // Include the Current Directory:


### PR DESCRIPTION
Fixes #11744

The algorithm isn't really "recursive" because the `GetDirectories` will return all sub-directories, at any level from teh current directory. Therefore, the later calls to `Search` all search only for files.

Update the comment to better reflect that.
