### PR TITLE
Corrected variable name in BlockingCollection<T> example

### DIFF
--- a/snippets/csharp/VS_Snippets_Misc/cds_blockingcollection/cs/blockingcollection.cs
+++ b/snippets/csharp/VS_Snippets_Misc/cds_blockingcollection/cs/blockingcollection.cs
@@ -31,7 +31,7 @@ namespace OverviewSnippets
                 {
                     
                     Data data = null;
-                    // Blocks if number.Count == 0
+                    // Blocks if dataItems.Count == 0.
                     // IOE means that Take() was called on a completed collection.
                     // Some other thread can call CompleteAdding after we pass the
                     // IsCompleted check but before we call Take. 

--- a/snippets/visualbasic/VS_Snippets_Misc/cds_blockingcollection/vb/introsnippetsbc.vb
+++ b/snippets/visualbasic/VS_Snippets_Misc/cds_blockingcollection/vb/introsnippetsbc.vb
@@ -48,7 +48,7 @@ Module IntroSnippetsBC
                                   While moreItemsToAdd = True
                                       Dim item As Data = GetData()
 
-                                      ' Blocks if numbers.Count = dataItems.BoundedCapacity
+                                      ' Blocks if dataItems.Count = dataItems.BoundedCapacity.
                                       dataItems.Add(item)
                                   End While
 


### PR DESCRIPTION
## Corrected variable name in BlockingCollection\<T> example

Fixes dotnet/docs#12348


