### PR TITLE
Move P/Invokes to NativeMethods class - structures

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR/conceptual.interop.marshaling/cpp/structures.cpp
+++ b/snippets/cpp/VS_Snippets_CLR/conceptual.interop.marshaling/cpp/structures.cpp
@@ -4,7 +4,7 @@ using namespace System::Runtime::InteropServices;
 
 //<snippet23>
 // Declares a managed structure for each unmanaged structure.
-[StructLayout(LayoutKind::Sequential, CharSet=CharSet::Ansi)]
+[StructLayout(LayoutKind::Sequential, CharSet = CharSet::Ansi)]
 public value struct MyPerson
 {
 public:
@@ -33,11 +33,11 @@ public value struct MyArrayStruct
 {
 public:
     bool flag;
-    [MarshalAs(UnmanagedType::ByValArray, SizeConst=3)]
+    [MarshalAs(UnmanagedType::ByValArray, SizeConst = 3)]
     array<int>^ vals;
 };
 
-public ref class LibWrap
+private ref class NativeMethods
 {
 public:
     // Declares a managed prototype for unmanaged function.
@@ -75,11 +75,11 @@ public:
         Console::WriteLine("first = {0}, last = {1}, age = {2}",
             personName.first, personName.last, personAll.age);
 
-        int res = LibWrap::TestStructInStruct(personAll);
+        int res = NativeMethods::TestStructInStruct(personAll);
 
         MyPerson personRes =
             (MyPerson)Marshal::PtrToStructure(personAll.person,
-            MyPerson::typeid);
+                MyPerson::typeid);
 
         Marshal::FreeCoTaskMem(buffer);
 
@@ -92,7 +92,7 @@ public:
         person3.person.first = "John";
         person3.person.last = "Evans";
         person3.age = 27;
-        LibWrap::TestStructInStruct3(person3);
+        NativeMethods::TestStructInStruct3(person3);
 
         // Structure with an embedded array.
         MyArrayStruct myStruct;// = new MyArrayStruct();
@@ -108,7 +108,7 @@ public:
         Console::WriteLine("{0} {1} {2}", myStruct.vals[0],
             myStruct.vals[1], myStruct.vals[2]);
 
-        LibWrap::TestArrayInStruct(myStruct);
+        NativeMethods::TestArrayInStruct(myStruct);
         Console::WriteLine("\nStructure with array after call:");
         Console::WriteLine(myStruct.flag);
         Console::WriteLine("{0} {1} {2}", myStruct.vals[0],

--- a/snippets/csharp/VS_Snippets_CLR/conceptual.interop.marshaling/cs/structures.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.interop.marshaling/cs/structures.cs
@@ -34,17 +34,17 @@ public struct MyArrayStruct
     public int[] vals;
 }
 
-public class LibWrap
+internal static class NativeMethods
 {
     // Declares a managed prototype for unmanaged function.
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestStructInStruct(ref MyPerson2 person2);
+    internal static extern int TestStructInStruct(ref MyPerson2 person2);
 
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestStructInStruct3(MyPerson3 person3);
+    internal static extern int TestStructInStruct3(MyPerson3 person3);
 
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestArrayInStruct(ref MyArrayStruct myStruct);
+    internal static extern int TestArrayInStruct(ref MyArrayStruct myStruct);
 }
 //</snippet23>
 
@@ -70,7 +70,7 @@ public class App
         Console.WriteLine("first = {0}, last = {1}, age = {2}",
             personName.first, personName.last, personAll.age);
 
-        int res = LibWrap.TestStructInStruct(ref personAll);
+        int res = NativeMethods.TestStructInStruct(ref personAll);
 
         MyPerson personRes =
             (MyPerson)Marshal.PtrToStructure(personAll.person,
@@ -87,7 +87,7 @@ public class App
         person3.person.first = "John";
         person3.person.last = "Evans";
         person3.age = 27;
-        LibWrap.TestStructInStruct3(person3);
+        NativeMethods.TestStructInStruct3(person3);
 
         // Structure with an embedded array.
         MyArrayStruct myStruct = new MyArrayStruct();
@@ -103,7 +103,7 @@ public class App
         Console.WriteLine("{0} {1} {2}", myStruct.vals[0],
             myStruct.vals[1], myStruct.vals[2]);
 
-        LibWrap.TestArrayInStruct(ref myStruct);
+        NativeMethods.TestArrayInStruct(ref myStruct);
         Console.WriteLine("\nStructure with array after call:");
         Console.WriteLine(myStruct.flag);
         Console.WriteLine("{0} {1} {2}", myStruct.vals[0],

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.interop.marshaling/vb/structures.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.interop.marshaling/vb/structures.vb
@@ -28,20 +28,20 @@ Public Structure MyArrayStruct
     Public vals As Integer()
 End Structure 'MyArrayStruct
 
-Public Class LibWrap
+Friend Class NativeMethods
     ' Declares managed prototypes for unmanaged functions.
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestStructInStruct(
+    Friend Shared Function TestStructInStruct(
         ByRef person2 As MyPerson2) As Integer
     End Function
 
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestStructInStruct3(
+    Friend Shared Function TestStructInStruct3(
         ByVal person3 As MyPerson3) As Integer
     End Function
 
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestArrayInStruct(
+    Friend Shared Function TestArrayInStruct(
         ByRef myStruct As MyArrayStruct) As Integer
     End Function
 End Class 'LibWrap
@@ -69,7 +69,7 @@ Public Class App
         Console.WriteLine("first = {0}, last = {1}, age = {2}",
             personName.first, personName.last, personAll.age)
 
-        Dim res As Integer = LibWrap.TestStructInStruct(personAll)
+        Dim res As Integer = NativeMethods.TestStructInStruct(personAll)
 
         Dim personRes As MyPerson =
             CType(Marshal.PtrToStructure(personAll.person,
@@ -87,7 +87,7 @@ Public Class App
         person3.person.first = "John"
         person3.person.last = "Evans"
         person3.age = 27
-        LibWrap.TestStructInStruct3(person3)
+        NativeMethods.TestStructInStruct3(person3)
 
         ' Structure with an embedded array.
         Dim myStruct As New MyArrayStruct()
@@ -104,7 +104,7 @@ Public Class App
         Console.WriteLine("{0} {1} {2}", myStruct.vals(0),
             myStruct.vals(1), myStruct.vals(2))
 
-        LibWrap.TestArrayInStruct(myStruct)
+        NativeMethods.TestArrayInStruct(myStruct)
         Console.WriteLine(vbNewLine + "Structure with array after call:")
         Console.WriteLine(myStruct.flag)
         Console.WriteLine("{0} {1} {2}", myStruct.vals(0),


### PR DESCRIPTION
Contributes to dotnet/docs#11396

The C++ example seems to have adopted the old-style 80-word line length limit. Do we have a new style?