### PR TITLE
Correct formatting tabbed to single spacing for DataGridViewCellCancelEventHandler

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.DataGridView.RowOperations/CS/rowoperations.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.DataGridView.RowOperations/CS/rowoperations.cs
@@ -279,7 +279,7 @@ public class RowOperations : System.Windows.Forms.Form
     {
         Int32 cellValueAsInt;
         if (cell.Value.ToString().Length == 0)
-		{
+        {
             cell.ErrorText = "Please enter a track";
             songsDataGridView.Rows[cell.RowIndex].ErrorText = 
                 "Please enter a track";
@@ -305,7 +305,7 @@ public class RowOperations : System.Windows.Forms.Form
     private Boolean IsDateGood(DataGridViewCell cell) 
     {
         if (cell.Value == null)
-		{
+        {
             cell.ErrorText = "Missing date";
             songsDataGridView.Rows[cell.RowIndex].ErrorText = 
                 "Missing date";


### PR DESCRIPTION
## Summary

Corrected formatting issue - converted tabbed to single spacing for DataGridViewCellCancelEventHandler Delegate snippet5 to be consistent with rest of code.

Fixes dotnet/dotnet-api-docs#2508