### PR TITLE
Fix variable name to be more portable across languages

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR_System/system.Threading.ThreadStart2/CPP/source3.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.Threading.ThreadStart2/CPP/source3.cpp
@@ -10,21 +10,21 @@ public ref class ThreadWithState
 private:
     // State information used in the task.
     String^ boilerplate;
-    int value;
+    int numberValue;
 
     // The constructor obtains the state information.
 public:
     ThreadWithState(String^ text, int number)
     {
         boilerplate = text;
-        value = number;
+        numberValue = number;
     }
 
     // The thread procedure performs the task, such as formatting
     // and printing a document.
     void ThreadProc()
     {
-        Console::WriteLine(boilerplate, value);
+        Console::WriteLine(boilerplate, numberValue);
     }
 };
 

--- a/snippets/cpp/VS_Snippets_CLR_System/system.Threading.ThreadStart2/CPP/source4.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.Threading.ThreadStart2/CPP/source4.cpp
@@ -15,7 +15,7 @@ public ref class ThreadWithState
 private:
     // State information used in the task.
     String^ boilerplate;
-    int value;
+    int numberValue;
 
     // Delegate used to execute the callback method when the
     // task is complete.
@@ -28,7 +28,7 @@ public:
         ExampleCallback^ callbackDelegate)
     {
         boilerplate = text;
-        value = number;
+        numberValue = number;
         callback = callbackDelegate;
     }
 
@@ -37,7 +37,7 @@ public:
     // the callback delegate with the number of lines printed.
     void ThreadProc()
     {
-        Console::WriteLine(boilerplate, value);
+        Console::WriteLine(boilerplate, numberValue);
         if (callback != nullptr)
         {
             callback(1);

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Threading.ThreadStart2/CS/source3.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Threading.ThreadStart2/CS/source3.cs
@@ -9,20 +9,20 @@ public class ThreadWithState
 {
     // State information used in the task.
     private string boilerplate;
-    private int value;
+    private int numberValue;
 
     // The constructor obtains the state information.
     public ThreadWithState(string text, int number)
     {
         boilerplate = text;
-        value = number;
+        numberValue = number;
     }
 
     // The thread procedure performs the task, such as formatting
     // and printing a document.
     public void ThreadProc()
     {
-        Console.WriteLine(boilerplate, value);
+        Console.WriteLine(boilerplate, numberValue);
     }
 }
 

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Threading.ThreadStart2/CS/source4.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Threading.ThreadStart2/CS/source4.cs
@@ -10,7 +10,7 @@ public class ThreadWithState
 {
     // State information used in the task.
     private string boilerplate;
-    private int value;
+    private int numberValue;
 
     // Delegate used to execute the callback method when the
     // task is complete.
@@ -22,7 +22,7 @@ public class ThreadWithState
         ExampleCallback callbackDelegate) 
     {
         boilerplate = text;
-        value = number;
+        numberValue = number;
         callback = callbackDelegate;
     }
     
@@ -31,7 +31,7 @@ public class ThreadWithState
     // the callback delegate with the number of lines printed.
     public void ThreadProc() 
     {
-        Console.WriteLine(boilerplate, value);
+        Console.WriteLine(boilerplate, numberValue);
         if (callback != null)
             callback(1);
     }

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.ThreadStart2/VB/source3.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.ThreadStart2/VB/source3.vb
@@ -6,18 +6,18 @@ Imports System.Threading
 Public Class ThreadWithState
     ' State information used in the task.
     Private boilerplate As String
-    Private value As Integer
+    Private numberValue As Integer
 
     ' The constructor obtains the state information.
     Public Sub New(text As String, number As Integer)
         boilerplate = text
-        value = number
+        numberValue = number
     End Sub
 
     ' The thread procedure performs the task, such as formatting
     ' and printing a document.
     Public Sub ThreadProc()
-        Console.WriteLine(boilerplate, value)
+        Console.WriteLine(boilerplate, numberValue)
     End Sub
 End Class
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.ThreadStart2/VB/source4.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.ThreadStart2/VB/source4.vb
@@ -7,7 +7,7 @@ Imports System.Threading
 Public Class ThreadWithState
     ' State information used in the task.
     Private boilerplate As String
-    Private value As Integer
+    Private numberValue As Integer
 
     ' Delegate used to execute the callback method when the
     ' task is complete.
@@ -18,7 +18,7 @@ Public Class ThreadWithState
     Public Sub New(text As String, number As Integer, _
         callbackDelegate As ExampleCallback)
         boilerplate = text
-        value = number
+        numberValue = number
         callback = callbackDelegate
     End Sub
 
@@ -26,7 +26,7 @@ Public Class ThreadWithState
     ' formatting and printing a document, and then invokes
     ' the callback delegate with the number of lines printed.
     Public Sub ThreadProc()
-        Console.WriteLine(boilerplate, value)
+        Console.WriteLine(boilerplate, numberValue)
         If Not (callback Is Nothing) Then
             callback(1)
         End If


### PR DESCRIPTION
## Summary

Changed the variable name from `value` to `numberValue`

Fixes dotnet/docs#12724
