### PR TITLE
Modernizing sample

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/ObjectX/CS/ObjectX.cs
+++ b/snippets/csharp/VS_Snippets_CLR/ObjectX/CS/ObjectX.cs
@@ -1,4 +1,4 @@
-﻿//Types:System.Object Vendor: Richter
+//Types:System.Object Vendor: Richter
 //<snippet1>
 using System;
 
@@ -20,7 +20,7 @@ class Point
         if (obj.GetType() != this.GetType()) return false;
 
         // Return true if  x and y fields match.
-        Point other = (Point) obj;
+        var other = (Point) obj;
         return (this.x == other.x) && (this.y == other.y);
     }
     //</snippet2>
@@ -37,7 +37,7 @@ class Point
     // Return the point's value as a string.
     public override String ToString() 
     {
-        return String.Format("({0}, {1})", x, y);
+        return $"({x}, {y})";
     }
     //</snippet4>
 
@@ -55,13 +55,13 @@ public sealed class App
     static void Main() 
     {
         // Construct a Point object.
-        Point p1 = new Point(1,2);
+        var p1 = new Point(1,2);
 
         // Make another Point object that is a copy of the first.
-        Point p2 = p1.Copy();
+        var p2 = p1.Copy();
 
         // Make another variable that references the first Point object.
-        Point p3 = p1;
+        var p3 = p1;
 
 	//<snippet6>
         // The line below displays false because p1 and p2 refer to two different objects.
@@ -78,7 +78,7 @@ public sealed class App
         
         //<snippet8> 
         // The line below displays: p1's value is: (1, 2)
-        Console.WriteLine("p1's value is: {0}", p1.ToString());
+        Console.WriteLine($"p1's value is: {p1.ToString()}");
         //</snippet8>
     }
 }

--- a/snippets/visualbasic/VS_Snippets_CLR/ObjectX/vb/objectX.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/ObjectX/vb/objectX.vb
@@ -72,7 +72,7 @@ NotInheritable Public Class App
         
         '<snippet8> 
         ' The line below displays: p1's value is: (1, 2)
-        Console.WriteLine("p1's value is: {0}", p1.ToString())
+        Console.WriteLine($"p1's value is: {p1.ToString()}")
     
     End Sub
         '</snippet8>

--- a/snippets/visualbasic/VS_Snippets_CLR/ObjectX/vb/objectX.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/ObjectX/vb/objectX.vb
@@ -1,4 +1,4 @@
-﻿'Types:System.Object Vendor: Richter
+'Types:System.Object Vendor: Richter
 ' <snippet1>
 ' The Point class is derived from System.Object.
 Class Point
@@ -26,14 +26,14 @@ Class Point
     '<snippet3>
     ' Return the XOR of the x and y fields.
     Public Overrides Function GetHashCode() As Integer 
-        Return (x << 1) XOr y
+        Return (x << 1) XOR y
     End Function 
     '</snippet3>
 
     '<snippet4>
     ' Return the point's value as a string.
     Public Overrides Function ToString() As String 
-        Return String.Format("({0}, {1})", x, y)
+        Return $"({x}, {y})"
     End Function
     '</snippet4>
 


### PR DESCRIPTION
In CSharp sample:
Used string interpolation, and var instead of data type when it's clear.

In Visual Basic sample:
Used string interplolation, and replaced `XOr` with `XOR`.
