### PR TITLE
Fixed wrong comment and typo

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/DPAPI-HowTO/cs/sample.cs
+++ b/snippets/csharp/VS_Snippets_CLR/DPAPI-HowTO/cs/sample.cs
@@ -94,7 +94,7 @@ public class MemoryProtectionSample
             throw new ArgumentException("Buffer");
         
 
-        // Encrypt the data in memory. The result is stored in the same same array as the original data.
+        // Encrypt the data in memory. The result is stored in the same array as the original data.
         ProtectedMemory.Protect(Buffer, Scope);
 
     }
@@ -107,7 +107,7 @@ public class MemoryProtectionSample
             throw new ArgumentException("Buffer");
         
 
-        // Decrypt the data in memory. The result is stored in the same same array as the original data.
+        // Decrypt the data in memory. The result is stored in the same array as the original data.
         ProtectedMemory.Unprotect(Buffer, Scope);
 
     }
@@ -142,7 +142,7 @@ public class MemoryProtectionSample
        
         int length = 0;
 
-        // Encrypt the data in memory. The result is stored in the same same array as the original data.
+        // Encrypt the data and store the result in a new byte array. The original data remains unchanged.
         byte[] encryptedData = ProtectedData.Protect(Buffer, Entropy, Scope);
 
         // Write the encrypted data to a stream.

--- a/snippets/visualbasic/VS_Snippets_CLR/DPAPI-HowTO/vb/sample.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/DPAPI-HowTO/vb/sample.vb
@@ -92,7 +92,7 @@ Public Module MemoryProtectionSample
             Throw New ArgumentException("Buffer")
         End If
 
-        ' Encrypt the data in memory. The result is stored in the same same array as the original data.
+        ' Encrypt the data in memory. The result is stored in the same array as the original data.
         ProtectedMemory.Protect(Buffer, Scope)
 
     End Sub 'EncryptInMemoryData
@@ -106,7 +106,7 @@ Public Module MemoryProtectionSample
             Throw New ArgumentException("Buffer")
         End If
 
-        ' Decrypt the data in memory. The result is stored in the same same array as the original data.
+        ' Decrypt the data in memory. The result is stored in the same array as the original data.
         ProtectedMemory.Unprotect(Buffer, Scope)
 
     End Sub 'DecryptInMemoryData
@@ -147,7 +147,7 @@ Public Module MemoryProtectionSample
         End If
         Dim length As Integer = 0
 
-        ' Encrypt the data in memory. The result is stored in the same same array as the original data.
+        ' Encrypt the data and store the result in a new byte array. The original data remains unchanged.
         Dim encryptedData As Byte() = ProtectedData.Protect(Buffer, Entropy, Scope)
 
         ' Write the encrypted data to a stream.


### PR DESCRIPTION
## Summary

Changed the comment above ProtectedData.Protect method in EncryptDataToStream to reflect what the method is doing exactly. Also fixed typo **same same** in sentences.

Fixes dotnet/docs#11586
