### PR TITLE
Fix `\n` in visual basic code

### DIFF
--- a/snippets/core/deploying/vb/deployment-example.vb
+++ b/snippets/core/deploying/vb/deployment-example.vb
@@ -7,7 +7,7 @@ Namespace Applications.ConsoleApps
             Console.WriteLine()
             Dim s = Console.ReadLine()
             ShowWords(s)
-            Console.Write("\nPress any key to continue... ")
+            Console.Write($"{vbCrLf}Press any key to continue... ")
             Console.ReadKey()
         End Sub
 

--- a/snippets/visualbasic/VS_Snippets_CLR/Process_GetProcessesByName2_2/VB/process_getprocessesbyname2_2.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/Process_GetProcessesByName2_2/VB/process_getprocessesbyname2_2.vb
@@ -45,11 +45,11 @@ Class GetProcessesByNameClass
         Catch e As PlatformNotSupportedException
             Console.WriteLine(
                 "Finding notepad processes on remote computers " &
-                "is not supported on this operating system.");
+                "is not supported on this operating system.")
         Catch e As InvalidOperationException
             Console.WriteLine("Unable to get process information on the remote computer.")
         End Try
-    End Sub 'Main
-End Class 'GetProcessesByNameClass
+    End Sub
+End Class
 ' </Snippet1>
 ' </Snippet2>

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.String.TrimStart/vb/sample.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.String.TrimStart/vb/sample.vb
@@ -51,10 +51,10 @@ Public Class TrimExample
    ' <Snippet1>
    Public Sub Main()
       ' TrimStart Examples
-      Dim lineWithLeadingSpaces as String = "   Hello World!";
-	    Dim lineWithLeadingSymbols as String = "$$$$Hello World!";
-      Dim lineWithLeadingUnderscores as String = "_____Hello World!";
-      Dim lineWithLeadingLetters as String = "xxxxHello World!";
+      Dim lineWithLeadingSpaces as String = "   Hello World!"
+	  Dim lineWithLeadingSymbols as String = "$$$$Hello World!"
+      Dim lineWithLeadingUnderscores as String = "_____Hello World!"
+      Dim lineWithLeadingLetters as String = "xxxxHello World!"
       Dim lineAfterTrimStart = String.Empty
 
       ' Make it easy to print out and work with all of the examples

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.reflection.propertyinfo.getvalue/vb/getvalue1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.reflection.propertyinfo.getvalue/vb/getvalue1.vb
@@ -31,7 +31,7 @@ End Class
 
 Module Example
    Public Sub Main()
-      Dim jupiter As New Planet("Jupiter", 3.65e08);
+      Dim jupiter As New Planet("Jupiter", 3.65e08)
       GetPropertyValues(jupiter)
    End Sub
    

--- a/snippets/visualbasic/api/system.diagnostics/process/standarderror/stderror-sync.vb
+++ b/snippets/visualbasic/api/system.diagnostics/process/standarderror/stderror-sync.vb
@@ -1,4 +1,4 @@
-﻿Imports System.Diagnostics'
+﻿Imports System.Diagnostics
 
 Public Module Example
     Public Sub Main()

--- a/snippets/visualbasic/api/system.diagnostics/process/standarderror/stderror-sync.vb
+++ b/snippets/visualbasic/api/system.diagnostics/process/standarderror/stderror-sync.vb
@@ -1,19 +1,19 @@
 ﻿Imports System.Diagnostics'
 
 Public Module Example
-   Public Sub Main()
-      Dim p As New Process()
-      p.StartInfo.UseShellExecute = False  
-      p.StartInfo.RedirectStandardError = True  
-      p.StartInfo.FileName = "Write500Lines.exe"  
-      p.Start() 
+    Public Sub Main()
+        Dim p As New Process()
+        p.StartInfo.UseShellExecute = False  
+        p.StartInfo.RedirectStandardError = True  
+        p.StartInfo.FileName = "Write500Lines.exe"  
+        p.Start() 
 
-      ' To avoid deadlocks, always read the output stream first and then wait.  
-      Dim output As String = p.StandardError.ReadToEnd()  
-      p.WaitForExit()
+        ' To avoid deadlocks, always read the output stream first and then wait.  
+        Dim output As String = p.StandardError.ReadToEnd()  
+        p.WaitForExit()
 
-      Console.WriteLine($"\nError stream: {output}");
-   End Sub
+        Console.WriteLine($"{vbCrLf}Error stream: {output}")
+    End Sub
 End Module
 ' The end of the output produced by the example includes the following:
 '      Error stream:


### PR DESCRIPTION
The `\n` will print as it is, not as a new line.

**Update:** After creating this PR, I've searched for `\n` in `.vb` files inside the whole repo and found many results. I noticed that `\t` was used in some places too instead of `vbTab`

![image](https://user-images.githubusercontent.com/31348972/64480557-22442100-d1ca-11e9-8190-9bd92792fe6c.png)

@rpetrusha , Can you confirm that the change is correct before I try to update all the occurrences ?
If that's correct, you can merge this PR until I work to fix all the `\n` occurrences.

I've also removed an extra `;` and will search if there are more occurrences in different files.