### PR TITLE
Fix enum flag values

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEnums/CS/Enums.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEnums/CS/Enums.cs
@@ -19,9 +19,9 @@ namespace Enums
         Monday = 0x2,
         Tuesday = 0x4,
         Wednesday = 0x8,
-        Thursday = 0x10,
-        Friday = 0x20,
-        Saturday = 0x40
+        Thursday = 0x16,
+        Friday = 0x32,
+        Saturday = 0x64
     }
     class MyClass
     {


### PR DESCRIPTION
## Summary

Enum values were not in power of 2 but * 2 😆 

Fixes dotnet/docs#13508