### PR TITLE
Fixes dead link to Readme in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in contributing to the .NET documentation!
 
-This repository contains the samples used in the .NET documentation. The main repository for .NET documentation is the [.NET Docs repository](https://github.com/dotnet/docs). See the [Readme](readme.md) and the [Contributing Guide](https://github.com/dotnet/docs/tree/master/CONTRIBUTING.md) for information on contributing samples and topics to the .NET documentation.
+This repository contains the samples used in the .NET documentation. The main repository for .NET documentation is the [.NET Docs repository](https://github.com/dotnet/docs). See the [Readme](README.md) and the [Contributing Guide](https://github.com/dotnet/docs/tree/master/CONTRIBUTING.md) for information on contributing samples and topics to the .NET documentation.


### PR DESCRIPTION
## Summary

Fixes dead link to [Readme ](https://github.com/dotnet/samples/blob/master/README.md)in [CONTRIBUTING.md](https://github.com/dotnet/samples/blob/master/CONTRIBUTING.md).

Corrects readme.md (dead link) to README.md (working link). GitHub links are case-sensitive.
