### PR TITLE
remove snippet tag

### DIFF
--- a/snippets/csharp/VS_Snippets_Remoting/Classic HttpGetClientProtocol Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic HttpGetClientProtocol Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet2>
 <%@ WebService Language="C#" Class="Math"%>
  using System.Web.Services;
  using System;
@@ -9,5 +8,3 @@
           return num1+num2;
           }
  }
-// </Snippet2>
-

--- a/snippets/csharp/VS_Snippets_Remoting/Classic HttpPostClientProtocol Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic HttpPostClientProtocol Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet2>
 <%@ WebService Language="C#" Class="Math"%>
  using System.Web.Services;
  using System;
@@ -9,5 +8,3 @@
           return num1+num2;
           }
  }
-// </Snippet2>
-

--- a/snippets/csharp/VS_Snippets_Remoting/Classic HttpSimpleClientProtocol.EndInvoke Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic HttpSimpleClientProtocol.EndInvoke Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet3>
 <%@ WebService Language="C#" Class="Math"%>
  using System.Web.Services;
  using System;
@@ -9,5 +8,3 @@
           return num1+num2;
           }
  }
-// </Snippet3>
-

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapException Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapException Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" class="ThrowSoapException"%>
 
 using System;
@@ -42,5 +41,3 @@ public class ThrowSoapException : WebService
         throw se;
         return;    }
 }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapException.Actor Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapException.Actor Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet2>
 <%@ WebService Language="C#" Class="Math"%>
  using System.Web.Services;
  using System;
@@ -11,6 +10,3 @@
          return dividend/divisor;
      }
   }
-// </Snippet2>
-
-

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapException.Detail Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapException.Detail Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" class="ThrowSoapException"%>
 
 using System;
@@ -47,7 +46,6 @@ public class ThrowSoapException : WebService
             SoapException.ClientFaultCode,Context.Request.Url.AbsoluteUri,node);
 
         throw se;
-        return;    }
+        return;    
+    }
 }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapException.DetailElementName Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapException.DetailElementName Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" class="ThrowSoapException"%>
 
 using System;
@@ -40,7 +39,6 @@ public class ThrowSoapException : WebService
         SoapException se = new SoapException("Fault occurred", SoapException.ClientFaultCode,Context.Request.Url.AbsoluteUri,node);
 
         throw se;
-        return;    }
+        return;    
+    }
 }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapHeader.DidUnderstand Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapHeader.DidUnderstand Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="MyWebService"%>
 using System.Web.Services;
 using System.Web.Services.Protocols;
@@ -37,5 +36,3 @@ public class MyWebService {
        return "Hello";
     }
 }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapHeaderAttribute Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapHeaderAttribute Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="MyWebService"%>
 using System.Web.Services;
 using System.Web.Services.Protocols;
@@ -36,5 +35,3 @@ public class MyWebService {
        }
     }
 }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapHttpClientProtocol Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapHttpClientProtocol Example/CS/sourcecs.asmx
@@ -1,14 +1,12 @@
-// <Snippet2>
 <%@ WebService Language="C#" Class="MyMath"%>
  using System.Web.Services;
  using System;
  
  [WebService(Namespace="http://www.contoso.com/")] 
  public class MyMath {
-      [ WebMethod ]
-      public int Add(int num1, int num2) {
-          return num1+num2;
-          }
+    
+    [ WebMethod ]
+    public int Add(int num1, int num2) {
+        return num1+num2;
+    }
  }
-// </Snippet2>
-

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.BeginInvoke Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.BeginInvoke Example/CS/sourcecs.asmx
@@ -1,14 +1,12 @@
-// <Snippet2>
 <%@ WebService Language="C#" Class="MyMath"%>
  using System.Web.Services;
  using System;
  
  [WebService(Namespace="http://www.contoso.com/")] 
  public class MyMath {
-      [ WebMethod ]
-      public int Add(int num1, int num2) {
-          return num1+num2;
-          }
- }
-// </Snippet2>
 
+    [ WebMethod ]
+    public int Add(int num1, int num2) {
+        return num1+num2;
+    }
+ }

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.EndInvoke Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.EndInvoke Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet2>
 <%@ WebService Language="C#" Class="MyMath"%>
  using System.Web.Services;
  using System;
@@ -10,5 +9,3 @@
           return num1+num2;
           }
  }
-// </Snippet2>
-

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.Invoke Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.Invoke Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet2>
 <%@ WebService Language="C#" Class="MyMath"%>
  using System.Web.Services;
  using System;
@@ -10,5 +9,3 @@
           return num1+num2;
           }
  }
-// </Snippet2>
-

--- a/snippets/csharp/VS_Snippets_Remoting/Classic SoapUnknownHeader.Element Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic SoapUnknownHeader.Element Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="MyWebService"%>
 using System.Web.Services;
 using System.Web.Services.Protocols;
@@ -41,5 +40,3 @@ public class MyWebService {
        return unknownHeaderAttributes;
     }
 }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util"%>
     using System;
     using System.Web.Services;
@@ -13,5 +12,3 @@
           return Server.MachineName;
        }
     }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.BufferResponse Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.BufferResponse Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@WebService class="Streaming" language="C#"%>
 
 using System;
@@ -113,4 +112,3 @@ public class TextFileEnumerator : IEnumerator {
         }
     }
 }
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.CacheDuration Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.CacheDuration Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Counter" %>
 
 using System.Web.Services;
@@ -23,5 +22,3 @@ public class Counter : WebService {
           return  (int) Application["MyServiceUsage"];
      }
 }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.Description Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.Description Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util" %>
  
  using System;
@@ -11,5 +10,3 @@
        return Server.MachineName;
     }   
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.EnableSession Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.EnableSession Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util" %>
  
  using System.Web.Services;
@@ -15,5 +14,3 @@
        return ((int) Session["HitCounter"]);
     }   
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.MessageName Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.MessageName Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Calculator" %>
  
  using System;
@@ -15,5 +14,3 @@
        return i + j + k;
     }   
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.TransactionOption Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebMethodAttribute.TransactionOption Example/CS/sourcecs.asmx
@@ -16,7 +16,7 @@
                // Explicitly abort the transaction.
                ContextUtil.SetAbort();
             else {
-               // Credit and Debit methods explictly vote within
+               // Credit and Debit methods explicitly vote within
                // the code for their methods whether to commit or
                // abort the transaction.
                objBank.Credit(Amount, AcctNumberTo);

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebService Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebService Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util" %>
  
  using System;
@@ -11,5 +10,3 @@
       return Context.Timestamp.TimeOfDay.ToString();
    }
  }
- 
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebService.Application Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebService.Application Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util"%>
  using System.Web.Services;
  
@@ -14,5 +13,3 @@
        return ((int) Application["HitCounter"]);
     }   
  }
-    
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebService.Server Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebService.Server Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util" %>
  
  using System.Web.Services;
@@ -9,5 +8,3 @@
        return Server.MachineName;
     }
  }
-    
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebService.User Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebService.User Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util" %>
  
  using System.Web.Services;
@@ -9,5 +8,3 @@
          return User.Identity.Name;
       }
  }
-    
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic WebServiceBindingAttribute Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic WebServiceBindingAttribute Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" class="BindingSample" %>
  using System;
  using System.Web.Services;
@@ -40,5 +39,3 @@
       }
  
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/Classic XmlIncludeAttribute Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/Classic XmlIncludeAttribute Example/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-<!--<Snippet1>-->
 <%@ WebService Language="C#" Class="Test" %>
  
 using System;
@@ -47,5 +46,3 @@ public class Car : Vehicle {
  
 public class Bike : Vehicle {
 }
-   
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/HttpSimpleClientProtocol.Invoke Example/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/HttpSimpleClientProtocol.Invoke Example/CS/sourcecs.asmx
@@ -1,5 +1,4 @@
-﻿//<Snippet3>
-<%@ WebService Language="C#" Class="Math"%>
+﻿<%@ WebService Language="C#" Class="Math"%>
  using System.Web.Services;
  using System;
  
@@ -9,4 +8,3 @@
           return num1+num2;
           }
  }
-//</Snippet3>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Action/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Action/CS/sourcecs.asmx
@@ -1,5 +1,4 @@
-﻿// <Snippet1>
-<%@ WebService Language="C#" class="MyUser" %>
+﻿<%@ WebService Language="C#" class="MyUser" %>
  
  using System.Web.Services;
  using System.Web.Services.Protocols;
@@ -11,5 +10,3 @@
        return User.Identity.Name;
       }
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Binding/CS/bindingcs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Binding/CS/bindingcs.asmx
@@ -1,5 +1,4 @@
-﻿//<Snippet1>
-<%@ WebService Language="C#" class="BindingSample" %>
+﻿<%@ WebService Language="C#" class="BindingSample" %>
  using System;
  using System.Web.Services;
  using System.Web.Services.Protocols;
@@ -35,5 +34,4 @@
 	  		return "Member of the default binding.";
       }
  
- }   
-//</Snippet1>
+ }

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.OneWay/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.OneWay/CS/sourcecs.asmx
@@ -1,5 +1,4 @@
-﻿// <Snippet1>
-<%@ WebService Language="C#" Class="Stats" %>
+﻿<%@ WebService Language="C#" Class="Stats" %>
  
  using System.Web.Services;
  using System.Web.Services.Protocols;
@@ -14,5 +13,3 @@
       }      
  
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.ParameterStyle/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.ParameterStyle/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="ShoppingCart" %>
  
  using System.Web.Services;
@@ -24,6 +23,3 @@ public class OrderItem
   public long CustomerID;
   public Decimal Cost;
 }
-
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.RequestNamespace/CS/examplecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.RequestNamespace/CS/examplecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="C#" Class="SoapDocumentMethodSample" %>
 	
 using System.Web.Services;
@@ -18,4 +17,3 @@ public class SoapDocumentMethodSample
         return intarray;
    }
 }
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.ResponseNamespace/CS/examplecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.ResponseNamespace/CS/examplecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="C#" Class="SoapDocumentMethodSample" %>
 	
 using System.Web.Services;
@@ -18,4 +17,3 @@ public class SoapDocumentMethodSample
         return intarray;
    }
 }
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Use/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Use/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="ShoppingCart" %>
  
  using System.Web.Services;
@@ -24,6 +23,3 @@ public class OrderItem
   public long CustomerID;
   public Decimal Cost;
 }
-
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentMethodAttribute/CS/sourcecs.asmx
@@ -1,5 +1,4 @@
-﻿// <Snippet1>
-<%@ WebService Language="C#" class="MyUser" %>
+﻿<%@ WebService Language="C#" class="MyUser" %>
  using System;
  using System.Web.Services;
  using System.Web.Services.Protocols;
@@ -20,7 +19,7 @@
            // Get the full user name, including the domain name if applicable.
            temp = User.Identity.Name;
  
-           // Deterime whether the user is part of a domain by searching for a backslash.
+           // Determine whether the user is part of a domain by searching for a backslash.
            pos = temp.IndexOf("\\");
            
            // Parse the domain name out of the string, if one exists.
@@ -40,5 +39,3 @@
      public string Name;
      public string Domain;
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentServiceAttribute/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentServiceAttribute/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="c#" Class="SumService" %>
 
 using System;
@@ -17,4 +16,3 @@ using System.Web.Services.Description;
 			return a + b;
 		}
 	}
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentServiceAttribute_UseParameterStyle/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentServiceAttribute_UseParameterStyle/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="c#" Class="SumService" %>
 
 using System;
@@ -16,4 +15,3 @@ using System.Web.Services.Description;
 			return a + b;
 		}
 	}
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentServiceAttribute_ctor/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentServiceAttribute_ctor/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="c#" Class="SumService" %>
 
 using System;
@@ -15,4 +14,3 @@ using System.Web.Services.Description;
 			return a + b;
 		}
 	}
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapDocumentServiceAttribute_ctor2/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapDocumentServiceAttribute_ctor2/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="c#" Class="SumService" %>
 
 using System;
@@ -15,4 +14,3 @@ using System.Web.Services.Description;
 			return a + b;
 		}
 	}
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapInclude Example/CS/ex1.cs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapInclude Example/CS/ex1.cs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="C#" Class="Test" %>
  
 using System;
@@ -48,6 +47,3 @@ public class Car : Vehicle {
  
 public class Bike : Vehicle {
 }
-   
-//</Snippet1>
-

--- a/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.Action/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.Action/CS/sourcecs.asmx
@@ -1,5 +1,4 @@
-﻿// <Snippet1>
-<%@ WebService Language="C#" class="MyUser" %>
+﻿<%@ WebService Language="C#" class="MyUser" %>
  using System;
  using System.Web.Services;
  using System.Web.Services.Protocols;
@@ -20,7 +19,7 @@
            // Get the full user name, including the domain name if applicable.
            temp = User.Identity.Name;
  
-           // Deterime whether the user is part of a domain by searching for a backslash.
+           // Determine whether the user is part of a domain by searching for a backslash.
            pos = temp.IndexOf("\\");
            
            // Parse the domain name out of the string, if one exists.
@@ -40,5 +39,3 @@
      public string Name;
      public string Domain;
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.Binding/CS/bindingcs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.Binding/CS/bindingcs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="C#" class="BindingSample" %>
  using System;
  using System.Web.Services;
@@ -34,5 +33,4 @@
 	  		return "Member of the default binding";
       }
  
- }   
-//</Snippet1>
+ }

--- a/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.OneWay/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.OneWay/CS/sourcecs.asmx
@@ -1,5 +1,4 @@
-﻿// <Snippet1>
-<%@ WebService Language="C#" Class="Stats" %>
+﻿<%@ WebService Language="C#" Class="Stats" %>
  
  using System.Web.Services;
  using System.Web.Services.Protocols;
@@ -13,5 +12,3 @@
       }      
  
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.RequestNamespace/CS/examplecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.RequestNamespace/CS/examplecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="C#" Class="SoapRpcMethodSample" %>
 	
 using System.Web.Services;
@@ -18,4 +17,3 @@ public class SoapRpcMethodSample
         return intarray;
    }
 }
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.ResponseNamespace/CS/examplecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute.ResponseNamespace/CS/examplecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="C#" Class="SoapRpcMethodSample" %>
 	
 using System.Web.Services;
@@ -18,4 +17,3 @@ public class SoapRpcMethodSample
         return intarray;
    }
 }
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapRpcMethodAttribute/CS/sourcecs.asmx
@@ -1,5 +1,4 @@
-﻿// <Snippet1>
-<%@ WebService Language="C#" class="MyUser" %>
+﻿<%@ WebService Language="C#" class="MyUser" %>
  using System;
  using System.Web.Services;
  using System.Web.Services.Protocols;
@@ -40,5 +39,3 @@
      public string Name;
      public string Domain;
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/SoapRpcServiceAttribute/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/SoapRpcServiceAttribute/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@ WebService Language="c#" Class="SumService" %>
 
 using System;
@@ -15,4 +14,3 @@ using System.Web.Services.Description;
 			return a + b;
 		}
 	}
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeConstructor_BufferResponse/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeConstructor_BufferResponse/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-//<Snippet1>
 <%@WebService class="Streaming" language="C#"%>
 <%@ assembly name="System.EnterpriseServices,Version=1.0.3300.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a" %>
 
@@ -115,4 +114,3 @@ public class TextFileEnumerator : IEnumerator {
         }
     }
 }
-//</Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeConstructor_CacheDuration/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeConstructor_CacheDuration/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Counter" %>
 <%@ assembly name="System.EnterpriseServices,Version=1.0.3300.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a" %>
 
@@ -24,5 +23,3 @@ public class Counter : WebService {
           return  (int) Application["MyServiceUsage"];
      }
 }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeConstructor_EnableSession/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeConstructor_EnableSession/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util" %>
  
  using System.Web.Services;
@@ -15,5 +14,3 @@
        return ((int) Session["HitCounter"]);
     }   
  }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeConstructor_TransactionOption/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeConstructor_TransactionOption/CS/sourcecs.asmx
@@ -19,7 +19,7 @@ public class Bank : WebService
             ContextUtil.SetAbort();
         else 
         {
-            // The Credit and Debit methods explictly determine, in their
+            // The Credit and Debit methods explicitly determine, in their
             // own code, whether to commit or end the transaction.
             objBank.Credit(Amount, AcctNumberTo);
             objBank.Debit(Amount, AcctNumberFrom);

--- a/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeDefaultConstructor/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/WebMethodAttributeDefaultConstructor/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" Class="Util"%>
     using System;
     using System.Web.Services;
@@ -12,5 +11,3 @@
           return Server.MachineName;
        }
     }
-
-// </Snippet1>

--- a/snippets/csharp/VS_Snippets_Remoting/WebServiceAttributeConstructor/CS/sourcecs.asmx
+++ b/snippets/csharp/VS_Snippets_Remoting/WebServiceAttributeConstructor/CS/sourcecs.asmx
@@ -1,4 +1,3 @@
-// <Snippet1>
 <%@ WebService Language="C#" class= "ServerVariables"%>
  
  using System;
@@ -12,5 +11,3 @@
        return Context.Timestamp.TimeOfDay.ToString();
     }
  }
- 
-// </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic HttpGetClientProtocol Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic HttpGetClientProtocol Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet2>
 <%@ WebService Language="VB" Class="Math"%>
 Imports System.Web.Services
 Imports System
@@ -9,5 +8,3 @@ Public Class Math
         Return num1 + num2
     End Function 'Add
 End Class 'Math
-' </Snippet2>
-

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic HttpPostClientProtocol Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic HttpPostClientProtocol Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet2>
 <%@ WebService Language="VB" Class="Math"%>
 Imports System.Web.Services
 Imports System
@@ -9,4 +8,3 @@ Public Class Math
         Return num1 + num2
     End Function 'Add
 End Class 'Math
-' </Snippet2>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic HttpSimpleClientProtocol.EndInvoke Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic HttpSimpleClientProtocol.EndInvoke Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet3>
 <%@ WebService Language="VB" Class="Math"%>
 Imports System.Web.Services
 Imports System
@@ -9,4 +8,3 @@ Public Class Math
         Return num1 + num2
     End Function 'Add
 End Class 'Math
-' </Snippet3>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapException Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapException Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" class="ThrowSoapException"%>
 
 Imports System
@@ -44,5 +43,3 @@ Public Class ThrowSoapException
         Return
     End Sub
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapException.Actor Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapException.Actor Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet2>
 <%@ WebService Language="VB" Class="Math"%>
 Imports System.Web.Services
 Imports System
@@ -14,5 +13,3 @@ Public Class Math
         Return Convert.ToSingle(dividend / divisor)
     End Function 'Divide
 End Class  'Math
-'</Snippet2>
-

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapException.Detail Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapException.Detail Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" class="ThrowSoapException"%>
 
 Imports System
@@ -44,5 +43,3 @@ Public Class ThrowSoapException
         Return
     End Sub
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapException.DetailElementName Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapException.DetailElementName Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" class="ThrowSoapException"%>
 
 Imports System
@@ -44,5 +43,3 @@ Public Class ThrowSoapException
         Return
     End Sub
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHeader.DidUnderstand Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHeader.DidUnderstand Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="MyWebService"%>
 
 Imports System.Web.Services
@@ -39,5 +38,3 @@ Public Class MyWebService
     End Function
     
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHeaderAttribute Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHeaderAttribute Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="MyWebService"%>
 Imports System.Web.Services
 Imports System.Web.Services.Protocols
@@ -36,5 +35,3 @@ Public Class MyWebService
         Next header
     End Sub
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHttpClientProtocol Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHttpClientProtocol Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet2>
 <%@ WebService Language="VB" Class="MyMath"%>
 Imports System.Web.Services
 Imports System
@@ -10,5 +9,3 @@ Public Class MyMath
         Return num1 + num2
     End Function 'Add
 End Class 'Math
-' </Snippet2>
-

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.BeginInvoke Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.BeginInvoke Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet2>
 <%@ WebService Language="VB" Class="MyMath"%>
 Imports System.Web.Services
 Imports System
@@ -10,5 +9,3 @@ Public Class MyMath
         Return num1 + num2
     End Function 'Add
 End Class 'Math
-' </Snippet2>
-

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.EndInvoke Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.EndInvoke Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet2>
 <%@ WebService Language="VB" Class="MyMath"%>
 Imports System.Web.Services
 Imports System
@@ -10,5 +9,3 @@ Public Class MyMath
         Return num1 + num2
     End Function 'Add
 End Class 'Math
-' </Snippet2>
-

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.Invoke Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapHttpClientProtocol.Invoke Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet2>
 <%@ WebService Language="VB" Class="MyMath"%>
 Imports System.Web.Services
 Imports System
@@ -10,5 +9,3 @@ Public Class MyMath
         Return num1 + num2
     End Function 'Add
 End Class 'Math
-' </Snippet2>
-

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapUnknownHeader.Element Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic SoapUnknownHeader.Element Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="MyWebService"%>
 Imports System.Web.Services
 Imports System.Web.Services.Protocols
@@ -43,5 +42,3 @@ Public Class MyWebService
         
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util"%>
 
 Imports System
@@ -18,5 +17,3 @@ Public Class Util
         Return Server.MachineName
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.BufferResponse Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.BufferResponse Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@WebService Class="Streaming" language="VB"%>
 
 Imports System
@@ -113,4 +112,3 @@ Public Class TextFileEnumerator
         End Get
     End Property
 End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.CacheDuration Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.CacheDuration Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Counter" %>
 
 Imports System.Web.Services
@@ -25,5 +24,3 @@ Public Class Counter
         Return CInt(Application("MyServiceUsage"))
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.Description Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.Description Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util" %>
 
 Imports System
@@ -14,5 +13,3 @@ Public Class Util
         Return Server.MachineName
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.EnableSession Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.EnableSession Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util" %>
  
 Imports System.Web.Services
@@ -18,5 +17,3 @@ Public Class Util
         Return CInt(Session("HitCounter"))
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.MessageName Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.MessageName Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Calculator" %>
 
 Imports System
@@ -20,5 +19,3 @@ Public Class Calculator
         Return i + j + k
     End Function    
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.TransactionOption Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebMethodAttribute.TransactionOption Example/VB/sourcevb.asmx
@@ -18,7 +18,7 @@ Public Class Bank
             ' Explicitly abort the transaction.
             ContextUtil.SetAbort()
         Else
-            ' Credit and Debit method explictly vote within
+            ' Credit and Debit method explicitly vote within
             ' the code for their methods whether to commit or
             ' abort the transaction.
             objBank.Credit(Amount, AcctNumberTo)

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebService Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebService Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util" %>
  
 Imports System
@@ -14,5 +13,3 @@ Public Class Util
         Return Context.Timestamp.TimeOfDay.ToString()
     End Function
 End Class
- 
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebService.Application Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebService.Application Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util"%>
 
 Imports System.Web.Services
@@ -18,5 +17,3 @@ Public Class Util
         Return CInt(Application("HitCounter"))
     End Function
 End Class
-    
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebService.Server Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebService.Server Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util" %> 
 
 Imports System.Web.Services
@@ -13,5 +12,3 @@ Public Class Util
         Return Server.MachineName
     End Function
 End Class
-    
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebService.User Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebService.User Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util" %>
  
 Imports System.Web.Services
@@ -13,5 +12,3 @@ Public Class Util
         Return User.Identity.Name
     End Function
 End Class
-    
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/Classic WebServiceBindingAttribute Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/Classic WebServiceBindingAttribute Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-<!--<Snippet1>-->
 <%@ WebService Language="VB" class="BindingSample" %>
 Imports System
 Imports System.Web.Services
@@ -41,5 +40,3 @@ Public Class BindingSample
         Return "Member of the default binding"
     End Function
 End Class
-
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/HttpSimpleClientProtocol.Invoke Example/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/HttpSimpleClientProtocol.Invoke Example/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet3>
 <%@ WebService Language="VB" Class="Math"%>
 Imports System.Web.Services
 Imports System
@@ -9,4 +8,3 @@ Public Class Math
         Return num1 + num2
     End Function 'Add
 End Class 'Math
-'</Snippet3>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Action/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Action/VB/sourcevb.asmx
@@ -1,5 +1,4 @@
-﻿' <Snippet1>
-<%@ WebService Language="VB" class="MyUser" %>
+﻿<%@ WebService Language="VB" class="MyUser" %>
 
 Imports System.Web.Services
 Imports System.Web.Services.Protocols
@@ -14,5 +13,3 @@ Public Class MyUser
         Return User.Identity.Name
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Binding/VB/bindingvb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Binding/VB/bindingvb.asmx
@@ -1,5 +1,4 @@
-﻿'<Snippet1>
-<%@ WebService Language="VB" class="BindingSample" %>
+﻿<%@ WebService Language="VB" class="BindingSample" %>
  Imports System.Web.Services
  Imports System.Web.Services.Protocols
 
@@ -28,5 +27,4 @@
 	  Public Function DefaultBindingMethod() As String
   		Return "Member of the default binding."
  	  End Function
-End Class    
-'</Snippet1>
+End Class

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.OneWay/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.OneWay/VB/sourcevb.asmx
@@ -1,5 +1,4 @@
-﻿' <Snippet1>
-<%@ WebService Language="VB" Class="Stats" %>
+﻿<%@ WebService Language="VB" Class="Stats" %>
  
 Imports System.Web.Services
 Imports System.Web.Services.Protocols
@@ -16,5 +15,3 @@ Public Class Stats
         ' A one-way method cannot have return values.
     End Sub
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.ParameterStyle/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.ParameterStyle/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="ShoppingCart" %>
  
 Imports System.Web.Services
@@ -24,4 +23,3 @@ Public Class OrderItem
   Public Cost as Decimal
 
 End Class
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.RequestNamespace/VB/examplevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.RequestNamespace/VB/examplevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SoapDocumentMethodSample" %>
 	
 Imports System.Web.Services
@@ -16,4 +15,3 @@ Public Class SoapDocumentMethodSample
         Return intarray
    End Function
 End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.ResponseNamespace/VB/examplevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.ResponseNamespace/VB/examplevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SoapDocumentMethodSample" %>
 	
 Imports System.Web.Services
@@ -16,4 +15,3 @@ Public Class SoapDocumentMethodSample
         Return intarray
    End Function
 End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Use/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute.Use/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="ShoppingCart" %>
  
 Imports System.Web.Services
@@ -25,4 +24,3 @@ Public Class OrderItem
   Public Cost as Decimal
 
 End Class
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentMethodAttribute/VB/sourcevb.asmx
@@ -1,5 +1,4 @@
-﻿' <Snippet1>
-<%@ WebService Language="VB" class="MyUser" %>
+﻿<%@ WebService Language="VB" class="MyUser" %>
 Imports System
 Imports System.Web.Services
 Imports System.Web.Services.Protocols
@@ -22,7 +21,7 @@ Public Class MyUser
         ' Get the full user name, including the domain name if applicable.
         temp = User.Identity.Name
         
-        ' Deterime whether the user is part of a Domain by searching for a backslash.
+        ' Determine whether the user is part of a Domain by searching for a backslash.
         pos = temp.IndexOf("\")
         
         ' Parse the domain name out of the string, if one exists.
@@ -41,5 +40,3 @@ Public Class UserName
     Public Name As String
     Public Domain As String
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentServiceAttribute/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentServiceAttribute/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SumService" %>
 
 Imports System
@@ -17,4 +16,3 @@ Imports System.Web.Services.Description
 		   return a + b
 		End Function
 	End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentServiceAttribute_UseParameterStyle/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentServiceAttribute_UseParameterStyle/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SumService" %>
 
 Imports System
@@ -16,4 +15,3 @@ Imports System.Web.Services.Description
 		   return a + b
 		End Function
 	End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentServiceAttribute_ctor/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentServiceAttribute_ctor/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SumService" %>
 
 Imports System
@@ -15,4 +14,3 @@ Imports System.Web.Services.Description
 		   return a + b
 		End Function
 	End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentServiceAttribute_ctor2/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapDocumentServiceAttribute_ctor2/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SumService" %>
 
 Imports System
@@ -15,4 +14,3 @@ Imports System.Web.Services.Description
 		   return a + b
 		End Function
 	End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapInclude Example/VB/ex1.vb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapInclude Example/VB/ex1.vb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="Test" %>
  
 Imports System
@@ -52,6 +51,3 @@ End Class
 public Class Bike 
    Inherits Vehicle 
 End Class
-   
-'</Snippet1>
-

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.Action/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.Action/VB/sourcevb.asmx
@@ -1,5 +1,4 @@
-﻿' <Snippet1>
-<%@ WebService Language="VB" class="MyUser" %>
+﻿<%@ WebService Language="VB" class="MyUser" %>
 Imports System
 Imports System.Web.Services
 Imports System.Web.Services.Protocols
@@ -23,7 +22,7 @@ Public Class MyUser
         ' Get the full user name, including the domain name if applicable.
         temp = User.Identity.Name
         
-        ' Deterime whether the user is part of a domain by searching for a backslash.
+        ' Determine whether the user is part of a domain by searching for a backslash.
         pos = temp.IndexOf("\")
         
         ' Parse the domain name out of the string, if one exists.
@@ -42,5 +41,3 @@ Public Class UserName
     Public Name As String
     Public Domain As String
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.Binding/VB/bindingvb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.Binding/VB/bindingvb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" class="BindingSample" %>
  Imports System.Web.Services
  Imports System.Web.Services.Protocols
@@ -28,5 +27,4 @@
 	  Public Function DefaultBindingMethod() As String
   		Return "Member of the default binding"
  	  End Function
-End Class    
-'</Snippet1>
+End Class

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.OneWay/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.OneWay/VB/sourcevb.asmx
@@ -1,5 +1,4 @@
-﻿' <Snippet1>
-<%@ WebService Language="VB" Class="Stats" %>
+﻿<%@ WebService Language="VB" Class="Stats" %>
  
 Imports System.Web.Services
 Imports System.Web.Services.Protocols
@@ -14,5 +13,3 @@ Public Class Stats
         ' Begin a process that takes a long time to complete.
     End Sub
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.RequestNamespace/VB/examplevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.RequestNamespace/VB/examplevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SoapRpcMethodSample" %>
 	
 Imports System.Web.Services
@@ -16,4 +15,3 @@ Public Class SoapRpcMethodSample
         Return intarray
    End Function
 End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.ResponseNamespace/VB/examplevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute.ResponseNamespace/VB/examplevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SoapRpcMethodSample" %>
 	
 Imports System.Web.Services
@@ -16,4 +15,3 @@ Public Class SoapRpcMethodSample
         Return intarray
    End Function
 End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcMethodAttribute/VB/sourcevb.asmx
@@ -1,5 +1,4 @@
-﻿' <Snippet1>
-<%@ WebService Language="VB" class="MyUser" %>
+﻿<%@ WebService Language="VB" class="MyUser" %>
 Imports System
 Imports System.Web.Services
 Imports System.Web.Services.Protocols
@@ -42,5 +41,3 @@ Public Class UserName
     Public Name As String
     Public Domain As String
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcServiceAttribute/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/SoapRpcServiceAttribute/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@ WebService Language="VB" Class="SumService" %>
 
 Imports System
@@ -15,4 +14,3 @@ Imports System.Web.Services.Description
 		   return a + b
 		End Function
 	End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/WebMethodAttributeConstructor_BufferResponse/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/WebMethodAttributeConstructor_BufferResponse/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-'<Snippet1>
 <%@WebService Class="Streaming" language="VB"%>
 <%@ assembly name="System.EnterpriseServices,Version=1.0.3300.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a" %>
 
@@ -115,4 +114,3 @@ Public Class TextFileEnumerator
         End Get
     End Property
 End Class
-'</Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/WebMethodAttributeConstructor_CacheDuration/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/WebMethodAttributeConstructor_CacheDuration/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Counter" %>
 <%@ assembly name="System.EnterpriseServices,Version=1.0.3300.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a" %>
 
@@ -25,5 +24,3 @@ Public Class Counter
         Return CInt(Application("MyServiceUsage"))
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/WebMethodAttributeConstructor_EnableSession/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/WebMethodAttributeConstructor_EnableSession/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util" %>
  
 Imports System.Web.Services
@@ -17,5 +16,3 @@ Public Class Util
         Return CInt(Session("HitCounter"))
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/WebMethodAttributeDefaultConstructor/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/WebMethodAttributeDefaultConstructor/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" Class="Util"%>
 
 Imports System
@@ -17,5 +16,3 @@ Public Class Util
         Return Server.MachineName
     End Function
 End Class
-
-' </Snippet1>

--- a/snippets/visualbasic/VS_Snippets_Remoting/WebServiceAttributeConstructor/VB/sourcevb.asmx
+++ b/snippets/visualbasic/VS_Snippets_Remoting/WebServiceAttributeConstructor/VB/sourcevb.asmx
@@ -1,4 +1,3 @@
-' <Snippet1>
 <%@ WebService Language="VB" class= "ServerVariables"%>
  
 Imports System
@@ -16,5 +15,3 @@ Public Class ServerVariables
         Return Context.Timestamp.TimeOfDay.ToString()
     End Function
 End Class
-
-' </Snippet1>


### PR DESCRIPTION
Removed snippet tags from asmx files under the VS_Snippets_Remoting that encompassed the entire file. OPS doesn't know how to interpret those.

These are potentially the samples that got dropped during our previous content migration. So we should try to recover the code references next.