### PR TITLE
Relocate C# operators examples

### DIFF
--- a/csharp/language-reference/operators/AdditionOperator.cs
+++ b/csharp/language-reference/operators/AdditionOperator.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace operators
+{
+    public static class AdditionOperator
+    {
+        public static void Examples()
+        {
+            NumericAddition();
+            StringConcatenation();
+            AddDelegates();
+            AddAndAssign();
+        }
+
+        private static void NumericAddition()
+        {
+            // <SnippetAddNumerics>
+            Console.WriteLine(5 + 4);       // output: 9
+            Console.WriteLine(5 + 4.3);     // output: 9.3
+            Console.WriteLine(5.1m + 4.2m); // output: 9.3
+            // </SnippetAddNumerics>
+        }
+
+        private static void StringConcatenation()
+        {
+            // <SnippetAddStrings>
+            Console.WriteLine("Forgot " + " white space");
+            Console.WriteLine("Probably the oldest constant: " + Math.PI);
+            // Output:
+            // Forgot white space
+            // Probably the oldest constant: 3.14159265358979
+            // </SnippetAddStrings>
+
+            // <SnippetUseStringInterpolation>
+            Console.WriteLine($"Probably the oldest constant: {Math.PI:F2}");
+            // Output:
+            // Probably the oldest constant: 3.14
+            // </SnippetUseStringInterpolation>
+        }
+
+        private static void AddDelegates()
+        {
+            // <SnippetAddDelegates>
+            Action a = () => Console.Write("a");
+            Action b = () => Console.Write("b");
+            Action ab = a + b;
+            ab();  // output: ab
+            // </SnippetAddDelegates>
+            Console.WriteLine();
+        }
+
+        private static void AddAndAssign()
+        {
+            // <SnippetAddAndAssign>
+            int i = 5;
+            i += 9;
+            Console.WriteLine(i);
+            // Output: 14
+
+            string story = "Start. ";
+            story += "End.";
+            Console.WriteLine(story);
+            // Output: Start. End.
+
+            Action printer = () => Console.Write("a");
+            printer();  // output: a
+            
+            Console.WriteLine();
+            printer += () => Console.Write("b");
+            printer();  // output: ab
+            // </SnippetAddAndAssign>
+            Console.WriteLine();
+        }
+    }
+}

--- a/csharp/language-reference/operators/ArithmeticOperators.cs
+++ b/csharp/language-reference/operators/ArithmeticOperators.cs
@@ -1,0 +1,263 @@
+using System;
+
+namespace operators
+{
+    public static class ArithmeticOperators
+    {
+        public static void Examples()
+        {
+            Console.WriteLine("==== ++ and -- operators");
+            Increment();
+            Decrement();
+            
+            Console.WriteLine("==== Unary + and - operators");
+            UnaryPlusAndMinus();
+            
+            Console.WriteLine("==== *, /, %, +, and - operators");
+            Multiplication();
+            IntegerDivision();
+            IntegerAsFloatingPointDivision();
+            FloatingPointDivision();
+            IntegerRemainder();
+            FloatingPointRemainder();
+            Addition();
+            Subtraction();
+            
+            Console.WriteLine("==== Precedence and associativity examples");
+            PrecedenceAndAssociativity();
+            
+            Console.WriteLine("==== Compound assignment");
+            CompoundAssignment();
+            CompoundAssignmentWithCast();
+            
+            Console.WriteLine("==== Special cases");
+            CheckedUnchecked();
+            FloatingPointOverflow();
+            RoundOffErrors();
+        }
+
+        private static void Increment()
+        {
+            // <SnippetPrefixIncrement>
+            double a = 1.5;
+            Console.WriteLine(a);   // output: 1.5
+            Console.WriteLine(++a); // output: 2.5
+            Console.WriteLine(a);   // output: 2.5
+            // </SnippetPrefixIncrement>
+
+            // <SnippetPostfixIncrement>
+            int i = 3;
+            Console.WriteLine(i);   // output: 3
+            Console.WriteLine(i++); // output: 3
+            Console.WriteLine(i);   // output: 4
+            // </SnippetPostfixIncrement>
+        }
+
+        private static void Decrement()
+        {
+            // <SnippetPrefixDecrement>
+            double a = 1.5;
+            Console.WriteLine(a);   // output: 1.5
+            Console.WriteLine(--a); // output: 0.5
+            Console.WriteLine(a);   // output: 0.5
+            // </SnippetPrefixDecrement>
+
+            // <SnippetPostfixDecrement>
+            int i = 3;
+            Console.WriteLine(i);   // output: 3
+            Console.WriteLine(i--); // output: 3
+            Console.WriteLine(i);   // output: 2
+            // </SnippetPostfixDecrement>
+        }
+
+        private static void UnaryPlusAndMinus()
+        {
+            // <SnippetUnaryPlusAndMinus>
+            Console.WriteLine(+4);     // output: 4
+
+            Console.WriteLine(-4);     // output: -4
+            Console.WriteLine(-(-4));  // output: 4
+
+            uint a = 5;
+            var b = -a;
+            Console.WriteLine(b);            // output: -5
+            Console.WriteLine(b.GetType());  // output: System.Int64
+
+            Console.WriteLine(-double.NaN);  // output: NaN
+            // </SnippetUnaryPlusAndMinus>
+        }
+
+        private static void Multiplication()
+        {
+            // <SnippetMultiplication>
+            Console.WriteLine(5 * 2);         // output: 10
+            Console.WriteLine(0.5 * 2.5);     // output: 1.25
+            Console.WriteLine(0.1m * 23.4m);  // output: 2.34
+            // </SnippetMultiplication>
+        }
+
+        private static void IntegerDivision()
+        {
+            // <SnippetIntegerDivision>
+            Console.WriteLine(13 / 5);    // output: 2
+            Console.WriteLine(-13 / 5);   // output: -2
+            Console.WriteLine(13 / -5);   // output: -2
+            Console.WriteLine(-13 / -5);  // output: 2
+            // </SnippetIntegerDivision>
+        }
+
+        private static void IntegerAsFloatingPointDivision()
+        {
+            // <SnippetIntegerAsFloatingPointDivision>
+            Console.WriteLine(13 / 5.0);       // output: 2.6
+
+            int a = 13;
+            int b = 5;
+            Console.WriteLine((double)a / b);  // output: 2.6
+            // </SnippetIntegerAsFloatingPointDivision>
+        }
+
+        private static void FloatingPointDivision()
+        {
+            // <SnippetFloatingPointDivision>
+            Console.WriteLine(16.8f / 4.1f);   // output: 4.097561
+            Console.WriteLine(16.8d / 4.1d);   // output: 4.09756097560976
+            Console.WriteLine(16.8m / 4.1m);   // output: 4.0975609756097560975609756098
+            // </SnippetFloatingPointDivision>
+        }
+
+        private static void IntegerRemainder()
+        {
+            // <SnippetIntegerRemainder>
+            Console.WriteLine(5 % 4);   // output: 1
+            Console.WriteLine(5 % -4);  // output: 1
+            Console.WriteLine(-5 % 4);  // output: -1
+            Console.WriteLine(-5 % -4); // output: -1
+            // </SnippetIntegerRemainder>
+        }
+
+        private static void FloatingPointRemainder()
+        {
+            // <SnippetFloatingPointRemainder>
+            Console.WriteLine(-5.2f % 2.0f); // output: -1.2
+            Console.WriteLine(5.9 % 3.1);    // output: 2.8
+            Console.WriteLine(5.9m % 3.1m);  // output: 2.8
+            // </SnippetFloatingPointRemainder>
+        }
+
+        private static void Addition()
+        {
+            // <SnippetAddition>
+            Console.WriteLine(5 + 4);       // output: 9
+            Console.WriteLine(5 + 4.3);     // output: 9.3
+            Console.WriteLine(5.1m + 4.2m); // output: 9.3
+            // </SnippetAddition>
+        }
+
+        private static void Subtraction()
+        {
+            // <SnippetSubtraction>
+            Console.WriteLine(47 - 3);      // output: 44
+            Console.WriteLine(5 - 4.3);     // output: 0.7
+            Console.WriteLine(7.5m - 2.3m); // output: 5.2
+            // </SnippetSubtraction>
+        }
+
+        private static void PrecedenceAndAssociativity()
+        {
+            // <SnippetPrecedenceAndAssociativity>
+            Console.WriteLine(2 + 2 * 2);   // output: 6
+            Console.WriteLine((2 + 2) * 2); // output: 8
+
+            Console.WriteLine(9 / 5 / 2);   // output: 0
+            Console.WriteLine(9 / (5 / 2)); // output: 4
+            // </SnippetPrecedenceAndAssociativity>
+        }
+
+        private static void CompoundAssignment()
+        {
+            // <SnippetCompoundAssignment>
+            int a = 5;
+            a += 9;
+            Console.WriteLine(a);  // output: 14
+
+            a -= 4;
+            Console.WriteLine(a);  // output: 10
+
+            a *= 2;
+            Console.WriteLine(a);  // output: 20
+
+            a /= 4;
+            Console.WriteLine(a);  // output: 5
+
+            a %= 3;
+            Console.WriteLine(a);  // output: 2
+            // </SnippetCompoundAssignment>
+        }
+
+        private static void CompoundAssignmentWithCast()
+        {
+            // <SnippetCompoundAssignmentWithCast>
+            byte a = 200;
+            byte b = 100;
+            
+            var c = a + b;
+            Console.WriteLine(c.GetType());  // output: System.Int32
+            Console.WriteLine(c);  // output: 300
+
+            a += b;
+            Console.WriteLine(a);  // output: 44
+            // </SnippetCompoundAssignmentWithCast>
+        }
+
+        private static void CheckedUnchecked()
+        {
+            // <SnippetCheckedUnchecked>
+            int a = int.MaxValue;
+            int b = 3;
+
+            Console.WriteLine(unchecked(a + b));  // output: -2147483646
+            try
+            {
+                int d = checked(a + b);
+            }
+            catch(OverflowException)
+            {
+                Console.WriteLine($"Overflow occured when adding {a} to {b}.");
+            }
+            // </SnippetCheckedUnchecked>
+        }
+
+        private static void FloatingPointOverflow()
+        {
+            // <SnippetFloatingPointOverflow>
+            double a = 1.0 / 0.0;
+            Console.WriteLine(a);                    // output: Infinity
+            Console.WriteLine(double.IsInfinity(a)); // output: True
+
+            Console.WriteLine(double.MaxValue + double.MaxValue); // output: Infinity
+
+            double b = 0.0 / 0.0;
+            Console.WriteLine(b);                // output: NaN
+            Console.WriteLine(double.IsNaN(b));  // output: True
+            // </SnippetFloatingPointOverflow>
+        }
+
+        private static void RoundOffErrors()
+        {
+            // <SnippetRoundOffErrors>
+            Console.WriteLine(.41f % .2f); // output: 0.00999999
+
+            double a = 0.1;
+            double b = 3 * a;
+            Console.WriteLine(b == 0.3);   // output: False
+            Console.WriteLine(b - 0.3);    // output: 5.55111512312578E-17
+
+            decimal c = 1 / 3.0m;
+            decimal d = 3 * c;
+            Console.WriteLine(d == 1.0m);  // output: False
+            Console.WriteLine(d);          // output: 0.9999999999999999999999999999
+            // </SnippetRoundOffErrors>
+        }
+    }
+}

--- a/csharp/language-reference/operators/AssignmentExamples.cs
+++ b/csharp/language-reference/operators/AssignmentExamples.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace operators
+{
+    public static class AssignmentExamples
+    {
+        public static void Examples()
+        {
+            VariablePropertyIndexerExample();
+            RefAssignmentExample();
+        }
+
+        private static void VariablePropertyIndexerExample()
+        {
+            // <SnippetAssignments>
+            var numbers = new List<double>() { 1.0, 2.0, 3.0 };
+
+            Console.WriteLine(numbers.Capacity);
+            numbers.Capacity = 100;
+            Console.WriteLine(numbers.Capacity);
+            // Output:
+            // 4
+            // 100
+
+            int newFirstElement;
+            double originalFirstElement = numbers[0];
+            newFirstElement = 5;
+            numbers[0] = newFirstElement;
+            Console.WriteLine(originalFirstElement);
+            Console.WriteLine(numbers[0]);
+            // Output:
+            // 1
+            // 5
+            // </SnippetAssignments>
+        }
+
+        private static void RefAssignmentExample()
+        {
+            // <SnippetRefAssignment>
+            void Display(double[] s) => Console.WriteLine(string.Join(" ", s));
+            
+            double[] arr = { 0.0, 0.0, 0.0 };
+            Display(arr);
+
+            ref double arrayElement = ref arr[0];
+            arrayElement = 3.0;
+            Display(arr);
+
+            arrayElement = ref arr[arr.Length - 1];
+            arrayElement = 5.0;
+            Display(arr);
+            // Output:
+            // 0 0 0
+            // 3 0 0
+            // 3 0 5
+            // </SnippetRefAssignment>
+        }
+    }
+}

--- a/csharp/language-reference/operators/BitwiseAndShiftOperators.cs
+++ b/csharp/language-reference/operators/BitwiseAndShiftOperators.cs
@@ -1,0 +1,205 @@
+using System;
+
+namespace operators
+{
+    public static class BitwiseAndShiftOperators
+    {
+        public static void Examples()
+        {
+            Console.WriteLine("==== ~, &, ^, and | operators");
+            BitwiseComplement();
+            BitwiseAnd();
+            BitwiseXor();
+            BitwiseOr();
+
+            Console.WriteLine("==== << and >> operators");
+            LeftShift();
+            RightShift();
+            ShiftCount();
+
+            Console.WriteLine("==== Additional examples");
+            CompoundAssignment();
+            CompoundAssignmentWithCast();
+            Precedence();
+        }
+
+        private static void BitwiseComplement()
+        {
+            // <SnippetBitwiseComplement>
+            uint a = 0b_0000_1111_0000_1111_0000_1111_0000_1100;
+            uint b = ~a;
+            Console.WriteLine(Convert.ToString(b, toBase: 2));
+            // Output:
+            // 11110000111100001111000011110011
+            // </SnippetBitwiseComplement>
+        }
+
+        private static void BitwiseAnd()
+        {
+            // <SnippetBitwiseAnd>
+            uint a = 0b_1111_1000;
+            uint b = 0b_1001_1101;
+            uint c = a & b;
+            Console.WriteLine(Convert.ToString(c, toBase: 2));
+            // Output:
+            // 10011000
+            // </SnippetBitwiseAnd>
+        }
+
+        private static void BitwiseXor()
+        {
+            // <SnippetBitwiseXor>
+            uint a = 0b_1111_1000;
+            uint b = 0b_0001_1100;
+            uint c = a ^ b;
+            Console.WriteLine(Convert.ToString(c, toBase: 2));
+            // Output:
+            // 11100100
+            // </SnippetBitwiseXor>
+        }
+
+        private static void BitwiseOr()
+        {
+            // <SnippetBitwiseOr>
+            uint a = 0b_1010_0000;
+            uint b = 0b_1001_0001;
+            uint c = a | b;
+            Console.WriteLine(Convert.ToString(c, toBase: 2));
+            // Output:
+            // 10110001
+            // </SnippetBitwiseOr>
+        }
+
+        private static void LeftShift()
+        {
+            // <SnippetLeftShift>
+            uint x = 0b_1100_1001_0000_0000_0000_0000_0001_0001;
+            Console.WriteLine($"Before: {Convert.ToString(x, toBase: 2)}");
+
+            uint y = x << 4;
+            Console.WriteLine($"After:  {Convert.ToString(y, toBase: 2)}");
+            // Output:
+            // Before: 11001001000000000000000000010001
+            // After:  10010000000000000000000100010000
+            // </SnippetLeftShift>
+
+            // <SnippetLeftShiftPromoted>
+            byte a = 0b_1111_0001;
+
+            var b = a << 8;
+            Console.WriteLine(b.GetType());
+            Console.WriteLine($"Shifted byte: {Convert.ToString(b, toBase: 2)}");
+            // Output:
+            // System.Int32
+            // Shifted byte: 1111000100000000
+            // </SnippetLeftShiftPromoted>
+        }
+
+        private static void RightShift()
+        {
+            // <SnippetRightShift>
+            uint x = 0b_1001;
+            Console.WriteLine($"Before: {Convert.ToString(x, toBase: 2), 4}");
+
+            uint y = x >> 2;
+            Console.WriteLine($"After:  {Convert.ToString(y, toBase: 2), 4}");
+            // Output:
+            // Before: 1001
+            // After:    10
+            // </SnippetRightShift>
+
+            // <SnippetArithmeticRightShift>
+            int a = int.MinValue;
+            Console.WriteLine($"Before: {Convert.ToString(a, toBase: 2)}");
+
+            int b = a >> 3;
+            Console.WriteLine($"After:  {Convert.ToString(b, toBase: 2)}");
+            // Output:
+            // Before: 10000000000000000000000000000000
+            // After:  11110000000000000000000000000000
+            // </SnippetArithmeticRightShift>
+
+            // <SnippetLogicalRightShift>
+            uint c = 0b_1000_0000_0000_0000_0000_0000_0000_0000;
+            Console.WriteLine($"Before: {Convert.ToString(c, toBase: 2), 32}");
+
+            uint d = c >> 3;
+            Console.WriteLine($"After:  {Convert.ToString(d, toBase: 2), 32}");
+            // Output:
+            // Before: 10000000000000000000000000000000
+            // After:     10000000000000000000000000000
+            // </SnippetLogicalRightShift>
+        }
+
+        private static void ShiftCount()
+        {
+            // <SnippetShiftCount>
+            int count1 = 0b_0000_0001;
+            int count2 = 0b_1110_0001;
+            
+            int a = 0b_0001;
+            Console.WriteLine($"{a} << {count1} is {a << count1}; {a} << {count2} is {a << count2}");
+            // Output:
+            // 1 << 1 is 2; 1 << 225 is 2
+
+            int b = 0b_0100;
+            Console.WriteLine($"{b} >> {count1} is {b >> count1}; {b} >> {count2} is {b >> count2}");
+            // Output:
+            // 4 >> 1 is 2; 4 >> 225 is 2
+            // </SnippetShiftCount>
+        }
+
+        private static void CompoundAssignment()
+        {
+            // <SnippetCompoundAssignment>
+            uint a = 0b_1111_1000;
+            a &= 0b_1001_1101;
+            Display(a);  // output: 10011000
+
+            a |= 0b_0011_0001;
+            Display(a);  // output: 10111001
+
+            a ^= 0b_1000_0000;
+            Display(a);  // output:   111001
+
+            a <<= 2;
+            Display(a);  // output: 11100100
+
+            a >>= 4;
+            Display(a);  // output:     1110
+
+            void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2), 8}");
+            // </SnippetCompoundAssignment>
+        }
+
+        private static void CompoundAssignmentWithCast()
+        {
+            // <SnippetCompoundAssignmentWithCast>
+            byte x = 0b_1111_0001;
+
+            int b = x << 8;
+            Console.WriteLine($"{Convert.ToString(b, toBase: 2)}");  // output: 1111000100000000
+
+            x <<= 8;
+            Console.WriteLine(x);  // output: 0
+            // </SnippetCompoundAssignmentWithCast>
+        }
+
+        private static void Precedence()
+        {
+            // <SnippetPrecedence>
+            uint a = 0b_1101;
+            uint b = 0b_1001;
+            uint c = 0b_1010;
+
+            uint d1 = a | b & c;
+            Display(d1);  // output: 1101
+
+            uint d2 = (a | b) & c;
+            Display(d2);  // output: 1000
+
+            void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2), 4}");
+            // </SnippetPrecedence>
+        }
+    }
+}

--- a/csharp/language-reference/operators/BooleanLogicalOperators.cs
+++ b/csharp/language-reference/operators/BooleanLogicalOperators.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace operators
 {
-    public static class LogicalOperators
+    public static class BooleanLogicalOperators
     {
         public static void Examples()
         {

--- a/csharp/language-reference/operators/ComparisonOperators.cs
+++ b/csharp/language-reference/operators/ComparisonOperators.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace operators
+{
+    public static class ComparisonOperators
+    {
+        public static void Examples()
+        {
+            Console.WriteLine("--- >");
+            Greater();
+            Console.WriteLine("--- <");
+            Less();
+            Console.WriteLine("--- >=");
+            GreaterOrEqual();
+            Console.WriteLine("--- <=");
+            LessOrEqual();
+        }
+
+        private static void Greater()
+        {
+            // <SnippetGreater>
+            Console.WriteLine(7.0 > 5.1);   // output: True
+            Console.WriteLine(5.1 > 5.1);   // output: False
+            Console.WriteLine(0.0 > 5.1);   // output: False
+
+            Console.WriteLine(double.NaN > 5.1);   // output: False
+            Console.WriteLine(double.NaN <= 5.1);  // output: False
+            // </SnippetGreater>
+        }
+
+        private static void Less()
+        {
+            // <SnippetLess>
+            Console.WriteLine(7.0 < 5.1);   // output: False
+            Console.WriteLine(5.1 < 5.1);   // output: False
+            Console.WriteLine(0.0 < 5.1);   // output: True
+
+            Console.WriteLine(double.NaN < 5.1);   // output: False
+            Console.WriteLine(double.NaN >= 5.1);  // output: False
+            // </SnippetLess>
+        }
+
+        private static void GreaterOrEqual()
+        {
+            // <SnippetGreaterOrEqual>
+            Console.WriteLine(7.0 >= 5.1);   // output: True
+            Console.WriteLine(5.1 >= 5.1);   // output: True
+            Console.WriteLine(0.0 >= 5.1);   // output: False
+
+            Console.WriteLine(double.NaN < 5.1);   // output: False
+            Console.WriteLine(double.NaN >= 5.1);  // output: False
+            // </SnippetGreaterOrEqual>
+        }
+
+        private static void LessOrEqual()
+        {
+            // <SnippetLessOrEqual>
+            Console.WriteLine(7.0 <= 5.1);   // output: False
+            Console.WriteLine(5.1 <= 5.1);   // output: True
+            Console.WriteLine(0.0 <= 5.1);   // output: True
+
+            Console.WriteLine(double.NaN > 5.1);   // output: False
+            Console.WriteLine(double.NaN <= 5.1);  // output: False
+            // </SnippetLessOrEqual>
+        }
+    }
+}

--- a/csharp/language-reference/operators/ConditionalOperator.cs
+++ b/csharp/language-reference/operators/ConditionalOperator.cs
@@ -1,0 +1,67 @@
+﻿using System;
+
+namespace operators
+{
+    public class ConditionalOperator
+    {
+        public static void Examples()
+        {
+            ConditionalRefExpressions();
+            ConditionalValueExpressions();
+            ComparisonWithIf();
+        }
+
+        private static void ConditionalRefExpressions()
+        {
+            // <SnippetConditionalRef>
+            var smallArray = new int[] { 1, 2, 3, 4, 5 };
+            var largeArray = new int[] { 10, 20, 30, 40, 50 };
+
+            int index = 7;
+            ref int refValue = ref ((index < 5) ? ref smallArray[index] : ref largeArray[index - 5]);
+            refValue = 0;
+
+            index = 2;
+            ((index < 5) ? ref smallArray[index] : ref largeArray[index - 5]) = 100;
+
+            Console.WriteLine(string.Join(" ", smallArray));
+            Console.WriteLine(string.Join(" ", largeArray));
+            // Output:
+            // 1 2 100 4 5
+            // 10 20 0 40 50
+            // </SnippetConditionalRef>
+        }
+
+        private static void ConditionalValueExpressions()
+        {
+            // <SnippetConditionalValue>
+            double sinc(double x) => x != 0.0 ? Math.Sin(x) / x : 1;
+
+            Console.WriteLine(sinc(0.1));
+            Console.WriteLine(sinc(0.0));
+            // Output:
+            // 0.998334166468282
+            // 1
+            // </SnippetConditionalValue>
+        }
+
+        private static void ComparisonWithIf()
+        {
+            // <SnippetCompareWithIf>
+            int input = new Random().Next(-5, 5);
+            
+            string classify;
+            if (input >= 0)
+            {
+                classify = "nonnegative";
+            }
+            else
+            {
+                classify = "negative";
+            }
+
+            classify = (input >= 0) ? "nonnegative" : "negative";
+            // </SnippetCompareWithIf>
+        }
+    }
+}

--- a/csharp/language-reference/operators/EqualityOperators.cs
+++ b/csharp/language-reference/operators/EqualityOperators.cs
@@ -1,0 +1,91 @@
+using System;
+
+namespace operators
+{
+    public static class EqualityOperators
+    {
+        public static void Examples()
+        {
+            Console.WriteLine("Value types:");
+            ValueTypesEquality();
+
+            Console.WriteLine("Strings:");
+            StringEquality();
+
+            Console.WriteLine("Reference types:");
+            ReferenceTypesEquality.Main();
+
+            Console.WriteLine("Non equality:");
+            NonEquality();
+        }
+
+        private static void ValueTypesEquality()
+        {
+            // <SnippetValueTypesEquality>
+            int a = 1 + 2 + 3;
+            int b = 6;
+            Console.WriteLine(a == b);  // output: True
+
+            char c1 = 'a';
+            char c2 = 'A';
+            Console.WriteLine(c1 == c2);  // output: False
+            Console.WriteLine(c1 == char.ToLower(c2));  // output: True
+            // </SnippetValueTypesEquality>
+        }
+
+        private static void StringEquality()
+        {
+            // <SnippetStringEquality>
+            string s1 = "hello!";
+            string s2 = "HeLLo!";
+            Console.WriteLine(s1 == s2.ToLower());  // output: True
+
+            string s3 = "Hello!";
+            Console.WriteLine(s1 == s3);  // output: False
+            // </SnippetStringEquality>
+        }
+
+        // Rationale for the structure of the next snippet.
+        // A method cannot contain a class definition. Thus, a standard way to include snippet doesn't work.
+        // We want snippets to be interactive. Thus, the whole snippet has a structure of the console program.
+        // (Running the code without the ReferenceTypesEquality class doesn't produce any output in the interactive Output control.)
+
+        // <SnippetReferenceTypesEquality>
+        public class ReferenceTypesEquality
+        {
+            public class MyClass
+            {
+                private int id;
+
+                public MyClass(int id) => this.id = id;
+            }
+
+            public static void Main()
+            {
+                var a = new MyClass(1);
+                var b = new MyClass(1);
+                var c = a;
+                Console.WriteLine(a == b);  // output: False
+                Console.WriteLine(a == c);  // output: True
+            }
+        }
+        // </SnippetReferenceTypesEquality>
+
+        private static void NonEquality()
+        {
+            // <SnippetNonEquality>
+            int a = 1 + 1 + 2 + 3;
+            int b = 6;
+            Console.WriteLine(a != b);  // output: True
+
+            string s1 = "Hello";
+            string s2 = "Hello";
+            Console.WriteLine(s1 != s2);  // output: False
+
+            object o1 = 1;
+            object o2 = 1;
+            Console.WriteLine(o1 != o2);  // output: True
+            // </SnippetNonEquality>
+        }
+    }
+}

--- a/csharp/language-reference/operators/InvocationOperatorExamples.cs
+++ b/csharp/language-reference/operators/InvocationOperatorExamples.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace operators
+{
+    public static class InvocationOperatorExamples
+    {
+        public static void Examples()
+        {
+            Invocation();
+            Cast();
+        }
+
+        private static void Invocation()
+        {
+            // <SnippetInvocation>
+            Action<int> display = s => Console.WriteLine(s);
+
+            var numbers = new List<int>();
+            numbers.Add(10);
+            numbers.Add(17);
+            display(numbers.Count);   // output: 2
+
+            numbers.Clear();
+            display(numbers.Count);   // output: 0
+            // </SnippetInvocation>
+        }
+
+        private static void Cast()
+        {
+            // <SnippetCast>
+            double x = 1234.7;
+            int a = (int)x;
+            Console.WriteLine(a);   // output: 1234
+            // </SnippetCast>
+        }
+    }
+}

--- a/csharp/language-reference/operators/LambdaOperator.cs
+++ b/csharp/language-reference/operators/LambdaOperator.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+
+namespace operators
+{
+    public static class LambdaOperator
+    {
+        public static void Examples()
+        {
+            WithInferredTypes();
+            WithExplicitTypes();
+            WithoutInput();
+        }
+
+        private static void WithInferredTypes()
+        {
+            // <SnippetInferredTypes>
+            string[] words = { "bot", "apple", "apricot" };
+            int minimalLength = words
+              .Where(w => w.StartsWith("a"))
+              .Min(w => w.Length);
+            Console.WriteLine(minimalLength);   // output: 5
+
+            int[] numbers = { 1, 4, 7, 10 };
+            int product = numbers.Aggregate(1, (interim, next) => interim * next);
+            Console.WriteLine(product);   // output: 280
+            // </SnippetInferredTypes>
+        }
+
+        private static void WithExplicitTypes()
+        {
+            // <SnippetExplicitTypes>
+            int[] numbers = { 1, 4, 7, 10 };
+            int product = numbers.Aggregate(1, (int interim, int next) => interim * next);
+            Console.WriteLine(product);   // output: 280
+            // </SnippetExplicitTypes>
+        }
+
+        private static void WithoutInput()
+        {
+            // <SnippetWithoutInput>
+            Func<string> greet = () => "Hello, World!";
+            Console.WriteLine(greet());
+            // </SnippetWithoutInput>
+        }
+    }
+}

--- a/csharp/language-reference/operators/LogicalOperators.cs
+++ b/csharp/language-reference/operators/LogicalOperators.cs
@@ -1,0 +1,189 @@
+using System;
+
+namespace operators
+{
+    public static class LogicalOperators
+    {
+        public static void Examples()
+        {
+            Console.WriteLine("==== !, &, |, ^ operators");
+            Negation();
+            And();
+            Or();
+            Xor();
+            WithNullableBoolean();
+
+            Console.WriteLine("==== && and || operators");
+            ConditionalAnd();
+            ConditionalOr();
+
+            Console.WriteLine("==== Compound assignment and precedence");
+            CompoundAssignment();
+            Precedence();
+        }
+
+        private static void Negation()
+        {
+            // <SnippetNegation>
+            bool passed = false;
+            Console.WriteLine(!passed);  // output: True
+            Console.WriteLine(!true);    // output: False
+            // </SnippetNegation>
+        }
+
+        private static void And()
+        {
+            // <SnippetAnd>
+            bool SecondOperand() 
+            {
+                Console.WriteLine("Second operand is evaluated.");
+                return true;
+            }
+            
+            bool a = false & SecondOperand();
+            Console.WriteLine(a);
+            // Output:
+            // Second operand is evaluated.
+            // False
+
+            bool b = true & SecondOperand();
+            Console.WriteLine(b);
+            // Output:
+            // Second operand is evaluated.
+            // True
+            // </SnippetAnd>
+        }
+
+        private static void Or()
+        {
+            // <SnippetOr>
+            bool SecondOperand() 
+            {
+                Console.WriteLine("Second operand is evaluated.");
+                return true;
+            }
+            
+            bool a = true | SecondOperand();
+            Console.WriteLine(a);
+            // Output:
+            // Second operand is evaluated.
+            // True
+
+            bool b = false | SecondOperand();
+            Console.WriteLine(b);
+            // Output:
+            // Second operand is evaluated.
+            // True
+            // </SnippetOr>
+        }
+
+        private static void Xor()
+        {
+            // <SnippetXor>
+            Console.WriteLine(true ^ true);    // output: False
+            Console.WriteLine(true ^ false);   // output: True
+            Console.WriteLine(false ^ true);   // output: True
+            Console.WriteLine(false ^ false);  // output: False
+            // </SnippetXor>
+        }
+
+        private static void ConditionalAnd()
+        {
+            // <SnippetConditionalAnd>
+            bool SecondOperand()
+            {
+                Console.WriteLine("Second operand is evaluated.");
+                return true;
+            }
+
+            bool a = false && SecondOperand();
+            Console.WriteLine(a);
+            // Output:
+            // False
+
+            bool b = true && SecondOperand();
+            Console.WriteLine(b);
+            // Output:
+            // Second operand is evaluated.
+            // True
+            // </SnippetConditionalAnd>
+        }
+
+        private static void ConditionalOr()
+        {
+            // <SnippetConditionalOr>
+            bool SecondOperand()
+            {
+                Console.WriteLine("Second operand is evaluated.");
+                return true;
+            }
+
+            bool a = true || SecondOperand();
+            Console.WriteLine(a);
+            // Output:
+            // True
+
+            bool b = false || SecondOperand();
+            Console.WriteLine(b);
+            // Output:
+            // Second operand is evaluated.
+            // True
+            // </SnippetConditionalOr>
+        }
+
+        private static void WithNullableBoolean()
+        {
+            // <SnippetWithNullableBoolean>
+            bool? test = null;
+            Display(!test);         // output: null
+            Display(test ^ false);  // output: null
+            Display(test ^ null);   // output: null
+            Display(true ^ null);   // output: null 
+
+            void Display(bool? b) => Console.WriteLine(b is null ? "null" : b.Value.ToString());
+            // </SnippetWithNullableBoolean>
+        }
+
+        private static void CompoundAssignment()
+        {
+            // <SnippetCompoundAssignment>
+            bool test = true;
+            test &= false;
+            Console.WriteLine(test);  // output: False
+
+            test |= true;
+            Console.WriteLine(test);  // output: True
+
+            test ^= false;
+            Console.WriteLine(test);  // output: True
+            // </SnippetCompoundAssignment>
+        }
+
+        private static void Precedence()
+        {
+            // <SnippetPrecedence>
+            Console.WriteLine(true | true & false);   // output: True
+            Console.WriteLine((true | true) & false); // output: False
+            
+            bool Operand(string name, bool value)
+            {
+                Console.WriteLine($"Operand {name} is evaluated.");
+                return value;
+            }
+
+            var byDefaultPrecedence = Operand("A", true) || Operand("B", true) && Operand("C", false);
+            Console.WriteLine(byDefaultPrecedence);
+            // Output:
+            // Operand A is evaluated.
+            // True
+
+            var changedOrder = (Operand("A", true) || Operand("B", true)) && Operand("C", false);
+            Console.WriteLine(changedOrder);
+            // Output:
+            // Operand A is evaluated.
+            // Operand C is evaluated.
+            // False
+            // </SnippetPrecedence>
+        }
+    }
+}

--- a/csharp/language-reference/operators/MemberAccessOperators.cs
+++ b/csharp/language-reference/operators/MemberAccessOperators.cs
@@ -1,0 +1,111 @@
+using System;
+// <SnippetNestedNamespace>
+using System.Collections.Generic;
+// </SnippetNestedNamespace>
+using System.Linq;
+
+namespace operators
+{
+    public static class MemberAccessOperators
+    {
+        public static void Examples()
+        {
+            TypeMemberAccess();
+            Arrays();
+            Indexers();
+            NullConditional();
+            Invocation();
+        }
+
+        private static void QualifiedName()
+        {
+            // <SnippetQualifiedName>
+            System.Collections.Generic.IEnumerable<int> numbers = new int[] { 1, 2, 3 };
+            // </SnippetQualifiedName>
+        }
+
+        private static void TypeMemberAccess()
+        {
+            // <SnippetTypeMemberAccess>
+            var constants = new List<double>();
+            constants.Add(Math.PI);
+            constants.Add(Math.E);
+            Console.WriteLine($"{constants.Count} values to show:");
+            Console.WriteLine(string.Join(", ", constants));
+            // Output:
+            // 2 values to show:
+            // 3.14159265358979, 2.71828182845905
+            // </SnippetTypeMemberAccess>
+        }
+
+        private static void Arrays()
+        {
+            // <SnippetArrays>
+            int[] fib = new int[10];
+            fib[0] = fib[1] = 1;
+            for (int i = 2; i < fib.Length; i++)
+            {
+                fib[i] = fib[i - 1] + fib[i - 2];
+            }
+            Console.WriteLine(fib[fib.Length - 1]);  // output: 55
+
+            double[,] matrix = new double[2,2];
+            matrix[0,0] = 1.0;
+            matrix[0,1] = 2.0;
+            matrix[1,0] = matrix[1,1] = 3.0;
+            var determinant = matrix[0,0] * matrix[1,1] - matrix[1,0] * matrix[0,1];
+            Console.WriteLine(determinant);  // output: -3
+            // </SnippetArrays>
+        }
+
+        private static void Indexers()
+        {
+            // <SnippetIndexers>
+            var dict = new Dictionary<string, double>();
+            dict["one"] = 1;
+            dict["pi"] = Math.PI;
+            Console.WriteLine(dict["one"] + dict["pi"]);  // output: 4.14159265358979
+            // </SnippetIndexers>
+        }
+
+        private static void NullConditional()
+        {
+            // <SnippetNullConditional>
+            double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
+            {
+                return setsOfNumbers?[indexOfSetToSum]?.Sum() ?? double.NaN;
+            }
+
+            var sum1 = SumNumbers(null, 0);
+            Console.WriteLine(sum1);  // output: NaN
+
+            var numberSets = new List<double[]>
+            {
+                new[] { 1.0, 2.0, 3.0 },
+                null
+            };
+
+            var sum2 = SumNumbers(numberSets, 0);
+            Console.WriteLine(sum2);  // output: 6
+
+            var sum3 = SumNumbers(numberSets, 1);
+            Console.WriteLine(sum3);  // output: NaN
+            // </SnippetNullConditional>
+        }
+
+        private static void Invocation()
+        {
+            // <SnippetInvocation>
+            Action<int> display = s => Console.WriteLine(s);
+
+            var numbers = new List<int>();
+            numbers.Add(10);
+            numbers.Add(17);
+            display(numbers.Count);   // output: 2
+
+            numbers.Clear();
+            display(numbers.Count);   // output: 0
+            // </SnippetInvocation>
+        }
+    }
+}

--- a/csharp/language-reference/operators/PointerOperators.cs
+++ b/csharp/language-reference/operators/PointerOperators.cs
@@ -1,0 +1,170 @@
+using System;
+
+namespace operators
+{
+    public static class PointerOperators
+    {
+        public static void Examples()
+        {
+            AddressOf();
+            PointerIndirection();
+            PointerMemberAccessExample.Main();
+            PointerElementAccess();
+            PointerAddition();
+            PointerSubtraction();
+            Increment();
+        }
+
+        private static void AddressOf()
+        {
+            // <SnippetAddressOf>
+            unsafe
+            {
+                int number = 27;
+                int* pointerToNumber = &number;
+
+                Console.WriteLine($"Value of the variable: {number}");
+                Console.WriteLine($"Address of the variable: {(long)pointerToNumber:X}");
+            }
+            // Output is similar to:
+            // Value of the variable: 27
+            // Address of the variable: 6C1457DBD4
+            // </SnippetAddressOf>
+        }
+
+        private static void AddressOfFixed()
+        {
+            // <SnippetAddressOfFixed>
+            unsafe
+            {
+                byte[] bytes = { 1, 2, 3 };
+                fixed (byte* pointerToFirst = &bytes[0])
+                {
+                    // The address stored in pointerToFirst 
+                    // is valid only inside this fixed statement block.
+                }
+            }
+            // </SnippetAddressOfFixed>
+        }
+
+        private static void PointerIndirection()
+        {
+            // <SnippetPointerIndirection>
+            unsafe
+            {
+                char letter = 'A';
+                char* pointerToLetter = &letter;
+                Console.WriteLine($"Value of the `letter` variable: {letter}");
+                Console.WriteLine($"Address of the `letter` variable: {(long)pointerToLetter:X}");
+
+                *pointerToLetter = 'Z';
+                Console.WriteLine($"Value of the `letter` variable after update: {letter}");
+            }
+            // Output is similar to:
+            // Value of the `letter` variable: A
+            // Address of the `letter` variable: DCB977DDF4
+            // Value of the `letter` variable after update: Z
+            // </SnippetPointerIndirection>
+        }
+
+        // <SnippetMemberAccess>
+        public struct Coords
+        {
+            public int X;
+            public int Y;
+            public override string ToString() => $"({X}, {Y})";
+        }
+
+        public class PointerMemberAccessExample
+        {
+            public static unsafe void Main()
+            {
+                Coords coords;
+                Coords* p = &coords;
+                p->X = 3;
+                p->Y = 4;
+                Console.WriteLine(p->ToString());  // output: (3, 4)
+            }
+        }
+        // </SnippetMemberAccess>
+
+        private static void PointerElementAccess()
+        {
+            // <SnippetElementAccess>
+            unsafe
+            {
+                char* pointerToChars = stackalloc char[123];
+
+                for (int i = 65; i < 123; i++)
+                {
+                    pointerToChars[i] = (char)i;
+                }
+
+                Console.Write("Uppercase letters: ");
+                for (int i = 65; i < 91; i++)
+                {
+                    Console.Write(pointerToChars[i]);
+                }
+            }
+            // Output:
+            // Uppercase letters: ABCDEFGHIJKLMNOPQRSTUVWXYZ
+            // </SnippetElementAccess>
+            Console.WriteLine();
+        }
+
+        private static void PointerAddition()
+        {
+            // <SnippetAddNumber>
+            unsafe
+            {
+                const int Count = 3;
+                int[] numbers = new int[Count] { 10, 20, 30 };
+                fixed (int* pointerToFirst = &numbers[0])
+                {
+                    int* pointerToLast = pointerToFirst + (Count - 1);
+
+                    Console.WriteLine($"Value {*pointerToFirst} at address {(long)pointerToFirst}");
+                    Console.WriteLine($"Value {*pointerToLast} at address {(long)pointerToLast}");
+                }
+            }
+            // Output is similar to:
+            // Value 10 at address 1818345918136
+            // Value 30 at address 1818345918144
+            // </SnippetAddNumber>
+        }
+
+        private static void PointerSubtraction()
+        {
+            // <SnippetSubtractPointers>
+            unsafe
+            {
+                int* numbers = stackalloc int[] { 0, 1, 2, 3, 4, 5 };
+                int* p1 = &numbers[1];
+                int* p2 = &numbers[5];
+                Console.WriteLine(p2 - p1);  // output: 4
+            }
+            // </SnippetSubtractPointers>
+        }
+
+        private static void Increment()
+        {
+            // <SnippetIncrement>
+            unsafe
+            {
+                int* numbers = stackalloc int[] { 0, 1, 2 };
+                int* p1 = &numbers[0];
+                int* p2 = p1;
+                Console.WriteLine($"Before operation: p1 - {(long)p1}, p2 - {(long)p2}");
+                Console.WriteLine($"Postfix increment of p1: {(long)(p1++)}");
+                Console.WriteLine($"Prefix increment of p2: {(long)(++p2)}");
+                Console.WriteLine($"After operation: p1 - {(long)p1}, p2 - {(long)p2}");
+            }
+            // Output is similar to
+            // Before operation: p1 - 816489946512, p2 - 816489946512
+            // Postfix increment of p1: 816489946512
+            // Prefix increment of p2: 816489946516
+            // After operation: p1 - 816489946516, p2 - 816489946516
+            // </SnippetIncrement>
+        }
+    }
+}

--- a/csharp/language-reference/operators/Program.cs
+++ b/csharp/language-reference/operators/Program.cs
@@ -15,7 +15,7 @@ namespace operators
             Console.WriteLine();
 
             Console.WriteLine("======== Logical operators examples ============");
-            LogicalOperators.Examples();
+            BooleanLogicalOperators.Examples();
             Console.WriteLine();
 
             Console.WriteLine("==== Bitwise and shift operators examples ======");

--- a/csharp/language-reference/operators/Program.cs
+++ b/csharp/language-reference/operators/Program.cs
@@ -6,8 +6,60 @@ namespace operators
     {
         static void Main(string[] args)
         {
+            Console.WriteLine("======== Arithmetic operators examples =========");
+            ArithmeticOperators.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("============= == and != operators examples =====");
+            EqualityOperators.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("======== Logical operators examples ============");
+            LogicalOperators.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("==== Bitwise and shift operators examples ======");
+            BitwiseAndShiftOperators.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("====== >, <, >=, and <= operators examples =====");
+            ComparisonOperators.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("========= Member access operators examples =====");
+            MemberAccessOperators.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("======= Pointer related operators examples =====");
+            PointerOperators.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("============== + operator examples =============");
+            AdditionOperator.Examples();
+            Console.WriteLine();
+
             Console.WriteLine("============== - operator examples =============");
             SubtractionOperator.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("============== = operator examples =============");
+            AssignmentExamples.Examples();
+            Console.WriteLine();
+            
+            Console.WriteLine("============== ?: operator examples ============");
+            ConditionalOperator.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("============== () operator examples ============");
+            InvocationOperatorExamples.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("============== => operator examples ============");
+            LambdaOperator.Examples();
+            Console.WriteLine();
+
+            Console.WriteLine("========= true and false operators examples ====");
+            LaunchStatusTest.Main();
             Console.WriteLine();
         }
     }

--- a/csharp/language-reference/operators/TrueFalseOperators.cs
+++ b/csharp/language-reference/operators/TrueFalseOperators.cs
@@ -1,0 +1,60 @@
+using System;
+
+public struct LaunchStatus
+{
+    public static readonly LaunchStatus Green = new LaunchStatus(0);
+    public static readonly LaunchStatus Yellow = new LaunchStatus(1);
+    public static readonly LaunchStatus Red = new LaunchStatus(2);
+
+    private int status;
+
+    private LaunchStatus(int status)
+    {
+        this.status = status;
+    }
+
+    public static bool operator true(LaunchStatus x) => x == Green || x == Yellow;
+    public static bool operator false(LaunchStatus x) => x == Red;
+
+    public static LaunchStatus operator &(LaunchStatus x, LaunchStatus y)
+    {
+        if (x == Red || y == Red || (x == Yellow && y == Yellow))
+        {
+            return Red;
+        }
+
+        if (x == Yellow || y == Yellow)
+        {
+            return Yellow;
+        }
+
+        return Green;
+    }
+
+    public static bool operator ==(LaunchStatus x, LaunchStatus y) => x.status == y.status;
+    public static bool operator !=(LaunchStatus x, LaunchStatus y) => !(x == y);
+
+    public override bool Equals(object obj) => obj is LaunchStatus other && this == other;
+    public override int GetHashCode() => status;
+}
+
+public class LaunchStatusTest
+{
+    public static void Main()
+    {
+        LaunchStatus okToLaunch = GetFuelLaunchStatus() && GetNavigationLaunchStatus();
+        Console.WriteLine(okToLaunch ? "Ready to go!" : "Wait!");
+    }
+
+    static LaunchStatus GetFuelLaunchStatus()
+    {
+        Console.WriteLine("Getting fuel launch status...");
+        return LaunchStatus.Red;
+    }
+
+    static LaunchStatus GetNavigationLaunchStatus()
+    {
+        Console.WriteLine("Getting navigation launch status...");
+        return LaunchStatus.Yellow;
+    }
+}

--- a/snippets/csharp/keywords/Program.cs
+++ b/snippets/csharp/keywords/Program.cs
@@ -16,8 +16,6 @@ namespace keywords
             IterationKeywordsExamples.Examples();
             Console.WriteLine("=================    readonly Keyword Examples ======================");
             ReadonlyKeywordExamples.Examples();
-            Console.WriteLine("=================    true and false operators examples ==============");
-            LaunchStatusTest.Main();
             Console.WriteLine("=================    true and false literals examples ===============");
             TrueFalseLiteralsExamples.Examples();
         }


### PR DESCRIPTION
This PR is the first of the two that moves the C# operators code examples out of the *snippets* folder:
https://github.com/dotnet/samples/tree/master/snippets/csharp/language-reference/operators

to the new location:
https://github.com/dotnet/samples/tree/master/csharp/language-reference/operators

To make the merge safe (that is, to keep the dotnet/docs master branch always build-able), this PR only *copies* examples from the old location to the new one. Another PR will clean the old location.

The content of the files is not changed. Only some files are renamed for consistency.

Supports dotnet/docs#12697

@BillWagner this is ready to merge from my point of view. However, you've asked (https://github.com/dotnet/samples/pull/916#issuecomment-494408453) about WIP PR. So, if that's ok to ship for you as well, I'm fine if you edit the title to remove the WIP mark.
