### PR TITLE
Bug in method IsApproximatelyEqual (Visual Basic) fixed

### DIFF
--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.double.structure/vb/comparison4.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.double.structure/vb/comparison4.vb
@@ -33,7 +33,7 @@ Module Example
          divisor = Math.Min(value1, value2)
       End If 
       
-      Return Math.Abs(value1 - value2)/divisor <= epsilon           
+      Return Math.Abs((value1 - value2) / divisor) <= epsilon           
    End Function
 End Module
 ' The example displays the following output:


### PR DESCRIPTION
The divisor can get negative, so we have to take as well the absolute value of the divisor and not only of the difference. Otherwise IsApproximatelyEqual(0, -1, 1e-15) would return true. See as well https://github.com/dotnet/samples/pull/1152.