### PR TITLE
Bug in method IsApproximatelyEqual fixed

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.double.structure/cs/comparison4.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.double.structure/cs/comparison4.cs
@@ -33,7 +33,7 @@ public class Example
       if (divisor.Equals(0)) 
          divisor = Math.Min(value1, value2);
       
-      return Math.Abs(value1 - value2)/divisor <= epsilon;           
+      return Math.Abs((value1 - value2) / divisor) <= epsilon;           
    } 
 }
 // The example displays the following output:


### PR DESCRIPTION
The divisor can get negative, so we have to take as well the absolute value of the divisor and not only of the difference. Otherwise IsApproximatelyEqual(0, -1, 1e-15) would return true.

