### PR TITLE
Formatting of try-catch

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.aggregateexception.class/cs/exception1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.aggregateexception.class/cs/exception1.cs
@@ -17,10 +17,12 @@ class Example
 
       // Use this line to throw an exception that is not handled.
       // Task task1 = Task.Factory.StartNew(() => { throw new IndexOutOfRangeException(); } );
-      try {
+      try
+      {
           await task1;
       }
-      catch (AggregateException ae) {
+      catch (AggregateException ae)
+      {
           ae.Handle((x) =>
           {
               if (x is UnauthorizedAccessException) // This we know how to handle.


### PR DESCRIPTION
Newline for curly braces.

Besides this, I'm not sure this example works. I've tried copying the code into a new console application and the debugger doesn't break inside the catch of the `AggregateException`. When awaiting a task like this, the original exception is thrown. In this case the `UnauthorizedAccessException`.

If doing the following, the `AggregateException` is thrown:

```
task1.Wait();
```