### PR TITLE
Update task-returning.cs

### DIFF
--- a/snippets/standard/buffers/memory-t/task-returning/task-returning.cs
+++ b/snippets/standard/buffers/memory-t/task-returning/task-returning.cs
@@ -9,9 +9,9 @@ public class Example
     // An acceptable implementation.
     static void Log(ReadOnlyMemory<char> message)
     {
+        string defensiveCopy = message.ToString();
         // Run in the background so that we don't block the main thread while performing IO.
         Task.Run(() => {
-            string defensiveCopy = message.ToString();
             StreamWriter sw = File.AppendText(@".\input-numbers.dat");
             sw.WriteLine(defensiveCopy);
             sw.Flush();


### PR DESCRIPTION
Fix defensiveCopy to run immediately, so it is not accessed after method return.

This sample is used in `Rule #3` in Usage guidlines section here: https://github.com/dotnet/docs/blob/master/docs/standard/memory-and-spans/memory-t-usage-guidelines.md