### PR TITLE
Removed PipeTransmissionMode.Message in property setter

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeClientStream_Sample/cpp/program.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeClientStream_Sample/cpp/program.cpp
@@ -13,16 +13,6 @@ public:
         if (args->Length > 1)
         {
             PipeStream^ pipeClient = gcnew AnonymousPipeClientStream(PipeDirection::In, args[1]);
-            // Show that anonymous Pipes do not support Message mode.
-            try
-            {
-                Console::WriteLine("[CLIENT] Setting ReadMode to \"Message\".");
-                pipeClient->ReadMode = PipeTransmissionMode::Message;
-            }
-            catch (NotSupportedException^ e)
-            {
-                Console::WriteLine("[CLIENT] Execption:\n    {0}", e->Message);
-            }
 
             Console::WriteLine("[CLIENT] Current TransmissionMode: {0}.",
                 pipeClient->TransmissionMode);

--- a/snippets/cpp/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeServerStream_Sample/cpp/program.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeServerStream_Sample/cpp/program.cpp
@@ -19,16 +19,6 @@ public:
         AnonymousPipeServerStream^ pipeServer =
             gcnew AnonymousPipeServerStream(PipeDirection::Out,
             HandleInheritability::Inheritable);
-        // Show that anonymous pipes do not support Message mode.
-        try
-        {
-            Console::WriteLine("[SERVER] Setting ReadMode to \"Message\".");
-            pipeServer->ReadMode = PipeTransmissionMode::Message;
-        }
-        catch (NotSupportedException^ e)
-        {
-            Console::WriteLine("[SERVER] Exception:\n    {0}", e->Message);
-        }
 
         Console::WriteLine("[SERVER] Current TransmissionMode: {0}.",
             pipeServer->TransmissionMode);

--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeClientStream_Sample/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeClientStream_Sample/cs/Program.cs
@@ -12,17 +12,6 @@ class PipeClient
             using (PipeStream pipeClient =
                 new AnonymousPipeClientStream(PipeDirection.In, args[0]))
             {
-                // Show that anonymous Pipes do not support Message mode.
-                try
-                {
-                    Console.WriteLine("[CLIENT] Setting ReadMode to \"Message\".");
-                    pipeClient.ReadMode = PipeTransmissionMode.Message;
-                }
-                catch (NotSupportedException e)
-                {
-                    Console.WriteLine("[CLIENT] Execption:\n    {0}", e.Message);
-                }
-
                 Console.WriteLine("[CLIENT] Current TransmissionMode: {0}.",
                    pipeClient.TransmissionMode);
 

--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeServerStream_Sample/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeServerStream_Sample/cs/Program.cs
@@ -16,17 +16,6 @@ class PipeServer
             new AnonymousPipeServerStream(PipeDirection.Out,
             HandleInheritability.Inheritable))
         {
-            // Show that anonymous pipes do not support Message mode.
-            try
-            {
-                Console.WriteLine("[SERVER] Setting ReadMode to \"Message\".");
-                pipeServer.ReadMode = PipeTransmissionMode.Message;
-            }
-            catch (NotSupportedException e)
-            {
-                Console.WriteLine("[SERVER] Exception:\n    {0}", e.Message);
-            }
-
             Console.WriteLine("[SERVER] Current TransmissionMode: {0}.",
                 pipeServer.TransmissionMode);
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeClientStream_Sample/vb/program.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeClientStream_Sample/vb/program.vb
@@ -1,5 +1,4 @@
 '<snippet01>
-Imports System
 Imports System.IO
 Imports System.IO.Pipes
 
@@ -7,14 +6,6 @@ Class PipeClient
     Shared Sub Main(args() as String)
         If args.Length > 0 Then
             Using pipeClient As New AnonymousPipeClientStream(PipeDirection.In, args(0))
-                ' Show that anonymous Pipes do not support Message mode.
-                Try
-                    Console.WriteLine("[CLIENT] Setting ReadMode to ""Message"".")
-                    pipeClient.ReadMode = PipeTransmissionMode.Message
-                Catch e As NotSupportedException
-                    Console.WriteLine("[CLIENT] Execption:" + vbNewLine + "    {0}", e.Message)
-                End Try
-
                 Console.WriteLine("[CLIENT] Current TransmissionMode: {0}.", _
                    pipeClient.TransmissionMode)
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeServerStream_Sample/vb/program.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeServerStream_Sample/vb/program.vb
@@ -13,14 +13,6 @@ Class PipeServer
         Using pipeServer As New AnonymousPipeServerStream(PipeDirection.Out, _
             HandleInheritability.Inheritable)
 
-            ' Show that anonymous pipes do not support Message mode.
-            Try
-                Console.WriteLine("[SERVER] Setting ReadMode to ""Message"".")
-                pipeServer.ReadMode = PipeTransmissionMode.Message
-            Catch e As NotSupportedException
-                Console.WriteLine("[SERVER] Exception:\n    {0}", e.Message)
-            End Try
-
             Console.WriteLine("[SERVER] Current TransmissionMode: {0}.",
                 pipeServer.TransmissionMode)
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeServerStream_Sample/vb/program.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.IO.Pipes.AnonymousPipeServerStream_Sample/vb/program.vb
@@ -1,5 +1,4 @@
 '<snippet01>
-Imports System
 Imports System.IO
 Imports System.IO.Pipes
 Imports System.Diagnostics


### PR DESCRIPTION
## Removed PipeTransmissionMode.Message in property setter

The example deliberately assigns an unsupported value to the AnonymousPipeServerStream.ReadMode and AnonymousPipeClientStream.ReadMode properties. That seems pointless; the reference documentation makes it clear that the value is not supported.

Related to dotnet/dotnet-api-docs#2659

Fixes dotnet/docs#2650

