### PR TITLE
Update Live with current Master

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/environment.FailFast/cs/ff.cs
+++ b/snippets/csharp/VS_Snippets_CLR/environment.FailFast/cs/ff.cs
@@ -11,10 +11,12 @@ class Example
        // terminate immediately. The try-finally block is not executed
        // and is included only to demonstrate that instructions within
        // try-catch blocks and finalizers are not performed.
-       try {
+       try 
+       {
            Environment.FailFast(causeOfFailure);
        }
-       finally {
+       finally 
+       {
            Console.WriteLine("This finally block will not be executed.");
        }
    }


### PR DESCRIPTION
In [corefx/coding-style.md at master · dotnet/corefx](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md ) NO.1, we use Allman style braces, where each brace begins on a new line. A single line statement block can go without braces but the block must be properly indented on its own line and must not be nested in other statement blocks that use braces (See issue 381 for examples). One exception is that a using statement is permitted to be nested within another using statement by starting on the following line at the same indentation level, even if the nested using contains a controlled block.

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
