### PR TITLE
Fix exception when sample is built for .NET Core debug.

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.runtime.compilerservices.conditionalweaktable.class/cs/example1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.runtime.compilerservices.conditionalweaktable.class/cs/example1.cs
@@ -24,7 +24,7 @@ public class Example
 
       if (wr2.Target == null)
           Console.WriteLine("No strong reference to mc2 exists.");   
-      else if (cwt.TryGetValue(mc2, out data))
+      else if (cwt.TryGetValue(wr2.Target, out data))
           Console.WriteLine("Data created at {0}", data.CreationTime);      
       else
           Console.WriteLine("mc2 not found in the table.");


### PR DESCRIPTION
## Summary

If you try this sample in a .NET Core project, and build as debug, it will throw an exception on line 27. This is because, when built for debug, the value is not garbage collected, so `wr2.Target` is not `null` and we hit the `else if`. In that line, `mc2` *is* `null` (because it is set to `null` on line 19) which throws an exception trying to use it as a key to the CWT.