### PR TITLE
Remove leading spaces and cleanup

### DIFF
--- a/snippets/csharp/how-to/strings/ParseStringsUsingSplit.cs
+++ b/snippets/csharp/how-to/strings/ParseStringsUsingSplit.cs
@@ -93,20 +93,19 @@ namespace HowToStrings
         private static void SplitUsingStrings()
         {
             // <Snippet5>
-            string[] separatingChars = { "<<", "..." };  
-    
-            string text = "one<<two......three<four";  
-            System.Console.WriteLine("Original text: '{0}'", text);  
-    
-            string[] words = text.Split(separatingChars, System.StringSplitOptions.RemoveEmptyEntries );  
-            System.Console.WriteLine("{0} substrings in text:", words.Length);  
-    
+            string[] separatingStrings = { "<<", "..." };
+
+            string text = "one<<two......three<four";
+            System.Console.WriteLine($"Original text: '{text}'");
+
+            string[] words = text.Split(separatingStrings, System.StringSplitOptions.RemoveEmptyEntries);
+            System.Console.WriteLine($"{words.Length} substrings in text:");
+
             foreach (var word in words)
             {
                 System.Console.WriteLine(word);
             }
             // </Snippet5>
-            
         }
     }
 }


### PR DESCRIPTION
Attempt at removing the leading spaces and also some minor cleanup to match the other examples.

Fixes dotnet/docs#11997