### PR TITLE
#1795 fix attribute convention

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR/conceptual.exception.handling/cpp/source.cpp
+++ b/snippets/cpp/VS_Snippets_CLR/conceptual.exception.handling/cpp/source.cpp
@@ -10,7 +10,7 @@ public:
     }
 };
 
-[FlagsAttribute]
+[Flags]
 public enum class ConnectionState
 {
     Closed = 0,

--- a/snippets/cpp/VS_Snippets_CLR/enummain/CPP/EnumMain.cpp
+++ b/snippets/cpp/VS_Snippets_CLR/enummain/CPP/EnumMain.cpp
@@ -12,7 +12,7 @@ enum class BoilingPoints
    Fahrenheit = 212
 };
 
-[FlagsAttribute]
+[Flags]
 
 enum class Colors
 {

--- a/snippets/cpp/VS_Snippets_CLR/enumparse/CPP/EnumParse.cpp
+++ b/snippets/cpp/VS_Snippets_CLR/enumparse/CPP/EnumParse.cpp
@@ -1,7 +1,7 @@
 //<snippet1>
 using namespace System;
 
-[FlagsAttribute]
+[Flags]
 enum class Colors
 {
    Red = 1,

--- a/snippets/cpp/VS_Snippets_CLR_System/system.FlagsAttribute/CPP/flags.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.FlagsAttribute/CPP/flags.cpp
@@ -13,7 +13,7 @@ public enum class SingleHue : short
 };
 
 // Define an Enum with FlagsAttribute.
-[FlagsAttribute]
+[Flags]
 enum class MultiHue : short
 {
    None = 0,

--- a/snippets/cpp/VS_Snippets_CLR_System/system.FlagsAttribute/CPP/flags1.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.FlagsAttribute/CPP/flags1.cpp
@@ -1,7 +1,7 @@
 // <Snippet2>
 using namespace System;
 
-[FlagsAttribute] enum class PhoneService
+[Flags] enum class PhoneService
 {
    None = 0,
    LandLine = 1,

--- a/snippets/cpp/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags/cpp/FxCop.Usage.EnumNoFlags.cpp
+++ b/snippets/cpp/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags/cpp/FxCop.Usage.EnumNoFlags.cpp
@@ -5,7 +5,7 @@ using namespace System;
 namespace Samples 
 {
     // Violates this rule    
-	[FlagsAttribute]    
+	[Flags]    
 	public enum class Color    
 	{        
 		None   = 0,        

--- a/snippets/cpp/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags2/cpp/FxCop.Usage.EnumNoFlags2.cpp
+++ b/snippets/cpp/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags2/cpp/FxCop.Usage.EnumNoFlags2.cpp
@@ -3,7 +3,7 @@ using namespace System;
  
 namespace Samples 
 {    
-	[FlagsAttribute]    
+	[Flags]    
 	public enum class Days    
 	{        
 		None        = 0,        

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.exception.handling/cs/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.exception.handling/cs/source.cs
@@ -11,7 +11,7 @@ public class FileReaderException : Exception
     }
 }
 
-[FlagsAttribute]
+[Flags]
 public enum ConnectionState
 {
     Closed = 0,

--- a/snippets/csharp/VS_Snippets_CLR/enummain/CS/EnumMain.cs
+++ b/snippets/csharp/VS_Snippets_CLR/enummain/CS/EnumMain.cs
@@ -4,7 +4,7 @@ using System;
 public class EnumTest {
     enum Days { Saturday, Sunday, Monday, Tuesday, Wednesday, Thursday, Friday };
     enum BoilingPoints { Celsius = 100, Fahrenheit = 212 };
-    [FlagsAttribute]
+    [Flags]
     enum Colors { Red = 1, Green = 2, Blue = 4, Yellow = 8 };
 
     public static void Main() {

--- a/snippets/csharp/VS_Snippets_CLR/enumparse/CS/EnumParse.cs
+++ b/snippets/csharp/VS_Snippets_CLR/enumparse/CS/EnumParse.cs
@@ -3,7 +3,7 @@ using System;
 
 public class ParseTest
 {
-    [FlagsAttribute]
+    [Flags]
     enum Colors { Red = 1, Green = 2, Blue = 4, Yellow = 8 };
 
     public static void Main()

--- a/snippets/csharp/VS_Snippets_CLR_System/system.FlagsAttribute/CS/flags.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.FlagsAttribute/CS/flags.cs
@@ -14,7 +14,7 @@ class Example
    };
 
    // Define an Enum with FlagsAttribute.
-   [FlagsAttribute] 
+   [Flags] 
    enum MultiHue : short
    {
       None = 0,

--- a/snippets/csharp/VS_Snippets_CLR_System/system.FlagsAttribute/CS/flags1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.FlagsAttribute/CS/flags1.cs
@@ -1,7 +1,7 @@
 // <Snippet2>
 using System;
 
-[FlagsAttribute] public enum PhoneService
+[Flags] public enum PhoneService
 {
    None = 0,
    LandLine = 1,

--- a/snippets/csharp/VS_Snippets_CodeAnalysis/FxCop.Design.EnumFlags/cs/FxCop.Design.EnumFlags.cs
+++ b/snippets/csharp/VS_Snippets_CodeAnalysis/FxCop.Design.EnumFlags/cs/FxCop.Design.EnumFlags.cs
@@ -16,7 +16,7 @@ namespace DesignLibrary
       All         = Monday| Tuesday | Wednesday | Thursday | Friday
    }
    // Violates rule: DoNotMarkEnumsWithFlags.
-   [FlagsAttribute]
+   [Flags]
    public enum ColorEnumShouldNotHaveFlag 
    {
       None        = 0,

--- a/snippets/csharp/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags/cs/FxCop.Usage.EnumNoFlags.cs
+++ b/snippets/csharp/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags/cs/FxCop.Usage.EnumNoFlags.cs
@@ -4,7 +4,7 @@ using System;
 namespace Samples
 {    
     // Violates this rule    
-    [FlagsAttribute]        
+    [Flags]        
     public enum Color
     { 
         None    = 0, 

--- a/snippets/csharp/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags2/cs/FxCop.Usage.EnumNoFlags2.cs
+++ b/snippets/csharp/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags2/cs/FxCop.Usage.EnumNoFlags2.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Samples
 {    
-    [FlagsAttribute]    
+    [Flags]    
     public enum Days    
     {        
         None        = 0,        

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.exception.handling/vb/source.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.exception.handling/vb/source.vb
@@ -12,7 +12,7 @@ Public Class FileReaderException
     End Sub
 End Class
 
-<FlagsAttribute> _
+<Flags()> _
 Public Enum ConnectionState
     Closed = 0
     Open = 1

--- a/snippets/visualbasic/VS_Snippets_CLR/enummain/VB/EnumMain.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/enummain/VB/EnumMain.vb
@@ -15,7 +15,7 @@ Public Class EnumTest
         Fahrenheit = 212
     End Enum 
     
-    <FlagsAttribute()> _
+    <Flags()> _
     Enum Colors
         Red = 1
         Green = 2

--- a/snippets/visualbasic/VS_Snippets_CLR/enumparse/VB/EnumParse.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/enumparse/VB/EnumParse.vb
@@ -3,7 +3,7 @@ Imports System
 
 Public Class ParseTest
 
-    <FlagsAttribute()> _
+    <Flags()> _
     Enum Colors
         Red = 1
         Green = 2

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.FlagsAttribute/VB/flags.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.FlagsAttribute/VB/flags.vb
@@ -10,7 +10,7 @@ Module Example
    End Enum
 
    ' Define an Enum with FlagsAttribute.
-   <FlagsAttribute> 
+   <Flags()> 
    Enum MultiHue As Short
       None = 0
       Black = 1

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.FlagsAttribute/VB/flags1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.FlagsAttribute/VB/flags1.vb
@@ -2,7 +2,7 @@
 Option Strict On
 
 ' <Snippet2>
-<FlagsAttribute> Public Enum PhoneService As Integer
+<Flags()> Public Enum PhoneService As Integer
    None = 0
    LandLine = 1
    Cell = 2

--- a/snippets/visualbasic/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags/vb/FxCop.Usage.EnumNoFlags.vb
+++ b/snippets/visualbasic/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags/vb/FxCop.Usage.EnumNoFlags.vb
@@ -4,7 +4,7 @@ Imports System
 Namespace Samples
 
     ' Violates this rule    
-    <FlagsAttribute()> _
+    <Flags()> _
     Public Enum Color
 
         None = 0

--- a/snippets/visualbasic/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags2/vb/FxCop.Usage.EnumNoFlags2.vb
+++ b/snippets/visualbasic/VS_Snippets_CodeAnalysis/FxCop.Usage.EnumNoFlags2/vb/FxCop.Usage.EnumNoFlags2.vb
@@ -2,7 +2,7 @@
 Imports System
 Namespace Samples
 
-    <FlagsAttribute()> _
+    <Flags()> _
     Public Enum Days
 
         None = 0


### PR DESCRIPTION
## Cleanup Attribute convention for FlagsAttribute

Find: `\[(System\.)?(FlagsAttribute)(\(\))?\]`
Replace: `[$1Flags]`

Find: `<(System\.)?(FlagsAttribute)(\(\))?>`
Replace: `<$1Flags()>`

So, `[FlagsAttribute]` is displayed as `[Flags]`.

Fixes dotnet/dotnet-api-docs#1795
