### PR TITLE
make snippets for samples

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/StringSplit2/CS/StringSplit10.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StringSplit2/CS/StringSplit10.cs
@@ -1,10 +1,10 @@
-//<snippet10>
 using System;
 
 public class Example
 {
    public static void Main() 
    {
+      //<snippet10>
       string delimStr = " ,.:";
       char [] delimiter = delimStr.ToCharArray();
       string words = "one two,three:four.";
@@ -18,28 +18,28 @@ public class Example
              Console.WriteLine("-{0}-", s);
          }
       }
+      // The example displays the following output:
+      //       The delimiters are - ,.:-
+      //       count =  1 ..............
+      //       -one two,three:four.-
+      //       count =  2 ..............
+      //       -one-
+      //       -two,three:four.-
+      //       count =  3 ..............
+      //       -one-
+      //       -two-
+      //       -three:four.-
+      //       count =  4 ..............
+      //       -one-
+      //       -two-
+      //       -three-
+      //       -four.-
+      //       count =  5 ..............
+      //       -one-
+      //       -two-
+      //       -three-
+      //       -four-
+      //       --
+      // </snippet10>
    }
 }
-// The example displays the following output:
-//       The delimiters are - ,.:-
-//       count =  1 ..............
-//       -one two,three:four.-
-//       count =  2 ..............
-//       -one-
-//       -two,three:four.-
-//       count =  3 ..............
-//       -one-
-//       -two-
-//       -three:four.-
-//       count =  4 ..............
-//       -one-
-//       -two-
-//       -three-
-//       -four.-
-//       count =  5 ..............
-//       -one-
-//       -two-
-//       -three-
-//       -four-
-//       --
-// </snippet10>

--- a/snippets/csharp/VS_Snippets_CLR/string.split3/CS/omit.cs
+++ b/snippets/csharp/VS_Snippets_CLR/string.split3/CS/omit.cs
@@ -1,12 +1,12 @@
-//<snippet1>
-// This example demonstrates the String() methods that use
-// the StringSplitOptions enumeration.
 using System;
 
 class Sample 
 {
     public static void Main() 
     {
+    //<snippet1>
+    // This example demonstrates the String() methods that use
+    // the StringSplitOptions enumeration.
     string s1 = ",ONE,,TWO,,,THREE,,";
     string s2 = "[stop]" +
                 "ONE[stop][stop]" +
@@ -15,133 +15,135 @@ class Sample
     char[] charSeparators = new char[] {','};
     string[] stringSeparators = new string[] {"[stop]"};
     string[] result;
-// ------------------------------------------------------------------------------
-// Split a string delimited by characters.
-// ------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------
+    // Split a string delimited by characters.
+    // ------------------------------------------------------------------------------
     Console.WriteLine("1) Split a string delimited by characters:\n");
 
-// Display the original string and delimiter characters.
+    // Display the original string and delimiter characters.
     Console.WriteLine("1a )The original string is \"{0}\".", s1);
     Console.WriteLine("The delimiter character is '{0}'.\n", 
                        charSeparators[0]);
 
-// Split a string delimited by characters and return all elements.
+    // Split a string delimited by characters and return all elements.
     Console.WriteLine("1b) Split a string delimited by characters and " +
                       "return all elements:");
     result = s1.Split(charSeparators, StringSplitOptions.None);
     Show(result);
 
-// Split a string delimited by characters and return all non-empty elements.
+    // Split a string delimited by characters and return all non-empty elements.
     Console.WriteLine("1c) Split a string delimited by characters and " +
                       "return all non-empty elements:");
     result = s1.Split(charSeparators, StringSplitOptions.RemoveEmptyEntries);
     Show(result);
 
-// Split the original string into the string and empty string before the 
-// delimiter and the remainder of the original string after the delimiter.
+    // Split the original string into the string and empty string before the 
+    // delimiter and the remainder of the original string after the delimiter.
     Console.WriteLine("1d) Split a string delimited by characters and " +
                       "return 2 elements:");
     result = s1.Split(charSeparators, 2, StringSplitOptions.None);
     Show(result);
 
-// Split the original string into the string after the delimiter and the 
-// remainder of the original string after the delimiter.
+    // Split the original string into the string after the delimiter and the 
+    // remainder of the original string after the delimiter.
     Console.WriteLine("1e) Split a string delimited by characters and " +
                       "return 2 non-empty elements:");
     result = s1.Split(charSeparators, 2, StringSplitOptions.RemoveEmptyEntries);
     Show(result);
 
-// ------------------------------------------------------------------------------
-// Split a string delimited by another string.
-// ------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------
+    // Split a string delimited by another string.
+    // ------------------------------------------------------------------------------
     Console.WriteLine("2) Split a string delimited by another string:\n");
 
-// Display the original string and delimiter string.
+    // Display the original string and delimiter string.
     Console.WriteLine("2a) The original string is \"{0}\".", s2);
     Console.WriteLine("The delimiter string is \"{0}\".\n", stringSeparators[0]);
 
-// Split a string delimited by another string and return all elements.
+    // Split a string delimited by another string and return all elements.
     Console.WriteLine("2b) Split a string delimited by another string and " +
                       "return all elements:");
     result = s2.Split(stringSeparators, StringSplitOptions.None);
     Show(result);
 
-// Split the original string at the delimiter and return all non-empty elements.
+    // Split the original string at the delimiter and return all non-empty elements.
     Console.WriteLine("2c) Split a string delimited by another string and " +
                       "return all non-empty elements:");
     result = s2.Split(stringSeparators, StringSplitOptions.RemoveEmptyEntries);
     Show(result);
 
-// Split the original string into the empty string before the 
-// delimiter and the remainder of the original string after the delimiter.
+    // Split the original string into the empty string before the 
+    // delimiter and the remainder of the original string after the delimiter.
     Console.WriteLine("2d) Split a string delimited by another string and " +
                       "return 2 elements:");
     result = s2.Split(stringSeparators, 2, StringSplitOptions.None);
     Show(result);
 
-// Split the original string into the string after the delimiter and the 
-// remainder of the original string after the delimiter.
+    // Split the original string into the string after the delimiter and the 
+    // remainder of the original string after the delimiter.
     Console.WriteLine("2e) Split a string delimited by another string and " + 
                       "return 2 non-empty elements:");
     result = s2.Split(stringSeparators, 2, StringSplitOptions.RemoveEmptyEntries);
     Show(result);
-    }
 
-// Display the array of separated strings.
-    public static void Show(string[] entries)
+    // Display the array of separated strings using a local function
+    void Show(string[] entries)
     {
-    Console.WriteLine("The return value contains these {0} elements:", entries.Length);
-    foreach (string entry in entries)
+        Console.WriteLine("The return value contains these {0} elements:", entries.Length);
+        foreach (string entry in entries)
         {
-        Console.Write("<{0}>", entry);
+            Console.Write("<{0}>", entry);
         }
-    Console.Write("\n\n");
+        Console.Write("\n\n");
     }
+
+    /*
+    This example produces the following results:
+
+    1) Split a string delimited by characters:
+
+    1a )The original string is ",ONE,,TWO,,,THREE,,".
+    The delimiter character is ','.
+
+    1b) Split a string delimited by characters and return all elements:
+    The return value contains these 9 elements:
+    <><ONE><><TWO><><><THREE><><>
+
+    1c) Split a string delimited by characters and return all non-empty elements:
+    The return value contains these 3 elements:
+    <ONE><TWO><THREE>
+
+    1d) Split a string delimited by characters and return 2 elements:
+    The return value contains these 2 elements:
+    <><ONE,,TWO,,,THREE,,>
+
+    1e) Split a string delimited by characters and return 2 non-empty elements:
+    The return value contains these 2 elements:
+    <ONE><TWO,,,THREE,,>
+
+    2) Split a string delimited by another string:
+
+    2a) The original string is "[stop]ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]".
+    The delimiter string is "[stop]".
+
+    2b) Split a string delimited by another string and return all elements:
+    The return value contains these 9 elements:
+    <><ONE><><TWO><><><THREE><><>
+
+    2c) Split a string delimited by another string and return all non-empty elements:
+    The return value contains these 3 elements:
+    <ONE><TWO><THREE>
+
+    2d) Split a string delimited by another string and return 2 elements:
+    The return value contains these 2 elements:
+    <><ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]>
+
+    2e) Split a string delimited by another string and return 2 non-empty elements:
+    The return value contains these 2 elements:
+    <ONE><TWO[stop][stop][stop]THREE[stop][stop]>
+
+    */
+    //</snippet1>
+    }
+
 }
-/*
-This example produces the following results:
-
-1) Split a string delimited by characters:
-
-1a )The original string is ",ONE,,TWO,,,THREE,,".
-The delimiter character is ','.
-
-1b) Split a string delimited by characters and return all elements:
-The return value contains these 9 elements:
-<><ONE><><TWO><><><THREE><><>
-
-1c) Split a string delimited by characters and return all non-empty elements:
-The return value contains these 3 elements:
-<ONE><TWO><THREE>
-
-1d) Split a string delimited by characters and return 2 elements:
-The return value contains these 2 elements:
-<><ONE,,TWO,,,THREE,,>
-
-1e) Split a string delimited by characters and return 2 non-empty elements:
-The return value contains these 2 elements:
-<ONE><TWO,,,THREE,,>
-
-2) Split a string delimited by another string:
-
-2a) The original string is "[stop]ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]".
-The delimiter string is "[stop]".
-
-2b) Split a string delimited by another string and return all elements:
-The return value contains these 9 elements:
-<><ONE><><TWO><><><THREE><><>
-
-2c) Split a string delimited by another string and return all non-empty elements:
-The return value contains these 3 elements:
-<ONE><TWO><THREE>
-
-2d) Split a string delimited by another string and return 2 elements:
-The return value contains these 2 elements:
-<><ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]>
-
-2e) Split a string delimited by another string and return 2 non-empty elements:
-The return value contains these 2 elements:
-<ONE><TWO[stop][stop][stop]THREE[stop][stop]>
-
-*/
-//</snippet1>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/Split.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/Split.cs
@@ -1,10 +1,10 @@
-// <Snippet1>
 using System;
 
 class Example 
 {
    public static void Main() 
    {
+   // <Snippet1>
       string source = "[stop]ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]";
       string[] stringSeparators = new string[] {"[stop]"};
       string[] result;
@@ -39,19 +39,19 @@ class Example
          Console.Write("'{0}' ", String.IsNullOrEmpty(s) ? "<>" : s);                   
       }
       Console.WriteLine();
+   // The example displays the following output:
+   //    Splitting the string:
+   //       "[stop]ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]".
+   //    
+   //    Using the delimiter string:
+   //       "[stop]"
+   //    
+   //    Result including all elements (9 elements):
+   //       '<>' 'ONE' '<>' 'TWO' '<>' '<>' 'THREE' '<>' '<>'
+   //    
+   //    Result including non-empty elements (3 elements):
+   //       'ONE' 'TWO' 'THREE'
+   // </Snippet1>
    }
 }
-// The example displays the following output:
-//    Splitting the string:
-//       "[stop]ONE[stop][stop]TWO[stop][stop][stop]THREE[stop][stop]".
-//    
-//    Using the delimiter string:
-//       "[stop]"
-//    
-//    Result including all elements (9 elements):
-//       '<>' 'ONE' '<>' 'TWO' '<>' '<>' 'THREE' '<>' '<>'
-//    
-//    Result including non-empty elements (3 elements):
-//       'ONE' 'TWO' 'THREE'
-// </Snippet1>
 

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/Split_CompilerResolution1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/Split_CompilerResolution1.cs
@@ -1,21 +1,21 @@
-// <Snippet12>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet12>
       String value = "This is a short string.";
       Char delimiter = 's';
       String[] substrings = value.Split(delimiter);
       foreach (var substring in substrings)
          Console.WriteLine(substring);
+      // The example displays the following output:
+      //     Thi
+      //      i
+      //      a
+      //     hort
+      //     tring.
+      // </Snippet12>
    }
 }
-// The example displays the following output:
-//     Thi
-//      i
-//      a
-//     hort
-//     tring.
-// </Snippet12>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/split2.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/split2.cs
@@ -1,9 +1,9 @@
-// <Snippet2>
 using System;
 
 public class SplitTest {
     public static void Main() {
 
+        // <Snippet2>
         string words = "This is a list of words, with: a bit of punctuation" +
                        "\tand a tab character.";
 
@@ -14,23 +14,22 @@ public class SplitTest {
             if (s.Trim() != "")
                 Console.WriteLine(s);
         }
+        // The example displays the following output to the console:
+        //       This
+        //       is
+        //       a
+        //       list
+        //       of
+        //       words
+        //       with
+        //       a
+        //       bit
+        //       of
+        //       punctuation
+        //       and
+        //       a
+        //       tab
+        //       character
+        // </Snippet2>
     }
 }
-// The example displays the following output to the console:
-//       This
-//       is
-//       a
-//       list
-//       of
-//       words
-//       with
-//       a
-//       bit
-//       of
-//       punctuation
-//       and
-//       a
-//       tab
-//       character
-// </Snippet2>
-

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/split7.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/split7.cs
@@ -1,30 +1,30 @@
-// <Snippet7>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet7>
       string[] separators = {",", ".", "!", "?", ";", ":", " "};
       string value = "The handsome, energetic, young dog was playing with his smaller, more lethargic litter mate.";
       string[] words = value.Split(separators, StringSplitOptions.RemoveEmptyEntries);
       foreach (var word in words)
          Console.WriteLine(word);
+      // The example displays the following output:
+      //       The
+      //       handsome
+      //       energetic
+      //       young
+      //       dog
+      //       was
+      //       playing
+      //       with
+      //       his
+      //       smaller
+      //       more
+      //       lethargic
+      //       litter
+      //       mate
+      // </Snippet7>
    }
 }
-// The example displays the following output:
-//       The
-//       handsome
-//       energetic
-//       young
-//       dog
-//       was
-//       playing
-//       with
-//       his
-//       smaller
-//       more
-//       lethargic
-//       litter
-//       mate
-// </Snippet7>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/splitalt1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/splitalt1.cs
@@ -1,17 +1,17 @@
-// <Snippet8>
 using System;
-using System.Text.RegularExpressions;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet8>
       String[] expressions = { "16 + 21", "31 * 3", "28 / 3",
                                "42 - 18", "12 * 7",
                                "2, 4, 6, 8" };
       String pattern = @"(\d+)\s+([-+*/])\s+(\d+)";
       foreach (var expression in expressions)
-         foreach (Match m in Regex.Matches(expression, pattern)) {
+         foreach (System.Text.RegularExpressions.Match m in 
+         System.Text.RegularExpressions.Regex.Matches(expression, pattern)) {
             int value1 = Int32.Parse(m.Groups[1].Value);
             int value2 = Int32.Parse(m.Groups[3].Value);
             switch (m.Groups[2].Value)
@@ -30,12 +30,12 @@ public class Example
                   break;
             }
          }
+   // The example displays the following output:
+   //       16 + 21 = 37
+   //       31 * 3 = 93
+   //       28 / 3 = 9.33
+   //       42 - 18 = 24
+   //       12 * 7 = 84
+   // </Snippet8>
    }
 }
-// The example displays the following output:
-//       16 + 21 = 37
-//       31 * 3 = 93
-//       28 / 3 = 9.33
-//       42 - 18 = 24
-//       12 * 7 = 84
-// </Snippet8>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/splitalt2.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/splitalt2.cs
@@ -1,28 +1,28 @@
-// <Snippet9>
 using System;
-using System.Text.RegularExpressions;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet9>
       String input = "[This is captured\ntext.]\n\n[\n" +
                      "[This is more captured text.]\n]\n" +
                      "[Some more captured text:\n   Option1" +
                      "\n   Option2][Terse text.]";
       String pattern = @"\[([^\[\]]+)\]";
       int ctr = 0;
-      foreach (Match m in Regex.Matches(input, pattern))
+      foreach (System.Text.RegularExpressions.Match m in 
+         System.Text.RegularExpressions.Regex.Matches(input, pattern))
          Console.WriteLine("{0}: {1}", ++ctr, m.Groups[1].Value);
+      // The example displays the following output:
+      //       1: This is captured
+      //       text.
+      //       2: This is more captured text.
+      //       3: Some more captured text:
+      //          Option1
+      //          Option2
+      //       4: Terse text.
+      // </Snippet9>
    }
 }
-// The example displays the following output:
-//       1: This is captured
-//       text.
-//       2: This is more captured text.
-//       3: Some more captured text:
-//          Option1
-//          Option2
-//       4: Terse text.
-// </Snippet9>
 

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/splitalt3.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/splitalt3.cs
@@ -1,25 +1,24 @@
-// <Snippet10>
 using System;
-using System.Text.RegularExpressions;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet10>
       String input = "abacus -- alabaster - * - atrium -+- " +
                      "any -*- actual - + - armoir - - alarm";
       String pattern = @"\s-\s?[+*]?\s?-\s";
-      String[] elements = Regex.Split(input, pattern);
+      String[] elements = System.Text.RegularExpressions.Regex.Split(input, pattern);
       foreach (var element in elements)
          Console.WriteLine(element);
+      // The example displays the following output:
+      //       abacus
+      //       alabaster
+      //       atrium
+      //       any
+      //       actual
+      //       armoir
+      //       alarm
+      // </Snippet10>
    }
 }
-// The example displays the following output:
-//       abacus
-//       alabaster
-//       atrium
-//       any
-//       actual
-//       armoir
-//       alarm
-// </Snippet10>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/splitalt4.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Split/cs/splitalt4.cs
@@ -1,4 +1,3 @@
-// <Snippet11>
 using System;
 using System.Collections.Generic;
 
@@ -6,6 +5,7 @@ public class Example
 {
    public static void Main()
    {
+      // <Snippet11>
       String value = "This is the first sentence in a string. " +
                      "More sentences will follow. For example, " +
                      "this is the third sentence. This is the " +
@@ -26,12 +26,12 @@ public class Example
       // Display the sentences.
       foreach (var sentence in sentences)
          Console.WriteLine(sentence);
+      // The example displays the following output:
+      //       This is the first sentence in a string.
+      //       More sentences will follow.
+      //       For example, this is the third sentence.
+      //       This is the fourth.
+      //       And this is the fifth and final sentence.
+      // </Snippet11>
    }
 }
-// The example displays the following output:
-//       This is the first sentence in a string.
-//       More sentences will follow.
-//       For example, this is the third sentence.
-//       This is the fourth.
-//       And this is the fifth and final sentence.
-// </Snippet11>


### PR DESCRIPTION
Contributes to dotnet/dotnet-api-docs#2539

For `String.Split`, almost all the samples had been changed to interactive. However, most were full programs. These were turned into snippets.

In one case, a static function was changed to a local function.

In two other cases, The `System.Text.RegularExpressions` namespace was added to variable declarations.

The dotnet-api-docs content does not need to be changed, so this may need to be verified after merging by forcing a new build in the portal.

