### PR TITLE
FromBase64Transform-sample uses InputBlockSize instead of hard-coded 4

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/CPP/class1.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/CPP/class1.cpp
@@ -3,6 +3,7 @@
 using namespace System;
 using namespace System::IO;
 using namespace System::Security::Cryptography;
+
 class MyMainClass
 {
 public:
@@ -11,24 +12,22 @@ public:
       FromBase64Transform^ myTransform = gcnew FromBase64Transform( FromBase64TransformMode::IgnoreWhiteSpaces );
       array<Byte>^myOutputBytes = gcnew array<Byte>(myTransform->OutputBlockSize);
       
-      //Open the input and output files.
+      // Open the input and output files.
       FileStream^ myInputFile = gcnew FileStream( inFileName,FileMode::Open,FileAccess::Read );
       FileStream^ myOutputFile = gcnew FileStream( outFileName,FileMode::Create,FileAccess::Write );
       
-      //Retrieve the file contents into a Byte array.
+      // Retrieve the file contents into a Byte array.
       array<Byte>^myInputBytes = gcnew array<Byte>(myInputFile->Length);
       myInputFile->Read( myInputBytes, 0, myInputBytes->Length );
       
-      //Transform the data in chunks the size of InputBlockSize.
+      // Transform the data in chunks the size of InputBlockSize.
       int i = 0;
-      while ( myInputBytes->Length - i > 4 )
+      while ( myInputBytes->Length - i > myTransform->InputBlockSize )
       {
-         myTransform->TransformBlock( myInputBytes, i, 4, myOutputBytes, 0 );
+         myTransform->TransformBlock( myInputBytes, i, myTransform->InputBlockSize, myOutputBytes, 0 );
          
-         /*myTransform->InputBlockSize*/
-         i += 4;
+         i += myTransform->InputBlockSize;
          
-         /*myTransform->InputBlockSize*/
          myOutputFile->Write( myOutputBytes, 0, myTransform->OutputBlockSize );
       }
 
@@ -42,7 +41,6 @@ public:
       myInputFile->Close();
       myOutputFile->Close();
    }
-
 };
 
 int main()

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/CS/class1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/CS/class1.cs
@@ -111,12 +111,12 @@ class Members
                         byte[] myInputBytes = new byte[myInputFile.Length];
                         myInputFile.Read(myInputBytes, 0, myInputBytes.Length);
 
-                        //Transform the data in chunks the size of InputBlockSize. 
+                        // Transform the data in chunks the size of InputBlockSize. 
                         int i = 0;
-                        while (myInputBytes.Length - i > 4/*myTransform.InputBlockSize*/)
+                        while (myInputBytes.Length - i > myTransform.InputBlockSize)
                         {
-                            int bytesWritten = myTransform.TransformBlock(myInputBytes, i, 4/*myTransform.InputBlockSize*/, myOutputBytes, 0);
-                            i += 4/*myTransform.InputBlockSize*/;
+                            int bytesWritten = myTransform.TransformBlock(myInputBytes, i, myTransform.InputBlockSize, myOutputBytes, 0);
+                            i += myTransform.InputBlockSize;
                             myOutputFile.Write(myOutputBytes, 0, bytesWritten);
                         }
 

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/CS/class1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/CS/class1.cs
@@ -123,9 +123,6 @@ class Members
                         //Transform the final block of data.
                         myOutputBytes = myTransform.TransformFinalBlock(myInputBytes, i, myInputBytes.Length - i);
                         myOutputFile.Write(myOutputBytes, 0, myOutputBytes.Length);
-
-                        //Free up any used resources.
-                        myTransform.Clear();
                     }
                 }
             }

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/CS/class1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/CS/class1.cs
@@ -98,16 +98,15 @@ class Members
         {
             using (FromBase64Transform myTransform = new FromBase64Transform(FromBase64TransformMode.IgnoreWhiteSpaces))
             {
-
                 byte[] myOutputBytes = new byte[myTransform.OutputBlockSize];
 
-                //Open the input and output files.
+                // Open the input and output files.
                 using (FileStream myInputFile = new FileStream(inFileName, FileMode.Open, FileAccess.Read))
                 {
                     using (FileStream myOutputFile = new FileStream(outFileName, FileMode.Create, FileAccess.Write))
                     {
 
-                        //Retrieve the file contents into a byte array. 
+                        // Retrieve the file contents into a byte array. 
                         byte[] myInputBytes = new byte[myInputFile.Length];
                         myInputFile.Read(myInputBytes, 0, myInputBytes.Length);
 
@@ -120,13 +119,12 @@ class Members
                             myOutputFile.Write(myOutputBytes, 0, bytesWritten);
                         }
 
-                        //Transform the final block of data.
+                        // Transform the final block of data.
                         myOutputBytes = myTransform.TransformFinalBlock(myInputBytes, i, myInputBytes.Length - i);
                         myOutputFile.Write(myOutputBytes, 0, myOutputBytes.Length);
                     }
                 }
             }
-
         }
 }
 

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/VB/class1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.Security.Cryptography.FromBase64Transform Example/VB/class1.vb
@@ -75,28 +75,25 @@ Friend Class Members
 
             Dim myOutputBytes(myTransform.OutputBlockSize - 1) As Byte
 
-            'Open the input and output files.
+            ' Open the input and output files.
             Using myInputFile As New FileStream(inFileName, FileMode.Open, FileAccess.Read)
                 Using myOutputFile As New FileStream(outFileName, FileMode.Create, FileAccess.Write)
 
-                    'Retrieve the file contents into a byte array. 
+                    ' Retrieve the file contents into a byte array. 
                     Dim myInputBytes(myInputFile.Length - 1) As Byte
                     myInputFile.Read(myInputBytes, 0, myInputBytes.Length)
 
-                    'Transform the data in chunks the size of InputBlockSize. 
+                    ' Transform the data in chunks the size of InputBlockSize. 
                     Dim i As Integer = 0
-                    Do While myInputBytes.Length - i > 4 'myTransform.InputBlockSize
-                        Dim bytesWritten As Int32 = myTransform.TransformBlock(myInputBytes, i, 4, myOutputBytes, 0) 'myTransform.InputBlockSize
-                        i += 4 'myTransform.InputBlockSize
+                    Do While myInputBytes.Length - i > myTransform.InputBlockSize
+                        Dim bytesWritten As Int32 = myTransform.TransformBlock(myInputBytes, i, myTransform.InputBlockSize, myOutputBytes, 0)
+                        i += myTransform.InputBlockSize
                         myOutputFile.Write(myOutputBytes, 0, bytesWritten)
                     Loop
 
-                    'Transform the final block of data.
+                    ' Transform the final block of data.
                     myOutputBytes = myTransform.TransformFinalBlock(myInputBytes, i, myInputBytes.Length - i)
                     myOutputFile.Write(myOutputBytes, 0, myOutputBytes.Length)
-
-                    'Free up any used resources.
-                    myTransform.Clear()
                 End Using
             End Using
         End Using


### PR DESCRIPTION
Depends on https://github.com/dotnet/corefx/pull/39599

`myTransform.InputBlockSize` returned `1`, so the sample code used `4` explicitely, as base64 decoding transforms 4 input bytes to 3 output bytes.

https://github.com/dotnet/corefx/pull/39599 fixes this, so the sample code can use the `InputBlockSize` provided by the transform.

Additional did unify the code comments in the sample.
And removed the redundant `Clear`, as this is called by `Dispose`.