### PR TITLE
Added stackalloc code snippets

### DIFF
--- a/csharp/language-reference/operators/Program.cs
+++ b/csharp/language-reference/operators/Program.cs
@@ -62,6 +62,10 @@ namespace operators
             LambdaOperator.Examples();
             Console.WriteLine();
 
+            Console.WriteLine("============ stackalloc operator examples ======");
+            StackallocOperator.Examples();
+            Console.WriteLine();
+
             Console.WriteLine("========= true and false operators examples ====");
             LaunchStatusTest.Main();
             Console.WriteLine();

--- a/csharp/language-reference/operators/StackallocOperator.cs
+++ b/csharp/language-reference/operators/StackallocOperator.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace operators
+{
+    public static class StackallocOperator
+    {
+        public static void Examples()
+        {
+            Console.WriteLine("No snippets with output");
+        }
+
+        private static void AssignToPointer()
+        {
+            // <SnippetAssignToPointer>
+            unsafe
+            {
+                int length = 3;
+                int* numbers = stackalloc int[length];
+                for (var i = 0; i < length; i++)
+                {
+                    numbers[i] = i;
+                }
+            }
+            // </SnippetAssignToPointer>
+        }
+
+        private static void AssignToSpan()
+        {
+            // <SnippetAssignToSpan>
+            int length = 3;
+            Span<int> numbers = stackalloc int[length];
+            for (var i = 0; i < length; i++)
+            {
+                numbers[i] = i;
+            }
+            // </SnippetAssignToSpan>
+        }
+
+        private static void AsExpression()
+        {
+            // <SnippetAsExpression>
+            int length = 1000;
+            Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
+            buffer = stackalloc byte[128];
+            // </SnippetAsExpression>
+        }
+
+        private static void StackallocInit()
+        {
+            // <SnippetStackallocInit>
+            Span<int> first = stackalloc int[3] { 1, 2, 3 };
+            Span<int> second = stackalloc int[] { 1, 2, 3 };
+            ReadOnlySpan<int> third = stackalloc[] { 1, 2, 3 };
+            // </SnippetStackallocInit>
+        }
+    }
+}

--- a/csharp/language-reference/operators/StackallocOperator.cs
+++ b/csharp/language-reference/operators/StackallocOperator.cs
@@ -41,7 +41,6 @@ namespace operators
             // <SnippetAsExpression>
             int length = 1000;
             Span<byte> buffer = length <= 1024 ? stackalloc byte[length] : new byte[length];
-            buffer = stackalloc byte[128];
             // </SnippetAsExpression>
         }
 


### PR DESCRIPTION
Supports dotnet/docs#12754

New examples are to show how to allocate memory, NOT how to use it afterwards. That's why there is no output generated and they are much shorter than existing examples. Having them in the project allows to make sure that all the code compiles.
