### PR TITLE
Move P/Invokes to NativeMethods class - arrays

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/conceptual.interop.marshaling/cs/arrays.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.interop.marshaling/cs/arrays.cs
@@ -29,12 +29,12 @@ public struct MyPerson
     }
 }
 
-public class LibWrap
+internal static class NativeMethods
 {
     // Declares a managed prototype for an array of integers by value.
     // The array size cannot be changed, but the array is copied back.
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestArrayOfInts(
+    internal static extern int TestArrayOfInts(
         [In, Out] int[] array, int size);
 
     // Declares a managed prototype for an array of integers by reference.
@@ -42,27 +42,27 @@ public class LibWrap
     // automatically because the marshaler does not know the resulting size.
     // The copy must be performed manually.
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestRefArrayOfInts(
+    internal static extern int TestRefArrayOfInts(
         ref IntPtr array, ref int size);
 
     // Declares a managed prototype for a matrix of integers by value.
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestMatrixOfInts(
+    internal static extern int TestMatrixOfInts(
         [In, Out] int[,] pMatrix, int row);
 
     // Declares a managed prototype for an array of strings by value.
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestArrayOfstrings(
+    internal static extern int TestArrayOfstrings(
         [In, Out] string[] stringArray, int size);
 
     // Declares a managed prototype for an array of structures with integers.
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestArrayOfStructs(
+    internal static extern int TestArrayOfStructs(
         [In, Out] MyPoint[] pointArray, int size);
 
     // Declares a managed prototype for an array of structures with strings.
     [DllImport("..\\LIB\\PinvokeLib.dll", CallingConvention = CallingConvention.Cdecl)]
-    public static extern int TestArrayOfStructs2(
+    internal static extern int TestArrayOfStructs2(
         [In, Out] MyPerson[] personArray, int size);
 }
 //</Snippet31>
@@ -81,7 +81,7 @@ public class App
             Console.Write(" " + array1[i]);
         }
 
-        int sum1 = LibWrap.TestArrayOfInts(array1, array1.Length);
+        int sum1 = NativeMethods.TestArrayOfInts(array1, array1.Length);
         Console.WriteLine("\nSum of elements:" + sum1);
         Console.WriteLine("\nInteger array passed ByVal after call:");
 
@@ -104,7 +104,7 @@ public class App
            * array2.Length);
         Marshal.Copy(array2, 0, buffer, array2.Length);
 
-        int sum2 = LibWrap.TestRefArrayOfInts(ref buffer, ref size);
+        int sum2 = NativeMethods.TestRefArrayOfInts(ref buffer, ref size);
         Console.WriteLine("\nSum of elements:" + sum2);
         if (size > 0)
         {
@@ -138,7 +138,7 @@ public class App
             Console.WriteLine("");
         }
 
-        int sum3 = LibWrap.TestMatrixOfInts(matrix, DIM);
+        int sum3 = NativeMethods.TestMatrixOfInts(matrix, DIM);
         Console.WriteLine("\nSum of elements:" + sum3);
         Console.WriteLine("\nMatrix after call:");
         for (int i = 0; i < DIM; i++)
@@ -159,7 +159,7 @@ public class App
             Console.Write(" " + s);
         }
 
-        int lenSum = LibWrap.TestArrayOfstrings(strArray, strArray.Length);
+        int lenSum = NativeMethods.TestArrayOfstrings(strArray, strArray.Length);
         Console.WriteLine("\nSum of string lengths:" + lenSum);
         Console.WriteLine("\nstring array after call:");
         foreach (string s in strArray)
@@ -175,7 +175,7 @@ public class App
             Console.WriteLine($"X = {p.X}, Y = {p.Y}");
         }
 
-        int allSum = LibWrap.TestArrayOfStructs(points, points.Length);
+        int allSum = NativeMethods.TestArrayOfStructs(points, points.Length);
         Console.WriteLine("\nSum of points:" + allSum);
         Console.WriteLine("\nPoints array after call:");
         foreach (MyPoint p in points)
@@ -197,7 +197,7 @@ public class App
             Console.WriteLine($"First = {pe.First}, Last = {pe.Last}");
         }
 
-        int namesSum = LibWrap.TestArrayOfStructs2(persons, persons.Length);
+        int namesSum = NativeMethods.TestArrayOfStructs2(persons, persons.Length);
         Console.WriteLine("\nSum of name lengths:" + namesSum);
         Console.WriteLine("\n\nPersons array after call:");
         foreach (MyPerson pe in persons)

--- a/snippets/visualbasic/VS_Snippets_CLR/conceptual.interop.marshaling/vb/arrays.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/conceptual.interop.marshaling/vb/arrays.vb
@@ -22,11 +22,11 @@ Public Structure MyPerson
     End Sub 'New
 End Structure
 
-Public Class LibWrap
+Friend Class NativeMethods
     ' Declares a managed prototype for an array of integers by value.
     ' The array size cannot be changed, but the array is copied back.
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestArrayOfInts(
+    Friend Shared Function TestArrayOfInts(
         <[In], Out> ByVal myArray() As Integer, ByVal size As Integer) _
         As Integer
     End Function
@@ -36,20 +36,20 @@ Public Class LibWrap
     ' automatically because the marshaler does not know the resulting size.
     ' The copy must be performed manually.
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestRefArrayOfInts(
+    Friend Shared Function TestRefArrayOfInts(
         ByRef myArray As IntPtr, ByRef size As Integer) As Integer
     End Function
 
     ' Declares a managed prototype for a matrix of integers by value.
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestMatrixOfInts(
+    Friend Shared Function TestMatrixOfInts(
         <[In], Out> ByVal matrix(,) As Integer, ByVal row As Integer) _
         As Integer
     End Function
 
     ' Declares a managed prototype for an array of strings by value.
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestArrayOfStrings(
+    Friend Shared Function TestArrayOfStrings(
         <[In], Out> ByVal strArray() As String, ByVal size As Integer) _
         As Integer
     End Function
@@ -57,14 +57,14 @@ Public Class LibWrap
     ' Declares a managed prototype for an array of structures with 
     ' integers.
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestArrayOfStructs(
+    Friend Shared Function TestArrayOfStructs(
         <[In], Out> ByVal pointArray() As MyPoint, ByVal size As Integer) _
         As Integer
     End Function
 
     ' Declares a managed prototype for an array of structures with strings.
     <DllImport("..\LIB\PinvokeLib.dll", CallingConvention:=CallingConvention.Cdecl)>
-    Shared Function TestArrayOfStructs2(
+    Friend Shared Function TestArrayOfStructs2(
         <[In], Out> ByVal personArray() As MyPerson, ByVal size As Integer) _
         As Integer
     End Function
@@ -84,7 +84,7 @@ Public Class App
             Console.Write(" " & array1(i))
         Next i
 
-        Dim sum1 As Integer = LibWrap.TestArrayOfInts(array1, array1.Length)
+        Dim sum1 As Integer = NativeMethods.TestArrayOfInts(array1, array1.Length)
         Console.WriteLine(ControlChars.CrLf & "Sum of elements:" & sum1)
         Console.WriteLine(ControlChars.CrLf & "Integer array passed ByVal after call:")
         For Each i In array1
@@ -103,7 +103,7 @@ Public Class App
         Dim buffer As IntPtr = Marshal.AllocCoTaskMem(Marshal.SizeOf(
             arraySize) * array2.Length)
         Marshal.Copy(array2, 0, buffer, array2.Length)
-        Dim sum2 As Integer = LibWrap.TestRefArrayOfInts(buffer,
+        Dim sum2 As Integer = NativeMethods.TestRefArrayOfInts(buffer,
             arraySize)
         Console.WriteLine(ControlChars.CrLf & "Sum of elements:" & sum2)
 
@@ -135,7 +135,7 @@ Public Class App
             Console.WriteLine("")
         Next i
 
-        Dim sum3 As Integer = LibWrap.TestMatrixOfInts(matrix, [DIM] + 1)
+        Dim sum3 As Integer = NativeMethods.TestMatrixOfInts(matrix, [DIM] + 1)
         Console.WriteLine(ControlChars.CrLf & "Sum of elements:" & sum3)
         Console.WriteLine(ControlChars.CrLf & "Matrix after call:")
         For i = 0 To [DIM]
@@ -155,7 +155,7 @@ Public Class App
         For Each s In strArray
             Console.Write(" " & s)
         Next s
-        Dim lenSum As Integer = LibWrap.TestArrayOfStrings(
+        Dim lenSum As Integer = NativeMethods.TestArrayOfStrings(
             strArray, strArray.Length)
         Console.WriteLine(ControlChars.CrLf &
             "Sum of string lengths:" & lenSum)
@@ -173,7 +173,7 @@ Public Class App
         For Each p In points
             Console.WriteLine($"x = {p.x}, y = {p.y}")
         Next p
-        Dim allSum As Integer = LibWrap.TestArrayOfStructs(points,
+        Dim allSum As Integer = NativeMethods.TestArrayOfStructs(points,
             points.Length)
         Console.WriteLine(ControlChars.CrLf & "Sum of points:" & allSum)
         Console.WriteLine(ControlChars.CrLf & "Points array after call:")
@@ -192,7 +192,7 @@ Public Class App
             Console.WriteLine($"first = {pe.first}, last = {pe.last}")
         Next pe
 
-        Dim namesSum As Integer = LibWrap.TestArrayOfStructs2(persons,
+        Dim namesSum As Integer = NativeMethods.TestArrayOfStructs2(persons,
             persons.Length)
         Console.WriteLine(ControlChars.CrLf & "Sum of name lengths:" &
             namesSum)


### PR DESCRIPTION
Contributes to dotnet/docs#11396

The corresponding C++ example is missing.