### PR TITLE
Follow coding conventions

### DIFF
--- a/snippets/standard/datetime/json/custom-reading-with-utf8jsonreader.cs
+++ b/snippets/standard/datetime/json/custom-reading-with-utf8jsonreader.cs
@@ -9,7 +9,7 @@ public class Example
     {
         byte[] utf8Data = Encoding.UTF8.GetBytes(@"""Friday, 26 July 2019 00:00:00""");
 
-        Utf8JsonReader json = new Utf8JsonReader(utf8Data);
+        var json = new Utf8JsonReader(utf8Data);
         while (json.Read())
         {
             if (json.TokenType == JsonTokenType.String)

--- a/snippets/standard/datetime/json/custom-writing-with-utf8jsonwriter.cs
+++ b/snippets/standard/datetime/json/custom-writing-with-utf8jsonwriter.cs
@@ -31,7 +31,7 @@ public class Example
     }
 }
 
-// The example similar output to the following:
+// The example displays output similar to the following:
 // {
 //     "date": "Tuesday, 27 August 2019 19:21:44",
 //     "temp": 42

--- a/snippets/standard/datetime/json/custom-writing-with-utf8jsonwriter.cs
+++ b/snippets/standard/datetime/json/custom-writing-with-utf8jsonwriter.cs
@@ -8,14 +8,14 @@ public class Example
 {
     public static void Main(string[] args)
     {
-        JsonWriterOptions options = new JsonWriterOptions
+        var options = new JsonWriterOptions
         {
             Indented = true
         };
 
-        using (MemoryStream stream = new MemoryStream())
+        using (var stream = new MemoryStream())
         {
-            using (Utf8JsonWriter writer = new Utf8JsonWriter(stream, options))
+            using (var writer = new Utf8JsonWriter(stream, options))
             {
                 string dateStr = DateTime.UtcNow.ToString("F", CultureInfo.InvariantCulture);
 
@@ -31,7 +31,7 @@ public class Example
     }
 }
 
-// The example displays the following output:
+// The example similar output to the following:
 // {
 //     "date": "Tuesday, 27 August 2019 19:21:44",
 //     "temp": 42


### PR DESCRIPTION
- Used `var`
- Changed `The example displays the following output:` to `The example similar output to the following:` because the output depends on the current time of running the code.