### PR TITLE
Fix Validation binding path to use current item

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml
+++ b/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml
@@ -26,7 +26,7 @@
           <Trigger Property="Validation.HasError" Value="true">
             <Setter Property="ToolTip"
               Value="{Binding RelativeSource={x:Static RelativeSource.Self},
-                              Path=(Validation.Errors)[0].ErrorContent}"/>
+                              Path=(Validation.Errors)/ErrorContent}"/>
           </Trigger>
         </Style.Triggers>
       </Style>


### PR DESCRIPTION
## Summary

Alter path to not use index but query the current item with `/`

Fixes dotnet/docs#12116
