### PR TITLE
Removed unused instance variable and fixed casing

### DIFF
--- a/machine-learning/tutorials/SentimentAnalysis/Program.cs
+++ b/machine-learning/tutorials/SentimentAnalysis/Program.cs
@@ -16,7 +16,6 @@ namespace SentimentAnalysis
     {
         // <SnippetDeclareGlobalVariables>
         static readonly string _dataPath = Path.Combine(Environment.CurrentDirectory, "Data", "yelp_labelled.txt");
-        static readonly string _modelPath = Path.Combine(Environment.CurrentDirectory, "Data", "Model.zip");
         // </SnippetDeclareGlobalVariables>
 
         static void Main(string[] args)
@@ -153,14 +152,14 @@ namespace SentimentAnalysis
             // </SnippetCreateTestIssue1>
 
             // <SnippetPredict>
-            var resultprediction = predictionFunction.Predict(sampleStatement);
+            var resultPrediction = predictionFunction.Predict(sampleStatement);
             // </SnippetPredict>
             // <SnippetOutputPrediction>
             Console.WriteLine();
             Console.WriteLine("=============== Prediction Test of model with a single sample and test dataset ===============");
 
             Console.WriteLine();
-            Console.WriteLine($"Sentiment: {resultprediction.SentimentText} | Prediction: {(Convert.ToBoolean(resultprediction.Prediction) ? "Positive" : "Negative")} | Probability: {resultprediction.Probability} ");
+            Console.WriteLine($"Sentiment: {resultPrediction.SentimentText} | Prediction: {(Convert.ToBoolean(resultPrediction.Prediction) ? "Positive" : "Negative")} | Probability: {resultPrediction.Probability} ");
 
             Console.WriteLine("=============== End of Predictions ===============");
             Console.WriteLine();


### PR DESCRIPTION
## Summary

The instance variable "_modelPath" is not used in this tutorial, and the local variable "resultprediction" in the UseModelWithSingleItem() method does not use the correct casing as per Microsoft's capitalization convention.