### PR TITLE
Remove property on v1 of object

### DIFF
--- a/csharp/events/Program.cs
+++ b/csharp/events/Program.cs
@@ -130,7 +130,6 @@ namespace VersionOne
     public class FileFoundArgs : EventArgs
     {
         public string FoundFile { get; }
-        public bool CancelRequested { get; set; }
 
         public FileFoundArgs(string fileName)
         {

--- a/snippets/core/whats-new/whats-new-in-30/cs/Program.cs
+++ b/snippets/core/whats-new/whats-new-in-30/cs/Program.cs
@@ -102,9 +102,6 @@ namespace whats_new
                 var name = config.GetProperty("name").GetString();
                 Console.WriteLine($"Config: {name}");
             }
-
-            JsonPerson[] a;
-            a = { { new JsonPerson() } };
         }
         // </SnippetReadJson>
     }

--- a/snippets/core/whats-new/whats-new-in-30/cs/Program.cs
+++ b/snippets/core/whats-new/whats-new-in-30/cs/Program.cs
@@ -102,6 +102,9 @@ namespace whats_new
                 var name = config.GetProperty("name").GetString();
                 Console.WriteLine($"Config: {name}");
             }
+
+            JsonPerson[] a;
+            a = { { new JsonPerson() } };
         }
         // </SnippetReadJson>
     }


### PR DESCRIPTION
## Summary

Remove the property from the v1 object that is added in the v2 object.

Fixes dotnet/docs#10268 
