### PR TITLE
Add missing whitespace in comments

### DIFF
--- a/snippets/cpp/VS_Snippets_Remoting/SerializationAttributes/CPP/s.cpp
+++ b/snippets/cpp/VS_Snippets_Remoting/SerializationAttributes/CPP/s.cpp
@@ -48,27 +48,26 @@ public:
 
 int main()
 {
-   
-   //Creates a new TestSimpleObject object.
+   // Creates a new TestSimpleObject object.
    TestSimpleObject^ obj = gcnew TestSimpleObject;
    Console::WriteLine( "Before serialization the Object* contains: " );
    obj->Print();
-   
-   //Opens a file and serializes the object into it in binary format.
+
+   // Opens a file and serializes the object into it in binary format.
    Stream^ stream = File::Open( "data.xml", FileMode::Create );
    SoapFormatter^ formatter = gcnew SoapFormatter;
-   
+
    //BinaryFormatter* formatter = new BinaryFormatter();
    formatter->Serialize( stream, obj );
    stream->Close();
-   
-   //Empties obj.
+
+   // Empties obj.
    obj = nullptr;
-   
-   //Opens file S"data.xml" and deserializes the object from it.
+
+   // Opens file S"data.xml" and deserializes the object from it.
    stream = File::Open( "data.xml", FileMode::Open );
    formatter = gcnew SoapFormatter;
-   
+
    //formatter = new BinaryFormatter();
    obj = dynamic_cast<TestSimpleObject^>(formatter->Deserialize( stream ));
    stream->Close();

--- a/snippets/csharp/VS_Snippets_Remoting/SerializationAttributes/CS/s.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/SerializationAttributes/CS/s.cs
@@ -8,13 +8,13 @@ using System.Runtime.Serialization.Formatters.Soap;
 public class Test {
    public static void Main()  {
 
-      //Creates a new TestSimpleObject object.
+      // Creates a new TestSimpleObject object.
       TestSimpleObject obj = new TestSimpleObject();
 
       Console.WriteLine("Before serialization the object contains: ");
       obj.Print();
 
-      //Opens a file and serializes the object into it in binary format.
+      // Opens a file and serializes the object into it in binary format.
       Stream stream = File.Open("data.xml", FileMode.Create);
       SoapFormatter formatter = new SoapFormatter();
 
@@ -22,11 +22,11 @@ public class Test {
 
       formatter.Serialize(stream, obj);
       stream.Close();
-   
-      //Empties obj.
+
+      // Empties obj.
       obj = null;
-   
-      //Opens file "data.xml" and deserializes the object from it.
+
+      // Opens file "data.xml" and deserializes the object from it.
       stream = File.Open("data.xml", FileMode.Open);
       formatter = new SoapFormatter();
 
@@ -43,17 +43,17 @@ public class Test {
 
 
 // A test object that needs to be serialized.
-[Serializable()]		
+[Serializable()]
 public class TestSimpleObject  {
 
     public int member1;
     public string member2;
     public string member3;
     public double member4;
-    
+
     // A field that is not serialized.
-    [NonSerialized()] public string member5; 
-    
+    [NonSerialized()] public string member5;
+
     public TestSimpleObject() {
 
         member1 = 11;


### PR DESCRIPTION
I happened to note these when looking at [the docs](https://docs.microsoft.com/en-us/dotnet/api/system.serializableattribute?view=netframework-4.8) for `[SerializationAttribute]`.

(The whitespace on empty lines was removed on VS Code automatically since I have "strip trailing whitespace" enabled I think; please let me know if you want me to revert that part.)