### PR TITLE
remove snippet tag

### DIFF
--- a/snippets/visualbasic/programming-guide/language-features/procedures/ref-returns1.cs
+++ b/snippets/visualbasic/programming-guide/language-features/procedures/ref-returns1.cs
@@ -1,5 +1,4 @@
-﻿// <Snippet1>
-using System;
+﻿using System;
 
 public class NumericValue
 {
@@ -21,5 +20,3 @@ public class NumericValue
       return value;
    }
 }
-// </Snippet1>
-


### PR DESCRIPTION
The snippet tags are being rendered on the docs and are not really needed
https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/procedures/ref-return-values

I'm wondering if the addition of the BOM marks in PR #1091 broke the logic to remove the snippet tags. Maybe if the snippet tag is in the first line, it doesn't behave as expected?