### PR TITLE
change Split call to a char argument

### DIFF
--- a/csharp/tutorials/exploration/csharp6-finished/Program.cs
+++ b/csharp/tutorials/exploration/csharp6-finished/Program.cs
@@ -42,7 +42,7 @@ public class Program
         // </SnippetInterpolationMain>
         // <SnippetPhrases>
         var phrase = "the quick brown fox jumps over the lazy dog";
-        var wordLength = from word in phrase.Split(" ") select word.Length;
+        var wordLength = from word in phrase.Split(' ') select word.Length;
         var average = wordLength.Average();
         WriteLine(average);
         // </SnippetPhrases>


### PR DESCRIPTION
The interactive scripting environment doesn't support the string overload.  See https://github.com/dotnet/docs/issues/14226#issuecomment-528387904

