### PR TITLE
Fix the interactive errors on string.format.

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format4.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format4.cs
@@ -1,10 +1,10 @@
-// <Snippet4>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet4>
       string formatString = "    {0,10} ({0,8:X8})\n" + 
                             "And {1,10} ({1,8:X8})\n" + 
                             "  = {2,10} ({2,8:X8})";
@@ -13,10 +13,10 @@ public class Example
       string result = String.Format(formatString, 
                                     value1, value2, value1 & value2);
       Console.WriteLine(result);
+      // The example displays the following output:
+      //                16932 (00004224)
+      //       And      15421 (00003C3D)
+      //         =         36 (00000024)
+      // </Snippet4>
    }
 }
-// The example displays the following output:
-//                16932 (00004224)
-//       And      15421 (00003C3D)
-//         =         36 (00000024)
-// </Snippet4>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format5.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format5.cs
@@ -1,10 +1,10 @@
-// <Snippet5>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet5>
       DateTime date1 = new DateTime(2009, 7, 1);
       TimeSpan hiTime = new TimeSpan(14, 17, 32);
       decimal hiTemp = 62.1m; 
@@ -19,13 +19,13 @@ public class Example
       string result2 = String.Format("Temperature on {0:d}:\n{1,11}: {2} degrees (hi)\n{3,11}: {4} degrees (lo)", 
                                      new object[] { date1, hiTime, hiTemp, loTime, loTemp });
       Console.WriteLine(result2);
+      // The example displays output like the following:
+      //       Temperature on 7/1/2009:
+      //          14:17:32: 62.1 degrees (hi)
+      //          03:16:10: 54.8 degrees (lo)
+      //       Temperature on 7/1/2009:
+      //          14:17:32: 62.1 degrees (hi)
+      //          03:16:10: 54.8 degrees (lo)
+      // </Snippet5>
    }
 }
-// The example displays output like the following:
-//       Temperature on 7/1/2009:
-//          14:17:32: 62.1 degrees (hi)
-//          03:16:10: 54.8 degrees (lo)
-//       Temperature on 7/1/2009:
-//          14:17:32: 62.1 degrees (hi)
-//          03:16:10: 54.8 degrees (lo)
-// </Snippet5>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format7.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format7.cs
@@ -1,10 +1,10 @@
-// <Snippet7>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet7>
       DateTime birthdate = new DateTime(1993, 7, 28);
       DateTime[] dates = { new DateTime(1993, 8, 16), 
                            new DateTime(1994, 7, 28), 
@@ -28,12 +28,12 @@ public class Example
             Console.WriteLine(output);
          }      
       }
+      // The example displays the following output:
+      //       You are now 0 years old.
+      //       You are now 1 years old.
+      //       You are now 7 years old.
+      //       You are now 9 years old.
+      //       You are now 13 years old.
+      // </Snippet7>
    }
 }
-// The example displays the following output:
-//       You are now 0 years old.
-//       You are now 1 years old.
-//       You are now 7 years old.
-//       You are now 9 years old.
-//       You are now 13 years old.
-// </Snippet7>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/formatexample4.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/formatexample4.cs
@@ -1,4 +1,3 @@
-// <Snippet6>
 using System;
 using System.Collections.Generic;
 
@@ -6,6 +5,7 @@ public class Example
 {
    public static void Main()
    {
+      // <Snippet6>
       Dictionary<DateTime, Double> temperatureInfo = new Dictionary<DateTime, Double>(); 
       temperatureInfo.Add(new DateTime(2010, 6, 1, 14, 0, 0), 87.46);
       temperatureInfo.Add(new DateTime(2010, 12, 1, 10, 0, 0), 36.81);
@@ -18,11 +18,11 @@ public class Example
                                 item.Key, item.Value);
          Console.WriteLine(output);
       }
+      // The example displays output like the following:
+      //       Temperature Information:
+      //       
+      //       Temperature at  2:00 PM on  6/1/2010:  87.5°F
+      //       Temperature at 10:00 AM on 12/1/2010:  36.8°F
+      // </Snippet6>
    }
 }
-// The example displays output like the following:
-//       Temperature Information:
-//       
-//       Temperature at  2:00 PM on  6/1/2010:  87.5°F
-//       Temperature at 10:00 AM on 12/1/2010:  36.8°F
-// </Snippet6>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/formatoverload2.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/formatoverload2.cs
@@ -1,10 +1,10 @@
-// <Snippet9>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet9>
       // Create array of 5-tuples with population data for three U.S. cities, 1940-1950.
       Tuple<string, DateTime, int, DateTime, int>[] cities = 
           { Tuple.Create("Los Angeles", new DateTime(1940, 1, 1), 1504277, 
@@ -25,14 +25,14 @@ public class Example
                                 city.Item1, city.Item2, city.Item3, city.Item4, city.Item5,
                                 (city.Item5 - city.Item3)/ (double)city.Item3);
          Console.WriteLine(output);
+      // The example displays the following output:
+      //    City            Year  Population    Year  Population    Change (%)
+      //    
+      //    Los Angeles     1940   1,504,277    1950   1,970,358        31.0 %
+      //    New York        1940   7,454,995    1950   7,891,957         5.9 %
+      //    Chicago         1940   3,396,808    1950   3,620,962         6.6 %
+      //    Detroit         1940   1,623,452    1950   1,849,568        13.9 %
+      // </Snippet9>
       }
    }
 }
-// The example displays the following output:
-//    City            Year  Population    Year  Population    Change (%)
-//    
-//    Los Angeles     1940   1,504,277    1950   1,970,358        31.0 %
-//    New York        1940   7,454,995    1950   7,891,957         5.9 %
-//    Chicago         1940   3,396,808    1950   3,620,962         6.6 %
-//    Detroit         1940   1,623,452    1950   1,849,568        13.9 %
-// </Snippet9>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa-interpolated1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa-interpolated1.cs
@@ -4,6 +4,7 @@ public class Example
 {
    public static void Main()
    {
+      // <SnippetQAInterpolated>
       string[] names = { "Balto", "Vanya", "Dakota", "Samuel", "Koani", "Yiska", "Yuma" };
       string output = names[0] + ", " + names[1] + ", " + names[2] + ", " + 
                       names[3] + ", " + names[4] + ", " + names[5] + ", " + 
@@ -14,9 +15,9 @@ public class Example
       output += String.Format("It is {0:t} on {0:d}. The day of the week is {1}.", 
                               date, date.DayOfWeek);
       Console.WriteLine(output);                           
+      // The example displays the following output:
+      //     Balto, Vanya, Dakota, Samuel, Koani, Yiska, Yuma
+      //     It is 10:29 AM on 1/8/2018. The day of the week is Monday.
+      // </SnippetQAInterpolated>
    }
 }
-// The example displays the following output:
-//     Balto, Vanya, Dakota, Samuel, Koani, Yiska, Yuma
-//     It is 10:29 AM on 1/8/2018. The day of the week is Monday.
-

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa-interpolated2.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa-interpolated2.cs
@@ -2,6 +2,7 @@ using System;
 
 public class Example
 {
+   // <SnippetQAInterpolated2>
    public static void Main()
    {
       string[] names = { "Balto", "Vanya", "Dakota", "Samuel", "Koani", "Yiska", "Yuma" };
@@ -11,9 +12,10 @@ public class Example
       var date = DateTime.Now;
       output += $"\nIt is {date:t} on {date:d}. The day of the week is {date.DayOfWeek}.";
       Console.WriteLine(output);                           
+      // The example displays the following output:
+      //     Balto, Vanya, Dakota, Samuel, Koani, Yiska, Yuma
+      //     It is 10:29 AM on 1/8/2018. The day of the week is Monday.
+      // </SnippetQAInterpolated2>
    }
 }
-// The example displays the following output:
-//     Balto, Vanya, Dakota, Samuel, Koani, Yiska, Yuma
-//     It is 10:29 AM on 1/8/2018. The day of the week is Monday.
 

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa1.cs
@@ -1,4 +1,3 @@
-// <Snippet21>
 using System;
 using System.Collections.Generic;
 
@@ -6,6 +5,7 @@ public class Example
 {
    public static void Main()
    {
+      // <Snippet21>
       Random rnd = new Random();
       int[]  numbers = new int[4];
       int total = 0;
@@ -16,6 +16,6 @@ public class Example
       }   
       numbers[3] = total;
       Console.WriteLine("{0} + {1} + {2} = {3}", numbers);   
+      // </Snippet21>
    }
 }
-// </Snippet21>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa2.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa2.cs
@@ -1,4 +1,3 @@
-// <Snippet22>
 using System;
 using System.Collections.Generic;
 
@@ -6,6 +5,7 @@ public class Example
 {
    public static void Main()
    {
+      // <Snippet22>
       Random rnd = new Random();
       int[]  numbers = new int[4];
       int total = 0;
@@ -18,6 +18,6 @@ public class Example
       object[] values = new object[numbers.Length];
       numbers.CopyTo(values, 0);
       Console.WriteLine("{0} + {1} + {2} = {3}", values);   
+      // </Snippet22>
    }
 }
-// </Snippet22>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa26.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa26.cs
@@ -1,23 +1,23 @@
-// <Snippet26>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet26>
       object[] values = { 1603, 1794.68235, 15436.14 };
       string result;
       foreach (var value in values) {
          result = String.Format("{0,12:C2}   {0,12:E3}   {0,12:F4}   {0,12:N3}  {1,12:P2}\n",
                                 Convert.ToDouble(value), Convert.ToDouble(value) / 10000);
          Console.WriteLine(result);
+      // The example displays output like the following:
+      //       $1,603.00     1.603E+003      1603.0000      1,603.000       16.03 %
+      //    
+      //       $1,794.68     1.795E+003      1794.6824      1,794.682       17.95 %
+      //    
+      //      $15,436.14     1.544E+004     15436.1400     15,436.140      154.36 %
+      // </Snippet26>
       }                           
    }
 }
-// The example displays output like the following:
-//       $1,603.00     1.603E+003      1603.0000      1,603.000       16.03 %
-//    
-//       $1,794.68     1.795E+003      1794.6824      1,794.682       17.95 %
-//    
-//      $15,436.14     1.544E+004     15436.1400     15,436.140      154.36 %
-// </Snippet26>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa27.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa27.cs
@@ -1,16 +1,16 @@
-// <Snippet27>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet27>
       decimal value = 16309.5436m;
       string result = String.Format("{0,12:#.00000} {0,12:0,000.00} {0,12:000.00#}", 
                                     value);
       Console.WriteLine(result);
+      // The example displays the following output:
+      //        16309.54360    16,309.54    16309.544
+      // </Snippet27>
    }
 }
-// The example displays the following output:
-//        16309.54360    16,309.54    16309.544
-// </Snippet27>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa28.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa28.cs
@@ -1,16 +1,16 @@
-// <Snippet28>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet28>
       int value = 16342;
       string result = String.Format("{0,18:00000000} {0,18:00000000.000} {0,18:000,0000,000.0}", 
                                     value);
       Console.WriteLine(result);
+      // The example displays the following output:
+      //           00016342       00016342.000    0,000,016,342.0
+      // </Snippet28>
    }
 }
-// The example displays the following output:
-//           00016342       00016342.000    0,000,016,342.0
-// </Snippet28>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa29.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa29.cs
@@ -1,15 +1,15 @@
-// <Snippet29>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet29>
       int value = 1326;
       string result = String.Format("{0,10:D6} {0,10:X8}", value);
       Console.WriteLine(result);
+      // The example displays the following output:
+      //     001326   0000052E
+      // </Snippet29>
    }
 }
-// The example displays the following output:
-//     001326   0000052E
-// </Snippet29>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/starting3.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/starting3.cs
@@ -14,13 +14,15 @@ class Example
           sb.Append(String.Format("{0,6} {1,15:N0}\n", years[index], population[index]));
   
        Console.WriteLine(sb);
+
+       // Result:
+       //      Year      Population
+       //
+       //      2013       1,025,632
+       //      2014       1,105,967
+       //      2015       1,148,203
+       // </Snippet33>
    }
 }  
-// Result:
-//      Year      Population
-//
-//      2013       1,025,632
-//      2014       1,105,967
-//      2015       1,148,203
 
 

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format2/cs/Example1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format2/cs/Example1.cs
@@ -1,10 +1,10 @@
 using System;
 
-// <Snippet1>
 public class Example
 {
    public static void Main()
    {
+      // <Snippet1>
       short[] values= { Int16.MinValue, -27, 0, 1042, Int16.MaxValue };
       Console.WriteLine("{0,10}  {1,10}\n", "Decimal", "Hex");
       foreach (short value in values)
@@ -12,14 +12,14 @@ public class Example
          string formatString = String.Format("{0,10:G}: {0,10:X}", value);
          Console.WriteLine(formatString);
       }   
+      // The example displays the following output:
+      //       Decimal         Hex
+      //    
+      //        -32768:       8000
+      //           -27:       FFE5
+      //             0:          0
+      //          1042:        412
+      //         32767:       7FFF
+      // </Snippet1>
    }
 }
-// The example displays the following output:
-//       Decimal         Hex
-//    
-//        -32768:       8000
-//           -27:       FFE5
-//             0:          0
-//          1042:        412
-//         32767:       7FFF
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Format2/cs/Example2.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Format2/cs/Example2.cs
@@ -1,4 +1,3 @@
-// <Snippet2>
 using System;
 using System.Globalization;
 
@@ -6,6 +5,7 @@ public class Example
 {
    public static void Main()
    {
+      // <Snippet2>
       string[] cultureNames = { "en-US", "fr-FR", "de-DE", "es-ES" };
       
       DateTime dateToDisplay = new DateTime(2009, 9, 1, 18, 32, 0);
@@ -19,13 +19,13 @@ public class Example
                                        culture.Name, dateToDisplay, value);
          Console.WriteLine(output);
       }    
+      // The example displays the following output:
+      //    Culture     Date                                Value
+      //    
+      //    en-US       Tuesday, September 01, 2009         9,164.32
+      //    fr-FR       mardi 1 septembre 2009              9 164,32
+      //    de-DE       Dienstag, 1. September 2009         9.164,32
+      //    es-ES       martes, 01 de septiembre de 2009    9.164,32
+      // </Snippet2>
    }
 }
-// The example displays the following output:
-//    Culture     Date                                Value
-//    
-//    en-US       Tuesday, September 01, 2009         9,164.32
-//    fr-FR       mardi 1 septembre 2009              9 164,32
-//    de-DE       Dienstag, 1. September 2009         9.164,32
-//    es-ES       martes, 01 de septiembre de 2009    9.164,32
-// </Snippet2>


### PR DESCRIPTION
contributes to dotnet/dotnet-api-docs#2539

When possible, update the snippets to work as included snippets.

Otherwise, turn off the interactive samples on those samples.

