### PR TITLE
Formatting examples for string best practices

### DIFF
--- a/snippets/standard/base-types/string-practices/cs/formattable.cs
+++ b/snippets/standard/base-types/string-practices/cs/formattable.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Globalization;
+
+class Program
+{
+    static void Main()
+    {
+        Decimal value = 126.03m;
+        FormattableString amount = $"The amount is {value:C}"; 
+        Console.WriteLine(amount.ToString());
+        Console.WriteLine(amount.ToString(new CultureInfo("fr-FR")));
+        Console.WriteLine(FormattableString.Invariant(amount));
+    }
+}
+// The example displays the following output:
+//    The amount is $126.03
+//    The amount is 126,03 €
+//    The amount is ¤126.03

--- a/snippets/standard/base-types/string-practices/cs/tostring.cs
+++ b/snippets/standard/base-types/string-practices/cs/tostring.cs
@@ -5,14 +5,14 @@ class Program
 {
     static void Main(string[] args)
     {
-        // <Snippet2>
-        string value = "The amount is " + 126.03.ToString(CultureInfo.InvariantCulture) + ".";
-        Console.WriteLine(value);
-        // </Snippet2>
-
         // <Snippet1>
-        value = "The amount is " + 126.03 + ".";
-        Console.WriteLine(value);
+        string concat1 = "The amount is " + 126.03 + ".";
+        Console.WriteLine(concat1);
         // </Snippet1>
+
+        // <Snippet2>
+        string concat2 = "The amount is " + 126.03.ToString(CultureInfo.InvariantCulture) + ".";
+        Console.WriteLine(concat2);
+        // </Snippet2>
     }
 }

--- a/snippets/standard/base-types/string-practices/cs/tostring.cs
+++ b/snippets/standard/base-types/string-practices/cs/tostring.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Globalization;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        // <Snippet2>
+        string value = "The amount is " + 126.03.ToString(CultureInfo.InvariantCulture) + ".";
+        Console.WriteLine(value);
+        // </Snippet2>
+
+        // <Snippet1>
+        value = "The amount is " + 126.03 + ".";
+        Console.WriteLine(value);
+        // </Snippet1>
+    }
+}

--- a/snippets/standard/base-types/string-practices/vb/formattable.vb
+++ b/snippets/standard/base-types/string-practices/vb/formattable.vb
@@ -1,0 +1,15 @@
+Imports System.Globalization
+
+Module Program
+    Sub Main()
+        Dim value As Decimal = 126.03
+        Dim amount As FormattableString = $"The amount is {value:C}" 
+        Console.WriteLine(amount.ToString())
+        Console.WriteLine(amount.ToString(new CultureInfo("fr-FR")))
+        Console.WriteLine(FormattableString.Invariant(amount))
+    End Sub
+End Module
+' The example displays the following output:
+'    The amount is $126.03
+'    The amount is 126,03 €
+'    The amount is ¤126.03


### PR DESCRIPTION
## Formatting examples for string best practices

Contributes to dotnet/docs#11429

Related to dotnet/docs#12158


