### PR TITLE
Updated method name to use .NET naming guidelines

### DIFF
--- a/snippets/csharp/VS_Snippets_Remoting/System.Net.IPAddress.Parse/CS/parse.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/System.Net.IPAddress.Parse/CS/parse.cs
@@ -29,7 +29,7 @@ class ParseAddress
       IPaddress = args[0];
 
     // Get the list of the IPv6 addresses associated with the requested host.
-    parse(IPaddress);
+    Parse(IPaddress);
    
   }
 

--- a/snippets/csharp/VS_Snippets_Remoting/System.Net.IPAddress.Parse/CS/parse.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/System.Net.IPAddress.Parse/CS/parse.cs
@@ -38,7 +38,7 @@ class ParseAddress
   // IPv6 address, the method displays the Parse output into quad-notation or
   // colon-hexadecimal notation, respectively. Otherwise, it displays an 
   // error message.
-  private static void parse(string ipAddress)
+  private static void Parse(string ipAddress)
   {
     try
     {


### PR DESCRIPTION
## Summary

Changed method name from parse to Parse to use .NET naming guidelines
