### PR TITLE
Correct comment indentation for DrawItemEventHandler Delegate C# example

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.MenuItemOwnerDraw/CS/form1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.MenuItemOwnerDraw/CS/form1.cs
@@ -77,7 +77,7 @@ public class Form1:
 		//Add the event-handler delegate to handle the DrawItem event.
         MenuItem2.DrawItem += new DrawItemEventHandler(DrawCustomMenuItem);
 		
-      // Add the items to the menu.
+        // Add the items to the menu.
 		MainMenu1 = new MainMenu(new MenuItem[]{MenuItem1, MenuItem2});																													  
 
 		// Add the menu to the form.


### PR DESCRIPTION
## Summary

Corrects comment indentation.

```
//Add the event-handler delegate to handle the DrawItem event.
   MenuItem2.DrawItem += new DrawItemEventHandler(DrawCustomMenuItem);
```

to

```
//Add the event-handler delegate to handle the DrawItem event.
MenuItem2.DrawItem += new DrawItemEventHandler(DrawCustomMenuItem);
```

Fixes https://github.com/dotnet/dotnet-api-docs/issues/2458
