### PR TITLE
Change hex to decimal to clear up confusion

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEnums/CS/Enums.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEnums/CS/Enums.cs
@@ -14,14 +14,14 @@ namespace Enums
     [Flags]
     enum Days
     {
-        None        = 0,
-        Sunday      = 1,
-        Monday      = 2,
-        Tuesday     = 4,
-        Wednesday   = 8,
-        Thursday    = 16,
-        Friday      = 32,
-        Saturday    = 64
+        None      = 0b_0000_0000, // 0
+        Sunday    = 0b_0000_0001, // 1
+        Monday    = 0b_0000_0010, // 2
+        Tuesday   = 0b_0000_0100, // 4
+        Wednesday = 0b_0000_1000, // 8
+        Thursday  = 0b_0001_0000, // 16
+        Friday    = 0b_0010_0000, // 32
+        Saturday  = 0b_0100_0000  // 64 
     }
     class MyClass
     {

--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEnums/CS/Enums.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEnums/CS/Enums.cs
@@ -14,14 +14,14 @@ namespace Enums
     [Flags]
     enum Days
     {
-        None = 0x0,
-        Sunday = 0x1,
-        Monday = 0x2,
-        Tuesday = 0x4,
-        Wednesday = 0x8,
-        Thursday = 0x10,
-        Friday = 0x20,
-        Saturday = 0x40
+        None        = 0,
+        Sunday      = 1,
+        Monday      = 2,
+        Tuesday     = 4,
+        Wednesday   = 8,
+        Thursday    = 16,
+        Friday      = 32,
+        Saturday    = 64
     }
     class MyClass
     {


### PR DESCRIPTION
## Summary

Swap out hex for dec

EDIT: Maybe I shouldn't say dec or someone with think I'm trying to change it to pdp octal? ha! 😉 

Fixes dotnet/docs#13508
