### PR TITLE
Corrected dispose pattern

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/derived1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/derived1.cs
@@ -48,7 +48,7 @@ public class DisposableStreamResource2 : DisposableStreamResource
       bool result = WriteFile(safeHandle, output, output.Length, out bytesWritten, IntPtr.Zero);                                     
    }
 
-   protected new virtual void Dispose(bool disposing)
+   protected override void Dispose(bool disposing)
    {
       if (disposed) return;
       


### PR DESCRIPTION
## Corrected dispose pattern

This PR corrects the C# example. There's also a corresponding VB example, but it is correct.

Fixes dotnet/docs#9035


