### PR TITLE
Correct Grid.Column/Row values for RepeatButton

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/ControlTemplateExamples/CS/resources/scrollbar.xaml
+++ b/snippets/csharp/VS_Snippets_Wpf/ControlTemplateExamples/CS/resources/scrollbar.xaml
@@ -193,7 +193,7 @@
                         Command="ScrollBar.PageDownCommand" />
         </Track.IncreaseRepeatButton>
       </Track>
-      <RepeatButton Grid.Row="3"
+      <RepeatButton Grid.Row="2"
                     Style="{StaticResource ScrollBarLineButton}"
                     Height="18"
                     Command="ScrollBar.LineDownCommand"
@@ -267,7 +267,7 @@
         </Track.IncreaseRepeatButton>
       </Track>
       <!--</SnippetRepeatButtonStyle_a_lileib>-->
-      <RepeatButton Grid.Column="3"
+      <RepeatButton Grid.Column="2"
                     Style="{StaticResource ScrollBarLineButton}"
                     Width="18"
                     Command="ScrollBar.LineRightCommand"


### PR DESCRIPTION
The horizontal and vertical scrollbar only have three grid colums/rows.
The Grid.Column/Row value of the RepeatButton in the last cell should therefore be 2.