### PR TITLE
System.Drawing.WorkingWithImages - Fix case of property name for consistency and to match output

### DIFF
--- a/snippets/csharp/VS_Snippets_Winforms/System.Drawing.WorkingWithImages/CS/Class1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/System.Drawing.WorkingWithImages/CS/Class1.cs
@@ -121,7 +121,7 @@ public class SystemDrawingWorkingWithImages : Form
             Y += font.Height;
 
             e.Graphics.DrawString(
-               "   iD: 0x" + propItem.Id.ToString("x"),
+               "   id: 0x" + propItem.Id.ToString("x"),
                font,
                blackBrush,
                X, Y);

--- a/snippets/visualbasic/VS_Snippets_Winforms/System.Drawing.WorkingWithImages/VB/Class1.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/System.Drawing.WorkingWithImages/VB/Class1.vb
@@ -115,7 +115,7 @@ Inherits Form
             Y += font.Height
 
             e.Graphics.DrawString( _
-               "   iD: 0x" & propItem.Id.ToString("x"), _
+               "   id: 0x" & propItem.Id.ToString("x"), _
                font, _
                blackBrush, _
                X, Y)


### PR DESCRIPTION
## Summary

Changed iD to id to match the rest of the property names and sample output.

Extension of https://github.com/dotnet/docs/pull/12847
