### PR TITLE
move snippet markers on samples for system.string

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/index1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/index1.cs
@@ -1,10 +1,10 @@
-// <Snippet4>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet4>
       string s1 = "This string consists of a single short sentence.";
       int nWords = 0;
 
@@ -15,10 +15,10 @@ public class Example
       }
       Console.WriteLine("The sentence\n   {0}\nhas {1} words.",
                         s1, nWords);                                                                     
+      // The example displays the following output:
+      //       The sentence
+      //          This string consists of a single short sentence.
+      //       has 8 words.
+      // </Snippet4>
    }
 }
-// The example displays the following output:
-//       The sentence
-//          This string consists of a single short sentence.
-//       has 8 words.
-// </Snippet4>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/index2.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/index2.cs
@@ -1,10 +1,10 @@
-// <Snippet5>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet5>
       string s1 = "This string consists of a single short sentence.";
       int nWords = 0;
 
@@ -15,10 +15,10 @@ public class Example
       }
       Console.WriteLine("The sentence\n   {0}\nhas {1} words.",
                         s1, nWords);                                                                     
+      // The example displays the following output:
+      //       The sentence
+      //          This string consists of a single short sentence.
+      //       has 8 words.
+      // </Snippet5>
    }
 }
-// The example displays the following output:
-//       The sentence
-//          This string consists of a single short sentence.
-//       has 8 words.
-// </Snippet5>

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/index3.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/index3.cs
@@ -1,12 +1,11 @@
-// <Snippet6>
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet6>
       // First sentence of The Mystery of the Yellow Room, by Leroux.
       string opening = "Ce n'est pas sans une certaine émotion que "+
                        "je commence à raconter ici les aventures " +
@@ -30,7 +29,8 @@ public class Example
          }
       }
 
-      TextElementEnumerator te = StringInfo.GetTextElementEnumerator(opening);
+      System.Globalization.TextElementEnumerator te = 
+         System.Globalization.StringInfo.GetTextElementEnumerator(opening);
       while (te.MoveNext()) {
          string s = te.GetTextElement();   
          // Skip the ' character.
@@ -50,27 +50,27 @@ public class Example
       for (int ctr = 0; ctr < chars.Count; ctr++) 
          Console.WriteLine("{0,6} {1,20} {2,20}",
                            ctr, chars[ctr], elements[ctr]); 
+      // The example displays the following output:
+      //       Word #         Char Objects           Characters
+      //            0                    2                    2
+      //            1                    4                    4
+      //            2                    3                    3
+      //            3                    4                    4
+      //            4                    3                    3
+      //            5                    8                    8
+      //            6                    8                    7
+      //            7                    3                    3
+      //            8                    2                    2
+      //            9                    8                    8
+      //           10                    2                    1
+      //           11                    8                    8
+      //           12                    3                    3
+      //           13                    3                    3
+      //           14                    9                    9
+      //           15                   15                   15
+      //           16                    2                    2
+      //           17                    6                    6
+      //           18                   12                   12
+      // </Snippet6>   
    }
 }
-// The example displays the following output:
-//       Word #         Char Objects           Characters
-//            0                    2                    2
-//            1                    4                    4
-//            2                    3                    3
-//            3                    4                    4
-//            4                    3                    3
-//            5                    8                    8
-//            6                    8                    7
-//            7                    3                    3
-//            8                    2                    2
-//            9                    8                    8
-//           10                    2                    1
-//           11                    8                    8
-//           12                    3                    3
-//           13                    3                    3
-//           14                    9                    9
-//           15                   15                   15
-//           16                    2                    2
-//           17                    6                    6
-//           18                   12                   12
-// </Snippet6>   

--- a/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/surrogate1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/surrogate1.cs
@@ -1,10 +1,10 @@
-// <Snippet3>
 using System;
 
 public class Example
 {
    public static void Main()
    {
+      // <Snippet3>
       string surrogate = "\uD800\uDC03";
       for (int ctr = 0; ctr < surrogate.Length; ctr++) 
          Console.Write("U+{0:X2} ", Convert.ToUInt16(surrogate[ctr]));
@@ -12,9 +12,9 @@ public class Example
       Console.WriteLine();
       Console.WriteLine("   Is Surrogate Pair: {0}", 
                         Char.IsSurrogatePair(surrogate[0], surrogate[1]));
+      // The example displays the following output:
+      //       U+D800 U+DC03
+      //          Is Surrogate Pair: True
+      // </Snippet3>
    }
 }
-// The example displays the following output:
-//       U+D800 U+DC03
-//          Is Surrogate Pair: True
-// </Snippet3>         


### PR DESCRIPTION
Contributes to dotnet/dotnet-api-docs#2539

Some of the samples work if the snippet markers only enclose the body of the Main method.

