### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/sample-issue.md
+++ b/.github/ISSUE_TEMPLATE/sample-issue.md
@@ -1,0 +1,33 @@
+---
+name: Doc sample issue
+about: Create an issue to help us improve
+
+---
+
+**Before you open an issue**
+
+If the issue is:
+
+- A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
+
+**Issue description**
+
+[&lt;]include description here]
+
+**Target framework**
+
+Check the .NET target framework(s) being used, and include the version number(s).
+
+- [ ] .NET Core
+- [ ] .NET Framework
+- [ ] .NET Standard
+
+If using the .NET Core SDK, include `dotnet --info` output. If using .NET Framework without the .NET Core SDK, include info from Visual Studio's **Help** > **About Microsoft Visual Studio** dialog.
+
+<details>
+<summary><strong>dotnet --info output</strong> or <strong>About VS info</strong></summary>
+
+```console
+<replace>
+```
+</details>

--- a/.github/ISSUE_TEMPLATE/sample-update-request.md
+++ b/.github/ISSUE_TEMPLATE/sample-update-request.md
@@ -17,41 +17,7 @@ Text in brackets are placeholders; replace the text with the requested informati
 
 [Brief description of the change]
 
-### Change description
-
-#### Old behavior
-
-#### New behavior
-
-#### Reason for change
-
-### Category
-
-[Choose a category from one of the following:
-
-- ASP.NET Core
-- C#
-- Core
-- CoreFx
-- Data
-- Debugger
-- Deployment for .NET Core
-- EF Core
-- Globalization
-- interop
-- JIT
-- LINQ
-- Managed Extensibility Framework (MEF)
-- MSBuild
-- Networking
-- Printing
-- Security
-- Serialization
-- Visual Basic
-- Windows Forms
-- Windows Presentation Foundation (WPF)
-- XML, XSLT
-]
+[Describe the outdated practice and what would be preferred for modern code]
 
 [What article (in dotnet/docs or dotnet/dotnet-api-docs) uses this sample?]
 

--- a/.github/ISSUE_TEMPLATE/sample-update-request.md
+++ b/.github/ISSUE_TEMPLATE/sample-update-request.md
@@ -1,0 +1,63 @@
+---
+name: Sample code update request
+about: Report when a sample does not match current coding guidelines
+
+---
+<!--
+This issue template is for use in opening issues that describe outdated coding practices in our samples. This template can be used to create an issue:
+
+- By Microsoft product team members who notice outdated coding practices.
+
+- By Microsoft customers who find that the sample style does not match current practices.
+
+Text in brackets are placeholders; replace the text with the requested information and remove the brackets before submitting the issue. Also, remove this comment before submitting the issue.
+
+-->
+## [Change Title]
+
+[Brief description of the change]
+
+### Change description
+
+#### Old behavior
+
+#### New behavior
+
+#### Reason for change
+
+### Category
+
+[Choose a category from one of the following:
+
+- ASP.NET Core
+- C#
+- Core
+- CoreFx
+- Data
+- Debugger
+- Deployment for .NET Core
+- EF Core
+- Globalization
+- interop
+- JIT
+- LINQ
+- Managed Extensibility Framework (MEF)
+- MSBuild
+- Networking
+- Printing
+- Security
+- Serialization
+- Visual Basic
+- Windows Forms
+- Windows Presentation Foundation (WPF)
+- XML, XSLT
+]
+
+[What article (in dotnet/docs or dotnet/dotnet-api-docs) uses this sample?]
+
+<!-- Do not modify anything below this line -->
+
+---
+#### Issue metadata
+
+* Issue type: sample-update


### PR DESCRIPTION
For dependabot to work correclty, it uses GitHub issues.

This PR adds initial templates to guide readers to create useful issues.
