### PR TITLE
Removed redundant variable

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsChecked/CS/csrefKeywordsChecked.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsChecked/CS/csrefKeywordsChecked.cs
@@ -152,10 +152,8 @@ namespace csrefKeywordsChecked
             // is the maximum value for integers. 
             //int i1 = 2147483647 + 10;
 
-            // The following example, which includes variable ten, does not cause
-            // a compiler error.
-            int ten = 10;
-            int i2 = 2147483647 + ten;
+            // The following example, does not cause a compiler error.
+            int i2 = 2147483647 + 10;
 
             // By default, the overflow in the previous statement also does
             // not cause a run-time exception. The following line displays 
@@ -169,12 +167,12 @@ namespace csrefKeywordsChecked
             // OverflowException error is raised.
 
             // Checked expression.
-            Console.WriteLine(checked(2147483647 + ten));
+            Console.WriteLine(checked(2147483647 + 10));
 
             // Checked block.
             checked
             {
-                int i3 = 2147483647 + ten;
+                int i3 = 2147483647 + 10;
                 Console.WriteLine(i3);
             }
             //</Snippet4>


### PR DESCRIPTION
The variable 10 has been removed as it simply did not make sense to declare a variable. The variable 10 was redundant, as it would suffice to just add 10

## Summary

The variable `ten` as been removed in favor of a 10. The variable seemed redundant as it didn't actually change the behavior of the compiler. The comments have been updated to reflect this change.

This can be proven with the following code:
```csharp
int max = int.MaxValue;
Console.WriteLine(max); // 2147483647
Console.WriteLine(max + 10); // -2147483639
checked {
    int y = max + 10; // An exception is thrown
}
```
