### PR TITLE
Fix areas where const naming conventions were not correctly followed

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideObjects/CS/Objects.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideObjects/CS/Objects.cs
@@ -1451,7 +1451,7 @@ class TestPerson
     //<Snippet65>
     class Calendar2
     {
-        const int Months = 12, Weeks = 52, Days = 365;
+        public const int Months = 12, Weeks = 52, Days = 365;
     }
     //</Snippet65>
 
@@ -1459,12 +1459,12 @@ class TestPerson
     //<Snippet66>
     class Calendar3
     {
-        const int Months = 12;
-        const int Weeks = 52;
-        const int Days = 365;
+        public const int Months = 12;
+        public const int Weeks = 52;
+        public const int Days = 365;
 
-        const double DaysPerWeek = (double) Days / (double) Weeks;
-        const double DaysPerMonth = (double) Days / (double) Months;
+        public const double DaysPerWeek = (double) Days / (double) Weeks;
+        public const double DaysPerMonth = (double) Days / (double) Months;
     }
     //</Snippet66>
 

--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideObjects/CS/Objects.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideObjects/CS/Objects.cs
@@ -1443,7 +1443,7 @@ class TestPerson
     //<Snippet64>
     class Calendar1
     {
-        public const int months = 12;
+        public const int Months = 12;
     }
     //</Snippet64>
 
@@ -1451,7 +1451,7 @@ class TestPerson
     //<Snippet65>
     class Calendar2
     {
-        const int months = 12, weeks = 52, days = 365;
+        const int Months = 12, Weeks = 52, Days = 365;
     }
     //</Snippet65>
 
@@ -1459,24 +1459,24 @@ class TestPerson
     //<Snippet66>
     class Calendar3
     {
-        const int months = 12;
-        const int weeks = 52;
-        const int days = 365;
+        const int Months = 12;
+        const int Weeks = 52;
+        const int Days = 365;
 
-        const double daysPerWeek = (double) days / (double) weeks;
-        const double daysPerMonth = (double) days / (double) months;
+        const double DaysPerWeek = (double) Days / (double) Weeks;
+        const double DaysPerMonth = (double) Days / (double) Months;
     }
     //</Snippet66>
 
 
     class Calendar
     {
-        public const int months = 12;
+        public const int Months = 12;
 
         static void test()
         {
             //<Snippet67>
-            int birthstones = Calendar.months;
+            int birthstones = Calendar.Months;
             //</Snippet67>
 
             Console.WriteLine(birthstones.ToString());

--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -174,8 +174,8 @@ namespace csrefKeywordsModifiers
         {
             public int x;
             public int y;
-            public const int c1 = 5;
-            public const int c2 = c1 + 5;
+            public const int C1 = 5;
+            public const int C2 = C1 + 5;
 
             public SampleClass(int p1, int p2) 
             {
@@ -188,13 +188,13 @@ namespace csrefKeywordsModifiers
         {
             SampleClass mC = new SampleClass(11, 22);
             Console.WriteLine("x = {0}, y = {1}", mC.x, mC.y);
-            Console.WriteLine("c1 = {0}, c2 = {1}", 
-                              SampleClass.c1, SampleClass.c2);
+            Console.WriteLine("C1 = {0}, C2 = {1}", 
+                              SampleClass.C1, SampleClass.C2);
         }
     }
     /* Output
         x = 11, y = 22
-        c1 = 5, c2 = 10
+        C1 = 5, C2 = 10
     */
     //</snippet5>
 
@@ -203,8 +203,8 @@ namespace csrefKeywordsModifiers
     {
         static void Main()
         {
-            const int c = 707;
-            Console.WriteLine("My local constant = {0}", c);
+            const int C = 707;
+            Console.WriteLine("My local constant = {0}", C);
         }
     }
     // Output: My local constant = 707


### PR DESCRIPTION
## Summary
There's probably other areas where this is going on but I just wanted to get the ones that I happened to notice addressed.
