### PR TITLE
Support both 64-bit and 32-bit WPF.

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/WriteableBitmap2/CS/Program.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/WriteableBitmap2/CS/Program.cs
@@ -66,7 +66,7 @@ namespace WriteableBitmapDemo
                 unsafe
                 {
                     // Get a pointer to the back buffer.
-                    int pBackBuffer = (int)writeableBitmap.BackBuffer;
+                    IntPtr pBackBuffer = writeableBitmap.BackBuffer;
 
                     // Find the address of the pixel to draw.
                     pBackBuffer += row * writeableBitmap.BackBufferStride;


### PR DESCRIPTION
This change allows the sample code to run correctly whether compiled for 64-bit or 32-bit WPF.

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
