### PR TITLE
Don't await finished tasks

### DIFF
--- a/snippets/csharp/tour-of-async/AsyncBreakfast-final/Program.cs
+++ b/snippets/csharp/tour-of-async/AsyncBreakfast-final/Program.cs
@@ -24,20 +24,16 @@ namespace AsyncBreakfast
                 if (finished == eggsTask)
                 {
                     Console.WriteLine("eggs are ready");
-                    allTasks.Remove(eggsTask);
-                    var eggs = await eggsTask;
-                } else if (finished == baconTask)
+                }
+                else if (finished == baconTask)
                 {
                     Console.WriteLine("bacon is ready");
-                    allTasks.Remove(baconTask);
-                    var bacon = await baconTask;
-                } else if (finished == toastTask)
+                }
+                else if (finished == toastTask)
                 {
                     Console.WriteLine("toast is ready");
-                    allTasks.Remove(toastTask);
-                    var toast = await toastTask;
-                } else
-                        allTasks.Remove(finished);
+                }
+                allTasks.Remove(finished);
             }
             Console.WriteLine("Breakfast is ready!");
             // </SnippetAwaitAnyTask>


### PR DESCRIPTION
Fixes dotnet/docs#12132

I just removed the code that was confusing readers.

The result of the `Task<T>` isn't used in this sample, so it's not enlightening.

Future tutorials for async should show how to use `WhenAny` and retrieve the results from the task that completes first.
