### PR TITLE
Meaningless condition

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/contiguous1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/contiguous1.cs
@@ -4,19 +4,19 @@ using System.Text.RegularExpressions;
 
 public class Example
 {
-   public static void Main()
-   {
-      string input = "capybara,squirrel,chipmunk,porcupine,gopher," + 
-                     "beaver,groundhog,hamster,guinea pig,gerbil," + 
-                     "chinchilla,prairie dog,mouse,rat";
-      string pattern = @"\G(\w+\s?\w*),?";
-      Match match = Regex.Match(input, pattern);
-      while (match.Success) 
-      {
-         Console.WriteLine(match.Groups[1].Value);
-         match = match.NextMatch();
-      } 
-   }
+    public static void Main()
+    {
+        string input = "capybara,squirrel,chipmunk,porcupine,gopher," +
+                       "beaver,groundhog,hamster,guinea pig,gerbil," +
+                       "chinchilla,prairie dog,mouse,rat";
+        string pattern = @"\G(\w+\s?\w*),?";
+        Match match = Regex.Match(input, pattern);
+        while (match.Success)
+        {
+            Console.WriteLine(match.Groups[1].Value);
+            match = match.NextMatch();
+        }
+    }
 }
 // The example displays the following output:
 //       capybara

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/endofstring1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/endofstring1.cs
@@ -4,96 +4,77 @@ using System.Text.RegularExpressions;
 
 public class Example
 {
-   public static void Main()
-   {
-      int startPos = 0, endPos = 70;
-      string cr = Environment.NewLine;
-      string input = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957" + cr +
-                     "Chicago Cubs, National League, 1903-present" + cr + 
-                     "Detroit Tigers, American League, 1901-present" + cr + 
-                     "New York Giants, National League, 1885-1957" + cr +  
-                     "Washington Senators, American League, 1901-1960" + cr;   
-      Match match;
+    public static void Main()
+    {
+        string cr = Environment.NewLine;
+        string input = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957" + cr +
+                       "Chicago Cubs, National League, 1903-present" + cr +
+                       "Detroit Tigers, American League, 1901-present" + cr +
+                       "New York Giants, National League, 1885-1957" + cr +
+                       "Washington Senators, American League, 1901-1960" + cr;
+        Match match;
 
-      string basePattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+";
-      string pattern = basePattern + "$";
-      Console.WriteLine("Attempting to match the entire input string:");
-      if (input.Substring(startPos, endPos).Contains(",")) {
-         match = Regex.Match(input, pattern);
-         while (match.Success) {
-            Console.Write("The {0} played in the {1} in", 
+        string basePattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+";
+        string pattern = basePattern + "$";
+        Console.WriteLine("Attempting to match the entire input string:");
+        match = Regex.Match(input, pattern);
+        while (match.Success)
+        {
+            Console.Write("The {0} played in the {1} in",
                               match.Groups[1].Value, match.Groups[4].Value);
             foreach (Capture capture in match.Groups[5].Captures)
-               Console.Write(capture.Value);
-   
+                Console.Write(capture.Value);
+
             Console.WriteLine(".");
-            startPos = match.Index + match.Length;
-            endPos = startPos + 70 <= input.Length ? 70 : input.Length - startPos;
-            if (! input.Substring(startPos, endPos).Contains(",")) break;
             match = match.NextMatch();
-         }
-         Console.WriteLine();
-      }
+        }
+        Console.WriteLine();
 
-      string[] teams = input.Split(new String[] { cr }, StringSplitOptions.RemoveEmptyEntries);
-      Console.WriteLine("Attempting to match each element in a string array:");
-      foreach (string team in teams)
-      {
-         if (team.Length > 70) continue;
+        string[] teams = input.Split(new String[] { cr }, StringSplitOptions.RemoveEmptyEntries);
+        Console.WriteLine("Attempting to match each element in a string array:");
+        foreach (string team in teams)
+        {
+            match = Regex.Match(team, pattern);
+            if (match.Success)
+            {
+                Console.Write("The {0} played in the {1} in",
+                              match.Groups[1].Value, match.Groups[4].Value);
+                foreach (Capture capture in match.Groups[5].Captures)
+                    Console.Write(capture.Value);
+                Console.WriteLine(".");
+            }
+        }
+        Console.WriteLine();
 
-         match = Regex.Match(team, pattern);
-         if (match.Success)
-         {
-            Console.Write("The {0} played in the {1} in", 
-                          match.Groups[1].Value, match.Groups[4].Value);
-            foreach (Capture capture in match.Groups[5].Captures)
-               Console.Write(capture.Value);
-            Console.WriteLine(".");
-         }
-      }
-      Console.WriteLine();
-      
-      startPos = 0;
-      endPos = 70;
-      Console.WriteLine("Attempting to match each line of an input string with '$':");
-      if (input.Substring(startPos, endPos).Contains(",")) {
-         match = Regex.Match(input, pattern, RegexOptions.Multiline);
-         while (match.Success) {
-            Console.Write("The {0} played in the {1} in", 
+        Console.WriteLine("Attempting to match each line of an input string with '$':");
+        match = Regex.Match(input, pattern, RegexOptions.Multiline);
+        while (match.Success)
+        {
+            Console.Write("The {0} played in the {1} in",
                               match.Groups[1].Value, match.Groups[4].Value);
             foreach (Capture capture in match.Groups[5].Captures)
-               Console.Write(capture.Value);
-   
+                Console.Write(capture.Value);
+
             Console.WriteLine(".");
-            startPos = match.Index + match.Length;
-            endPos = startPos + 70 <= input.Length ? 70 : input.Length - startPos;
-            if (! input.Substring(startPos, endPos).Contains(",")) break;
             match = match.NextMatch();
-         }
-         Console.WriteLine();
-      }
-      
-      startPos = 0;
-      endPos = 70;
-      pattern = basePattern + "\r?$"; 
-      Console.WriteLine(@"Attempting to match each line of an input string with '\r?$':");
-      if (input.Substring(startPos, endPos).Contains(",")) {
-         match = Regex.Match(input, pattern, RegexOptions.Multiline);
-         while (match.Success) {
-            Console.Write("The {0} played in the {1} in", 
+        }
+        Console.WriteLine();
+
+        pattern = basePattern + "\r?$";
+        Console.WriteLine(@"Attempting to match each line of an input string with '\r?$':");
+        match = Regex.Match(input, pattern, RegexOptions.Multiline);
+        while (match.Success)
+        {
+            Console.Write("The {0} played in the {1} in",
                               match.Groups[1].Value, match.Groups[4].Value);
             foreach (Capture capture in match.Groups[5].Captures)
-               Console.Write(capture.Value);
-   
+                Console.Write(capture.Value);
+
             Console.WriteLine(".");
-            startPos = match.Index + match.Length;
-            endPos = startPos + 70 <= input.Length ? 70 : input.Length - startPos;
-            if (! input.Substring(startPos, endPos).Contains(",")) break;
             match = match.NextMatch();
-         }
-         Console.WriteLine();
-      }
-   }
+        }
+        Console.WriteLine();
+    }
 }
 // The example displays the following output:
 //    Attempting to match the entire input string:
@@ -107,7 +88,7 @@ public class Example
 //    
 //    Attempting to match each line of an input string with '$':
 //    
-//    Attempting to match each line of an input string with '\r+$':
+//    Attempting to match each line of an input string with '\r?$':
 //    The Brooklyn Dodgers played in the National League in 1911, 1912, 1932-1957.
 //    The Chicago Cubs played in the National League in 1903-present.
 //    The Detroit Tigers played in the American League in 1901-present.

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/endofstring2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/endofstring2.cs
@@ -4,27 +4,25 @@ using System.Text.RegularExpressions;
 
 public class Example
 {
-   public static void Main()
-   {
-      string[] inputs = { "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957",  
-                          "Chicago Cubs, National League, 1903-present" + Environment.NewLine, 
-                          "Detroit Tigers, American League, 1901-present" + Regex.Unescape(@"\n"), 
-                          "New York Giants, National League, 1885-1957", 
-                          "Washington Senators, American League, 1901-1960" + Environment.NewLine}; 
-      string pattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+\r?\Z";
+    public static void Main()
+    {
+        string[] inputs = { "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957",
+                          "Chicago Cubs, National League, 1903-present" + Environment.NewLine,
+                          "Detroit Tigers, American League, 1901-present" + Regex.Unescape(@"\n"),
+                          "New York Giants, National League, 1885-1957",
+                          "Washington Senators, American League, 1901-1960" + Environment.NewLine};
+        string pattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+\r?\Z";
 
-      foreach (string input in inputs)
-      {
-         if (input.Length > 70 || ! input.Contains(",")) continue;
-         
-         Console.WriteLine(Regex.Escape(input));
-         Match match = Regex.Match(input, pattern);
-         if (match.Success)
-            Console.WriteLine("   Match succeeded.");
-         else
-            Console.WriteLine("   Match failed.");
-      }   
-   }
+        foreach (string input in inputs)
+        {
+            Console.WriteLine(Regex.Escape(input));
+            Match match = Regex.Match(input, pattern);
+            if (match.Success)
+                Console.WriteLine("   Match succeeded.");
+            else
+                Console.WriteLine("   Match failed.");
+        }
+    }
 }
 // The example displays the following output:
 //    Brooklyn\ Dodgers,\ National\ League,\ 1911,\ 1912,\ 1932-1957

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/endofstring3.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/endofstring3.cs
@@ -4,27 +4,25 @@ using System.Text.RegularExpressions;
 
 public class Example
 {
-   public static void Main()
-   {
-      string[] inputs = { "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957", 
+    public static void Main()
+    {
+        string[] inputs = { "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957",
                           "Chicago Cubs, National League, 1903-present" + Environment.NewLine,
-                          "Detroit Tigers, American League, 1901-present\\r",
+                          "Detroit Tigers, American League, 1901-present\n",
                           "New York Giants, National League, 1885-1957",
-                          "Washington Senators, American League, 1901-1960" + Environment.NewLine };  
-      string pattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+\r?\z";
+                          "Washington Senators, American League, 1901-1960" + Environment.NewLine };
+        string pattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+\r?\z";
 
-      foreach (string input in inputs)
-      {
-         if (input.Length > 70 || ! input.Contains(",")) continue;
-         
-         Console.WriteLine(Regex.Escape(input));
-         Match match = Regex.Match(input, pattern);
-         if (match.Success)
-            Console.WriteLine("   Match succeeded.");
-         else
-            Console.WriteLine("   Match failed.");
-      }   
-   }
+        foreach (string input in inputs)
+        {
+            Console.WriteLine(Regex.Escape(input));
+            Match match = Regex.Match(input, pattern);
+            if (match.Success)
+                Console.WriteLine("   Match succeeded.");
+            else
+                Console.WriteLine("   Match failed.");
+        }
+    }
 }
 // The example displays the following output:
 //    Brooklyn\ Dodgers,\ National\ League,\ 1911,\ 1912,\ 1932-1957

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/nonword1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/nonword1.cs
@@ -4,14 +4,14 @@ using System.Text.RegularExpressions;
 
 public class Example
 {
-   public static void Main()
-   {
-      string input = "equity queen equip acquaint quiet";
-      string pattern = @"\Bqu\w+";
-      foreach (Match match in Regex.Matches(input, pattern))
-         Console.WriteLine("'{0}' found at position {1}", 
-                           match.Value, match.Index);
-   }
+    public static void Main()
+    {
+        string input = "equity queen equip acquaint quiet";
+        string pattern = @"\Bqu\w+";
+        foreach (Match match in Regex.Matches(input, pattern))
+            Console.WriteLine("'{0}' found at position {1}",
+                              match.Value, match.Index);
+    }
 }
 // The example displays the following output:
 //       'quity' found at position 1

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/startofstring1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/startofstring1.cs
@@ -7,16 +7,17 @@ public class Example
     public static void Main()
     {
         string input = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957\n" +
-                     "Chicago Cubs, National League, 1903-present\n" + 
-                     "Detroit Tigers, American League, 1901-present\n" + 
-                     "New York Giants, National League, 1885-1957\n" +  
-                     "Washington Senators, American League, 1901-1960\n";   
+                     "Chicago Cubs, National League, 1903-present\n" +
+                     "Detroit Tigers, American League, 1901-present\n" +
+                     "New York Giants, National League, 1885-1957\n" +
+                     "Washington Senators, American League, 1901-1960\n";
         string pattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+";
         Match match;
-      
+
         match = Regex.Match(input, pattern);
-        while (match.Success) {
-            Console.Write("The {0} played in the {1} in", 
+        while (match.Success)
+        {
+            Console.Write("The {0} played in the {1} in",
                               match.Groups[1].Value, match.Groups[4].Value);
             foreach (Capture capture in match.Groups[5].Captures)
                 Console.Write(capture.Value);
@@ -25,10 +26,11 @@ public class Example
             match = match.NextMatch();
         }
         Console.WriteLine();
-         
+
         match = Regex.Match(input, pattern, RegexOptions.Multiline);
-        while (match.Success) {
-            Console.Write("The {0} played in the {1} in", 
+        while (match.Success)
+        {
+            Console.Write("The {0} played in the {1} in",
                               match.Groups[1].Value, match.Groups[4].Value);
             foreach (Capture capture in match.Groups[5].Captures)
                 Console.Write(capture.Value);

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/startofstring1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/startofstring1.cs
@@ -4,51 +4,40 @@ using System.Text.RegularExpressions;
 
 public class Example
 {
-   public static void Main()
-   {
-      int startPos = 0, endPos = 70;
-      string input = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957\n" +
+    public static void Main()
+    {
+        string input = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957\n" +
                      "Chicago Cubs, National League, 1903-present\n" + 
                      "Detroit Tigers, American League, 1901-present\n" + 
                      "New York Giants, National League, 1885-1957\n" +  
                      "Washington Senators, American League, 1901-1960\n";   
-      string pattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+";
-      Match match;
+        string pattern = @"^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+";
+        Match match;
       
-      if (input.Substring(startPos, endPos).Contains(",")) {
-         match = Regex.Match(input, pattern);
-         while (match.Success) {
+        match = Regex.Match(input, pattern);
+        while (match.Success) {
             Console.Write("The {0} played in the {1} in", 
                               match.Groups[1].Value, match.Groups[4].Value);
             foreach (Capture capture in match.Groups[5].Captures)
-               Console.Write(capture.Value);
-   
+                Console.Write(capture.Value);
+
             Console.WriteLine(".");
-            startPos = match.Index + match.Length;
-            endPos = startPos + 70 <= input.Length ? 70 : input.Length - startPos;
-            if (! input.Substring(startPos, endPos).Contains(",")) break;
             match = match.NextMatch();
-         }
-         Console.WriteLine();
-      }
+        }
+        Console.WriteLine();
          
-      if (input.Substring(startPos, endPos).Contains(",")) {
-         match = Regex.Match(input, pattern, RegexOptions.Multiline);
-         while (match.Success) {
+        match = Regex.Match(input, pattern, RegexOptions.Multiline);
+        while (match.Success) {
             Console.Write("The {0} played in the {1} in", 
                               match.Groups[1].Value, match.Groups[4].Value);
             foreach (Capture capture in match.Groups[5].Captures)
-               Console.Write(capture.Value);
-   
+                Console.Write(capture.Value);
+
             Console.WriteLine(".");
-            startPos = match.Index + match.Length;
-            endPos = startPos + 70 <= input.Length ? 70 : input.Length - startPos;
-            if (! input.Substring(startPos, endPos).Contains(",")) break;
             match = match.NextMatch();
-         }
-         Console.WriteLine();
-      }
-   }
+        }
+        Console.WriteLine();
+    }
 }
 // The example displays the following output:
 //    The Brooklyn Dodgers played in the National League in 1911, 1912, 1932-1957.

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/startofstring2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/startofstring2.cs
@@ -4,35 +4,29 @@ using System.Text.RegularExpressions;
 
 public class Example
 {
-   public static void Main()
-   {
-      int startPos = 0, endPos = 70;
-      string input = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957\n" +
-                     "Chicago Cubs, National League, 1903-present\n" + 
-                     "Detroit Tigers, American League, 1901-present\n" + 
-                     "New York Giants, National League, 1885-1957\n" +  
-                     "Washington Senators, American League, 1901-1960\n";   
+    public static void Main()
+    {
+        string input = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957\n" +
+                       "Chicago Cubs, National League, 1903-present\n" +
+                       "Detroit Tigers, American League, 1901-present\n" +
+                       "New York Giants, National League, 1885-1957\n" +
+                       "Washington Senators, American League, 1901-1960\n";
 
-      string pattern = @"\A((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+";
-      Match match;
+        string pattern = @"\A((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+";
 
-      if (input.Substring(startPos, endPos).Contains(",")) {
-         match = Regex.Match(input, pattern, RegexOptions.Multiline);
-         while (match.Success) {
-            Console.Write("The {0} played in the {1} in", 
+        Match match = Regex.Match(input, pattern, RegexOptions.Multiline);
+        while (match.Success)
+        {
+            Console.Write("The {0} played in the {1} in",
                               match.Groups[1].Value, match.Groups[4].Value);
             foreach (Capture capture in match.Groups[5].Captures)
-               Console.Write(capture.Value);
-   
+                Console.Write(capture.Value);
+
             Console.WriteLine(".");
-            startPos = match.Index + match.Length;
-            endPos = startPos + 70 <= input.Length ? 70 : input.Length - startPos;
-            if (! input.Substring(startPos, endPos).Contains(",")) break;
             match = match.NextMatch();
-         }
-         Console.WriteLine();
-      }
-   }
+        }
+        Console.WriteLine();
+    }
 }
 // The example displays the following output:
 //    The Brooklyn Dodgers played in the National League in 1911, 1912, 1932-1957.

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/word1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.assertions/cs/word1.cs
@@ -4,15 +4,15 @@ using System.Text.RegularExpressions;
 
 public class Example
 {
-   public static void Main()
-   {
-      string input = "area bare arena mare";
-      string pattern = @"\bare\w*\b";
-      Console.WriteLine("Words that begin with 'are':");
-      foreach (Match match in Regex.Matches(input, pattern))
-         Console.WriteLine("'{0}' found at position {1}",
-                           match.Value, match.Index);
-   }
+    public static void Main()
+    {
+        string input = "area bare arena mare";
+        string pattern = @"\bare\w*\b";
+        Console.WriteLine("Words that begin with 'are':");
+        foreach (Match match in Regex.Matches(input, pattern))
+            Console.WriteLine("'{0}' found at position {1}",
+                              match.Value, match.Index);
+    }
 }
 // The example displays the following output:
 //       Words that begin with 'are':

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/contiguous1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/contiguous1.vb
@@ -5,17 +5,17 @@ Option Strict On
 Imports System.Text.RegularExpressions
 
 Module Example
-   Public Sub Main()
-      Dim input As String = "capybara,squirrel,chipmunk,porcupine,gopher," + _
-                            "beaver,groundhog,hamster,guinea pig,gerbil," + _
-                            "chinchilla,prairie dog,mouse,rat"
-      Dim pattern As String = "\G(\w+\s?\w*),?"
-      Dim match As Match = Regex.Match(input, pattern)
-      Do While match.Success
-         Console.WriteLine(match.Groups(1).Value)
-         match = match.NextMatch()
-      Loop 
-   End Sub
+    Public Sub Main()
+        Dim input As String = "capybara,squirrel,chipmunk,porcupine,gopher," +
+                              "beaver,groundhog,hamster,guinea pig,gerbil," +
+                              "chinchilla,prairie dog,mouse,rat"
+        Dim pattern As String = "\G(\w+\s?\w*),?"
+        Dim match As Match = Regex.Match(input, pattern)
+        Do While match.Success
+            Console.WriteLine(match.Groups(1).Value)
+            match = match.NextMatch()
+        Loop
+    End Sub
 End Module
 ' The example displays the following output:
 '       capybara

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/endofstring1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/endofstring1.vb
@@ -5,98 +5,73 @@ Option Strict On
 Imports System.Text.RegularExpressions
 
 Module Example
-   Public Sub Main()
-      Dim startPos As Integer = 0
-      Dim endPos As Integer = 70
-      Dim input As String = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957" + vbCrLf + _
-                            "Chicago Cubs, National League, 1903-present" + vbCrLf + _
-                            "Detroit Tigers, American League, 1901-present" + vbCrLf + _
-                            "New York Giants, National League, 1885-1957" + vbCrLf + _
-                            "Washington Senators, American League, 1901-1960" + vbCrLf  
+    Public Sub Main()
+        Dim input As String = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957" + vbCrLf +
+                              "Chicago Cubs, National League, 1903-present" + vbCrLf +
+                              "Detroit Tigers, American League, 1901-present" + vbCrLf +
+                              "New York Giants, National League, 1885-1957" + vbCrLf +
+                              "Washington Senators, American League, 1901-1960" + vbCrLf
 
-      Dim basePattern As String = "^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+"
-      Dim match As Match
+        Dim basePattern As String = "^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+"
+        Dim match As Match
 
-      Dim pattern As String = basePattern + "$"
-      Console.WriteLine("Attempting to match the entire input string:")
-      ' Provide minimal validation in the event the input is invalid.
-      If input.Substring(startPos, endPos).Contains(",") Then
-         match = Regex.Match(input, pattern)
-         Do While match.Success
-            Console.Write("The {0} played in the {1} in", _
+        Dim pattern As String = basePattern + "$"
+        Console.WriteLine("Attempting to match the entire input string:")
+        match = Regex.Match(input, pattern)
+        Do While match.Success
+            Console.Write("The {0} played in the {1} in",
                               match.Groups(1).Value, match.Groups(4).Value)
             For Each capture As Capture In match.Groups(5).Captures
-               Console.Write(capture.Value)
+                Console.Write(capture.Value)
             Next
             Console.WriteLine(".")
-            startPos = match.Index + match.Length 
-            endPos = CInt(IIf(startPos + 70 <= input.Length, 70, input.Length - startPos))
-            If Not input.Substring(startPos, endPos).Contains(",") Then Exit Do
-            match = match.NextMatch()            
-         Loop
-         Console.WriteLine()                               
-      End If      
-      
-      Dim teams() As String = input.Split(New String() { vbCrLf }, StringSplitOptions.RemoveEmptyEntries)
-      Console.WriteLine("Attempting to match each element in a string array:")
-      For Each team As String In teams
-         If team.Length > 70 Then Continue For
-         match = Regex.Match(team, pattern)
-         If match.Success Then
-            Console.Write("The {0} played in the {1} in", _
-                           match.Groups(1).Value, match.Groups(4).Value)
-            For Each capture As Capture In match.Groups(5).Captures
-               Console.Write(capture.Value)
-            Next
-            Console.WriteLine(".")
-         End If
-      Next
-      Console.WriteLine()
-      
-      startPos = 0
-      endPos = 70
-      Console.WriteLine("Attempting to match each line of an input string with '$':")
-      ' Provide minimal validation in the event the input is invalid.
-      If input.Substring(startPos, endPos).Contains(",") Then
-         match = Regex.Match(input, pattern, RegexOptions.Multiline)
-         Do While match.Success
-            Console.Write("The {0} played in the {1} in", _
-                              match.Groups(1).Value, match.Groups(4).Value)
-            For Each capture As Capture In match.Groups(5).Captures
-               Console.Write(capture.Value)
-            Next
-            Console.WriteLine(".")
-            startPos = match.Index + match.Length 
-            endPos = CInt(IIf(startPos + 70 <= input.Length, 70, input.Length - startPos))
-            If Not input.Substring(startPos, endPos).Contains(",") Then Exit Do
-            match = match.NextMatch()            
-         Loop
-         Console.WriteLine()                               
-      End If      
+            match = match.NextMatch()
+        Loop
+        Console.WriteLine()
 
-      
-      startPos = 0
-      endPos = 70
-      pattern = basePattern + "\r?$" 
-      Console.WriteLine("Attempting to match each line of an input string with '\r?$':")
-      ' Provide minimal validation in the event the input is invalid.
-      If input.Substring(startPos, endPos).Contains(",") Then
-         match = Regex.Match(input, pattern, RegexOptions.Multiline)
-         Do While match.Success
-            Console.Write("The {0} played in the {1} in", _
+        Dim teams() As String = input.Split(New String() {vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
+        Console.WriteLine("Attempting to match each element in a string array:")
+        For Each team As String In teams
+            match = Regex.Match(team, pattern)
+            If match.Success Then
+                Console.Write("The {0} played in the {1} in",
+                               match.Groups(1).Value, match.Groups(4).Value)
+                For Each capture As Capture In match.Groups(5).Captures
+                    Console.Write(capture.Value)
+                Next
+                Console.WriteLine(".")
+            End If
+        Next
+        Console.WriteLine()
+
+        Console.WriteLine("Attempting to match each line of an input string with '$':")
+        match = Regex.Match(input, pattern, RegexOptions.Multiline)
+        Do While match.Success
+            Console.Write("The {0} played in the {1} in",
                               match.Groups(1).Value, match.Groups(4).Value)
             For Each capture As Capture In match.Groups(5).Captures
-               Console.Write(capture.Value)
+                Console.Write(capture.Value)
             Next
             Console.WriteLine(".")
-            startPos = match.Index + match.Length 
-            endPos = CInt(IIf(startPos + 70 <= input.Length, 70, input.Length - startPos))
-            If Not input.Substring(startPos, endPos).Contains(",") Then Exit Do
-            match = match.NextMatch()            
-         Loop
-         Console.WriteLine()                               
-      End If      
-   End Sub
+            match = match.NextMatch()
+        Loop
+        Console.WriteLine()
+
+        pattern = basePattern + "\r?$"
+        Console.WriteLine("Attempting to match each line of an input string with '\r?$':")
+        match = Regex.Match(input, pattern, RegexOptions.Multiline)
+        Do While match.Success
+            Console.Write("The {0} played in the {1} in",
+                              match.Groups(1).Value, match.Groups(4).Value)
+            For Each capture As Capture In match.Groups(5).Captures
+                Console.Write(capture.Value)
+            Next
+            Console.WriteLine(".")
+
+            match = match.NextMatch()
+        Loop
+        Console.WriteLine()
+    End Sub
 End Module
 ' The example displays the following output:
 '    Attempting to match the entire input string:
@@ -110,7 +85,7 @@ End Module
 '    
 '    Attempting to match each line of an input string with '$':
 '    
-'    Attempting to match each line of an input string with '\r+$':
+'    Attempting to match each line of an input string with '\r?$':
 '    The Brooklyn Dodgers played in the National League in 1911, 1912, 1932-1957.
 '    The Chicago Cubs played in the National League in 1903-present.
 '    The Detroit Tigers played in the American League in 1901-present.

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/endofstring2.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/endofstring2.vb
@@ -5,26 +5,24 @@ Option Strict On
 Imports System.Text.RegularExpressions
 
 Module Example
-   Public Sub Main()
-      Dim inputs() As String = { "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957",  _
-                            "Chicago Cubs, National League, 1903-present" + vbCrLf, _
-                            "Detroit Tigers, American League, 1901-present" + vbLf, _
-                            "New York Giants, National League, 1885-1957", _
-                            "Washington Senators, American League, 1901-1960" + vbCrLf }  
-      Dim pattern As String = "^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+\r?\Z"
+    Public Sub Main()
+        Dim inputs() As String = {"Brooklyn Dodgers, National League, 1911, 1912, 1932-1957",
+                              "Chicago Cubs, National League, 1903-present" + vbCrLf,
+                              "Detroit Tigers, American League, 1901-present" + vbLf,
+                              "New York Giants, National League, 1885-1957",
+                              "Washington Senators, American League, 1901-1960" + vbCrLf}
+        Dim pattern As String = "^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+\r?\Z"
 
-      For Each input As String In inputs
-         If input.Length > 70 Or Not input.Contains(",") Then Continue For
-         
-         Console.WriteLine(Regex.Escape(input))
-         Dim match As Match = Regex.Match(input, pattern)
-         If match.Success Then
-            Console.WriteLine("   Match succeeded.")
-         Else
-            Console.WriteLine("   Match failed.")
-         End If
-      Next   
-   End Sub
+        For Each input As String In inputs
+            Console.WriteLine(Regex.Escape(input))
+            Dim match As Match = Regex.Match(input, pattern)
+            If match.Success Then
+                Console.WriteLine("   Match succeeded.")
+            Else
+                Console.WriteLine("   Match failed.")
+            End If
+        Next
+    End Sub
 End Module
 ' The example displays the following output:
 '    Brooklyn\ Dodgers,\ National\ League,\ 1911,\ 1912,\ 1932-1957

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/endofstring3.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/endofstring3.vb
@@ -5,26 +5,24 @@ Option Strict On
 Imports System.Text.RegularExpressions
 
 Module Example
-   Public Sub Main()
-      Dim inputs() As String = { "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957",  _
-                            "Chicago Cubs, National League, 1903-present" + vbCrLf, _
-                            "Detroit Tigers, American League, 1901-present" + vbLf, _
-                            "New York Giants, National League, 1885-1957", _
-                            "Washington Senators, American League, 1901-1960" + vbCrLf }  
-      Dim pattern As String = "^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+\r?\z"
+    Public Sub Main()
+        Dim inputs() As String = {"Brooklyn Dodgers, National League, 1911, 1912, 1932-1957",
+                              "Chicago Cubs, National League, 1903-present" + vbCrLf,
+                              "Detroit Tigers, American League, 1901-present" + vbLf,
+                              "New York Giants, National League, 1885-1957",
+                              "Washington Senators, American League, 1901-1960" + vbCrLf}
+        Dim pattern As String = "^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+\r?\z"
 
-      For Each input As String In inputs
-         If input.Length > 70 Or Not input.Contains(",") Then Continue For
-
-         Console.WriteLine(Regex.Escape(input))
-         Dim match As Match = Regex.Match(input, pattern)
-         If match.Success Then
-            Console.WriteLine("   Match succeeded.")
-         Else
-            Console.WriteLine("   Match failed.")
-         End If
-      Next   
-   End Sub
+        For Each input As String In inputs
+            Console.WriteLine(Regex.Escape(input))
+            Dim match As Match = Regex.Match(input, pattern)
+            If match.Success Then
+                Console.WriteLine("   Match succeeded.")
+            Else
+                Console.WriteLine("   Match failed.")
+            End If
+        Next
+    End Sub
 End Module
 ' The example displays the following output:
 '    Brooklyn\ Dodgers,\ National\ League,\ 1911,\ 1912,\ 1932-1957

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/nonword1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/nonword1.vb
@@ -5,14 +5,14 @@ Option Strict On
 Imports System.Text.RegularExpressions
 
 Module Example
-   Public Sub Main()
-      Dim input As String = "equity queen equip acquaint quiet"
-      Dim pattern As String = "\Bqu\w+"
-      For Each match As Match In Regex.Matches(input, pattern)
-         Console.WriteLine("'{0}' found at position {1}", _
-                           match.Value, match.Index)
-      Next
-   End Sub
+    Public Sub Main()
+        Dim input As String = "equity queen equip acquaint quiet"
+        Dim pattern As String = "\Bqu\w+"
+        For Each match As Match In Regex.Matches(input, pattern)
+            Console.WriteLine("'{0}' found at position {1}",
+                              match.Value, match.Index)
+        Next
+    End Sub
 End Module
 ' The example displays the following output:
 '       'quity' found at position 1

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/startofstring1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/startofstring1.vb
@@ -5,65 +5,40 @@ Option Strict On
 Imports System.Text.RegularExpressions
 
 Module Example
-   Public Sub Main()
-      Dim startPos As Integer = 0
-      Dim endPos As Integer = 70
-      Dim input As String = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957" + vbCrLf + _
-                            "Chicago Cubs, National League, 1903-present" + vbCrLf + _
-                            "Detroit Tigers, American League, 1901-present" + vbCrLf + _
-                            "New York Giants, National League, 1885-1957" + vbCrLf + _
-                            "Washington Senators, American League, 1901-1960" + vbCrLf  
+    Public Sub Main()
+        Dim input As String = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957" + vbCrLf +
+                              "Chicago Cubs, National League, 1903-present" + vbCrLf +
+                              "Detroit Tigers, American League, 1901-present" + vbCrLf +
+                              "New York Giants, National League, 1885-1957" + vbCrLf +
+                              "Washington Senators, American League, 1901-1960" + vbCrLf
 
-      Dim pattern As String = "^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+"
-      Dim match As Match
-      
-      ' Provide minimal validation in the event the input is invalid.
-      If input.Substring(startPos, endPos).Contains(",") Then
-         match = Regex.Match(input, pattern)
-         Do While match.Success
-            Console.Write("The {0} played in the {1} in", _
+        Dim pattern As String = "^((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+"
+        Dim match As Match
+
+        match = Regex.Match(input, pattern)
+        Do While match.Success
+            Console.Write("The {0} played in the {1} in",
                               match.Groups(1).Value, match.Groups(4).Value)
             For Each capture As Capture In match.Groups(5).Captures
-               Console.Write(capture.Value)
+                Console.Write(capture.Value)
             Next
             Console.WriteLine(".")
-            startPos = match.Index + match.Length 
-            endPos = CInt(IIf(startPos + 70 <= input.Length, 70, input.Length - startPos))
-            If Not input.Substring(startPos, endPos).Contains(",") Then Exit Do
-            match = match.NextMatch()            
-         Loop
-         Console.WriteLine()                               
-      End If      
+            match = match.NextMatch()
+        Loop
+        Console.WriteLine()
 
-      startPos = 0
-      endPos = 70
-      If input.Substring(startPos, endPos).Contains(",") Then
-         match = Regex.Match(input, pattern, RegexOptions.Multiline)
-         Do While match.Success
-            Console.Write("The {0} played in the {1} in", _
+        match = Regex.Match(input, pattern, RegexOptions.Multiline)
+        Do While match.Success
+            Console.Write("The {0} played in the {1} in",
                               match.Groups(1).Value, match.Groups(4).Value)
             For Each capture As Capture In match.Groups(5).Captures
-               Console.Write(capture.Value)
+                Console.Write(capture.Value)
             Next
             Console.WriteLine(".")
-            startPos = match.Index + match.Length 
-            endPos = CInt(IIf(startPos + 70 <= input.Length, 70, input.Length - startPos))
-            If Not input.Substring(startPos, endPos).Contains(",") Then Exit Do
-            match = match.NextMatch()            
-         Loop
-         Console.WriteLine()                               
-      End If      
-
-      
-'       For Each match As Match in Regex.Matches(input, pattern, RegexOptions.Multiline)
-'          Console.Write("The {0} played in the {1} in", _
-'                            match.Groups(1).Value, match.Groups(4).Value)
-'          For Each capture As Capture In match.Groups(5).Captures
-'             Console.Write(capture.Value)
-'          Next
-'          Console.WriteLine(".")
-'       Next
-   End Sub
+            match = match.NextMatch()
+        Loop
+        Console.WriteLine()
+    End Sub
 End Module
 ' The example displays the following output:
 '    The Brooklyn Dodgers played in the National League in 1911, 1912, 1932-1957.

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/startofstring2.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/startofstring2.vb
@@ -5,36 +5,27 @@ Option Strict On
 Imports System.Text.RegularExpressions
 
 Module Example
-   Public Sub Main()
-      Dim startPos As Integer = 0
-      Dim endPos As Integer = 70
-      Dim input As String = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957" + vbCrLf + _
-                            "Chicago Cubs, National League, 1903-present" + vbCrLf + _
-                            "Detroit Tigers, American League, 1901-present" + vbCrLf + _
-                            "New York Giants, National League, 1885-1957" + vbCrLf + _
-                            "Washington Senators, American League, 1901-1960" + vbCrLf  
+    Public Sub Main()
+        Dim input As String = "Brooklyn Dodgers, National League, 1911, 1912, 1932-1957" + vbCrLf +
+                            "Chicago Cubs, National League, 1903-present" + vbCrLf +
+                            "Detroit Tigers, American League, 1901-present" + vbCrLf +
+                            "New York Giants, National League, 1885-1957" + vbCrLf +
+                            "Washington Senators, American League, 1901-1960" + vbCrLf
 
-      Dim pattern As String = "\A((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+"
-      Dim match As Match
-      
-      ' Provide minimal validation in the event the input is invalid.
-      If input.Substring(startPos, endPos).Contains(",") Then
-         match = Regex.Match(input, pattern, RegexOptions.Multiline)
-         Do While match.Success
-            Console.Write("The {0} played in the {1} in", _
+        Dim pattern As String = "\A((\w+(\s?)){2,}),\s(\w+\s\w+),(\s\d{4}(-(\d{4}|present))?,?)+"
+
+        Dim match As Match = Regex.Match(input, pattern, RegexOptions.Multiline)
+        Do While match.Success
+            Console.Write("The {0} played in the {1} in",
                               match.Groups(1).Value, match.Groups(4).Value)
             For Each capture As Capture In match.Groups(5).Captures
-               Console.Write(capture.Value)
+                Console.Write(capture.Value)
             Next
             Console.WriteLine(".")
-            startPos = match.Index + match.Length 
-            endPos = CInt(IIf(startPos + 70 <= input.Length, 70, input.Length - startPos))
-            If Not input.Substring(startPos, endPos).Contains(",") Then Exit Do
-            match = match.NextMatch()            
-         Loop
-         Console.WriteLine()                               
-      End If      
-   End Sub   
+            match = match.NextMatch()
+        Loop
+        Console.WriteLine()
+    End Sub
 End Module
 ' The example displays the following output:
 '    The Brooklyn Dodgers played in the National League in 1911, 1912, 1932-1957.

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/word1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.assertions/vb/word1.vb
@@ -5,15 +5,15 @@ Option Strict On
 Imports System.Text.RegularExpressions
 
 Module Example
-   Public Sub Main()
-      Dim input As String = "area bare arena mare"
-      Dim pattern As String = "\bare\w*\b"
-      Console.WriteLine("Words that begin with 'are':")
-      For Each match As Match In Regex.Matches(input, pattern)
-         Console.WriteLine("'{0}' found at position {1}", _
-                           match.Value, match.Index)
-      Next
-   End Sub
+    Public Sub Main()
+        Dim input As String = "area bare arena mare"
+        Dim pattern As String = "\bare\w*\b"
+        Console.WriteLine("Words that begin with 'are':")
+        For Each match As Match In Regex.Matches(input, pattern)
+            Console.WriteLine("'{0}' found at position {1}",
+                              match.Value, match.Index)
+        Next
+    End Sub
 End Module
 ' The example displays the following output:
 '       Words that begin with 'are':


### PR DESCRIPTION
Meaningless condition, repeated with `match.Succes`

## Summary

removed startPos endPos and if