### PR TITLE
Correct single spacing to tabs for Snippet 2 in HtmlWindowCollection Class

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.HtmlWindow/CS/Form1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.HtmlWindow/CS/Form1.cs
@@ -48,7 +48,7 @@ namespace HtmlWindowProjectCSharp
 					Hashtable docLinksHash = new Hashtable();
 					linksTable.Add(webBrowser1.Document.Url.ToString(), docLinksHash);
 
-                    foreach (HtmlElement hrefElement in webBrowser1.Document.Links)
+					foreach (HtmlElement hrefElement in webBrowser1.Document.Links)
 					{
 						docLinksHash.Add(hrefElement.GetAttribute("HREF"), "Url");
 					}


### PR DESCRIPTION
## Summary

Corrects single spacing to tabs for snippet 2 for loop.

Fixes dotnet/dotnet-api-docs#2482
