### PR TITLE
Correct string concatenation example

### DIFF
--- a/csharp/language-reference/operators/AdditionOperator.cs
+++ b/csharp/language-reference/operators/AdditionOperator.cs
@@ -24,10 +24,10 @@ namespace operators
         private static void StringConcatenation()
         {
             // <SnippetAddStrings>
-            Console.WriteLine("Forgot " + " white space");
+            Console.WriteLine("Forgot" + "white space");
             Console.WriteLine("Probably the oldest constant: " + Math.PI);
             // Output:
-            // Forgot white space
+            // Forgotwhite space
             // Probably the oldest constant: 3.14159265358979
             // </SnippetAddStrings>
 


### PR DESCRIPTION
Fixes dotnet/docs#12751
