### PR TITLE
Lint Catch Exception snippet, use string interpolation

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception.cs
+++ b/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception.cs
@@ -8,16 +8,16 @@ class ExceptionTestClass
       int x = 0;
       try 
       {
-         int y = 100/x;
+         int y = 100 / x;
       }
-         catch (ArithmeticException e) 
-         {
-            Console.WriteLine("ArithmeticException Handler: {0}", e.ToString());
-         }
-         catch (Exception e) 
-         {
-            Console.WriteLine("Generic Exception Handler: {0}", e.ToString());
-         }
+      catch (ArithmeticException e) 
+      {
+         Console.WriteLine($"ArithmeticException Handler: {e}");
+      }
+      catch (Exception e) 
+      {
+         Console.WriteLine($"Generic Exception Handler: {e}");
+      }
    }	
 }
 /*


### PR DESCRIPTION
## Summary

 - Fixes the indentation of the catch blocks, these were inconsistent with the try block
 - Changes the example to use string interpolation instead of format strings and replacement
