### PR TITLE
Try Fix encoding

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.Single.ToString/CS/ToString1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Single.ToString/CS/ToString1.cs
@@ -173,12 +173,12 @@ public class Class1
       // Displays:    $16,325.63
       culture = CultureInfo.CreateSpecificCulture("en-GB");
       Console.WriteLine(value.ToString(specifier, culture));
-      // Displays:    £16,325.63
+      // Displays:    Â£16,325.63
       
       specifier = "E04";
       culture = CultureInfo.CreateSpecificCulture("sv-SE");
       Console.WriteLine(value.ToString(specifier, culture));
-      // Displays: 1,6326E+004   
+      // Displays:    1,6326E+004   
        culture = CultureInfo.CreateSpecificCulture("en-NZ");
        Console.WriteLine(value.ToString(specifier, culture));
       // Displays:    1.6326E+004   


### PR DESCRIPTION
The pound sign in this code sample renders incorrectly

![image](https://user-images.githubusercontent.com/4837132/61088389-32d95480-a430-11e9-8d16-143dc5ac7ae4.png)
https://docs.microsoft.com/en-us/dotnet/api/system.single.tostring?view=netframework-4.8

I _believe_ this is because the file was ISO-8859-1 encoded rather than UTF-8. This message popped up when trying to edit it - according to GitHub the file encoding will be automatically changed when the commit is made. 

I also had to make an unrelated change for GitHub to allow me to submit the PR.