### PR TITLE
Disambiguate C# and VB examples

### DIFF
--- a/winforms/formatting-utility/cs/readme.md
+++ b/winforms/formatting-utility/cs/readme.md
@@ -5,9 +5,9 @@ products:
 - dotnet-core
 - windows
 page_type: sample
-name: ".NET Core WinForms Formatting Utility"
+name: ".NET Core WinForms Formatting Utility (C#)"
 urlFragment: "winforms-formatting-utility-cs"
-description: "A .NET Core Windows Forms application that allows you to apply standard or custom format strings."
+description: "A .NET Core Windows Forms application written in C# that allows you to apply standard or custom format strings."
 ---
 
 # .NET Formatting Utility

--- a/winforms/formatting-utility/vb/readme.md
+++ b/winforms/formatting-utility/vb/readme.md
@@ -5,9 +5,9 @@ products:
 - dotnet-core
 - windows
 page_type: sample
-name: ".NET Core WinForms Formatting Utility"
+name: ".NET Core WinForms Formatting Utility (Visual Basic)"
 urlFragment: "winforms-formatting-utility-vb"
-description: "A .NET Core Windows Forms application that allows you to apply standard or custom format strings.."
+description: "A .NET Core Windows Forms application written in Visual Basic that allows you to apply standard or custom format strings."
 ---
 # .NET Formatting Utility
 


### PR DESCRIPTION
## Disambiguate C# and VB examples

The Visual Basic and C# examples for the formatting utility now appear in the Samples Browser, but they need to be disambiguated:

![image](https://user-images.githubusercontent.com/10886961/63284223-ee7b7880-c267-11e9-8cb5-077822c80a1d.png)
