### PR TITLE
Update source.cs

### DIFF
--- a/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlCommand Example/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlCommand Example/CS/source.cs
@@ -27,19 +27,13 @@ namespace SqlCommandCS
                 SqlCommand command = new SqlCommand(
                     queryString, connection);
                 connection.Open();
-                SqlDataReader reader = command.ExecuteReader();
-                try
+                using(SqlDataReader reader = command.ExecuteReader())
                 {
                     while (reader.Read())
                     {
                         Console.WriteLine(String.Format("{0}, {1}",
                             reader[0], reader[1]));
                     }
-                }
-                finally
-                {
-                    // Always call Close when done reading.
-                    reader.Close();
                 }
             }
         }


### PR DESCRIPTION
Rather than the try finally around the reader (SqlDataReader)_ I believe that the using construct is best practice and consistent with the SqlConnection.  I know try / finally does the same thing - but the using construct is, I think, the way to go with all IDisposable classes.

## Summary

Describe your changes here.
Consistent use of using statement for IDisposable class SqlDataReader
