### PR TITLE
update for C# interactive

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs
+++ b/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs
@@ -51,7 +51,7 @@ class formatting
       // current culture is English (United States):
       //       $12,345.68
       //       $12,345.679
-      //       kr 12.345,679
+      //       12.345,679 kr
       // </Snippet1> 
    }
    

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Double.ToString/cs/roundtripex1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Double.ToString/cs/roundtripex1.cs
@@ -6,6 +6,7 @@ public class Example
 {
    static void Main(string[] args)
    {
+      // <SnippetRoundTrip>
       Console.WriteLine("Attempting to round-trip a Double with 'R':");
       double initialValue = 0.6822871999174;
       string valueString = initialValue.ToString("R",
@@ -22,13 +23,14 @@ public class Example
                                            CultureInfo.InvariantCulture);
       Console.WriteLine("{0:R} = {1:R}: {2}\n",
                         initialValue, roundTripped17, initialValue.Equals(roundTripped17));
+      // If compiled to an application that targets anycpu or x64 and run on an x64 system,
+      // the example displays the following output:
+      //       Attempting to round-trip a Double with 'R':
+      //       0.6822871999174 = 0.68228719991740006: False
+      //
+      //       Attempting to round-trip a Double with 'G17':
+      //       0.6822871999174 = 0.6822871999174: True
+      // </SnippetRoundTrip>
    }
 }
-// If compiled to an application that targets anycpu or x64 and run on an x64 system,
-// the example displays the following output:
-//       Attempting to round-trip a Double with 'R':
-//       0.6822871999174 = 0.68228719991740006: False
-//
-//       Attempting to round-trip a Double with 'G17':
-//       0.6822871999174 = 0.6822871999174: True
 // </Snippet5>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.X.ToString-and-Culture/cs/xts.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.X.ToString-and-Culture/cs/xts.cs
@@ -176,6 +176,7 @@ public class NumericFormats
 {
    public static void Main()
    {
+      // <SnippetFinalExample>
       // Display string representations of numbers for en-us culture
       CultureInfo ci = new CultureInfo("en-us");
       
@@ -216,6 +217,7 @@ public class NumericFormats
       Console.WriteLine("X: 0x{0}", 
               integral.ToString("X", ci));           // Displays "X: 0x20CB"
       Console.WriteLine();
+      // </SnippetFinalExample>
    }
 }
 // </Snippet1>

--- a/snippets/standard/base-types/format-strings/csharp/g17.cs
+++ b/snippets/standard/base-types/format-strings/csharp/g17.cs
@@ -4,6 +4,7 @@ public class Example
 {
    public static void Main()
    {
+      // <SnippetGeneralFormatSpecifier>
       double original = 0.84551240822557006;
       var rSpecifier = original.ToString("R");
       var g17Specifier = original.ToString("G17");
@@ -13,6 +14,10 @@ public class Example
       
       Console.WriteLine($"{original:G17} = {rSpecifier} (R): {original.Equals(rValue)}");
       Console.WriteLine($"{original:G17} = {g17Specifier} (G17): {original.Equals(g17Value)}");
+      // The example displays the following output:
+      //     0.84551240822557006 = 0.84551240822557: False
+      //     0.84551240822557006 = 0.84551240822557006: True
+      // <SnippetGeneralFormatSpecifier>
    }
 }
 // The example displays the following output:


### PR DESCRIPTION
The C# interactive experience uses scaffolding around the included code blocks.

That means some of these samples didn't work and were hard-coded to use the scriptcs implementation.  This PR and the accompanying docs PR updates those to work with the current scaffolding.

/cc @rchande 