### PR TITLE
Fix the COM sample to work on latest preview

### DIFF
--- a/core/extensions/COMServerDemo/COMServer/COMServer.csproj
+++ b/core/extensions/COMServerDemo/COMServer/COMServer.csproj
@@ -18,7 +18,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <!-- Indicate the assembly is providing a COM server -->
-    <UseComHost>True</UseComHost>
+    <EnableComHosting>True</EnableComHosting>
 
     <!-- Generate a RegFree COM manifest -->
     <EnableRegFreeCom Condition="'$(RegFree)' == 'True'">True</EnableRegFreeCom>

--- a/core/extensions/COMServerDemo/ReadMe.md
+++ b/core/extensions/COMServerDemo/ReadMe.md
@@ -6,7 +6,7 @@ This is a basic example of providing a managed COM server in .NET Core 3.0. Docu
 Key Features
 ------------
 
-Demonstrates how to provide a COM server in .NET Core 3.0 Preview 5 or later.
+Demonstrates how to provide a COM server in .NET Core 3.0 Preview 8 or later.
 
 Additional comments are contained in source and project files.
 
@@ -31,7 +31,7 @@ Program should output an estimated value of &#960;.
 
 ### RegFree COM ###
 
-1) Install .NET Core 3.0 Preview 5 or later.
+1) Install .NET Core 3.0 Preview 8 or later.
 
 1) Navigate to the root directory and run `dotnet.exe build /p:RegFree=True`.
 
@@ -42,3 +42,5 @@ Program should output an estimated value of &#960;.
 Program should output an estimated value of &#960;.
 
 **Note** The RegFree COM scenario requires a customized [application manifest](https://docs.microsoft.com/windows/desktop/sbscs/manifests) in the executing binary. This means that attempting to execute through `dotnet.exe` will not work and instead trigger a rebuild of the project.
+
+**Note** Running the "Registered COM" first and then immediately follow it by "RegFree COM" will not work, since the build system will not correctly rebuild all files (the simple property change is not detected as a reason for a full rebuild). To fix this, run `dotnet clean` between the two samples.


### PR DESCRIPTION
The COM server sample was written for .NET Core 3.0 Preview 5. Since then the way the COM hosting is setup changed slightly so the sample doesn't work on latest previews.

The change fixes it to work on preview 8 (and breaks it on earlier previews).

Also some small tweaks to the readme.
