### PR TITLE
Correct formatting single spacing to tabs for LabelEditEventArgs Class

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.ListView3/CS/form1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.ListView3/CS/form1.cs
@@ -69,7 +69,7 @@ public class Form1:
 	}
 
 	//<snippet1>
-   	private void ListView1_BeforeLabelEdit(object sender, 
+	private void ListView1_BeforeLabelEdit(object sender, 
 		System.Windows.Forms.LabelEditEventArgs e)
 	{
 		// Allow all but the first two items of the list to 


### PR DESCRIPTION
## Summary

Correct formatting single spacing to tabs for snippet1 of System.Windows.Forms.ListView3 for LabelEditEventArgs Class to be consistent with the rest of the code.

Fixes dotnet/dotnet-api-docs#2478