### PR TITLE
Use StreamWriter constructor available on the same targets as the used StreamReader constructor.

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/StrmReader Ctor1/CS/strmreader ctor1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StrmReader Ctor1/CS/strmreader ctor1.cs
@@ -15,7 +15,7 @@ class Test
                 File.Delete(path);
             }
 
-            using (StreamWriter sw = new StreamWriter(path))
+            using (StreamWriter sw = new StreamWriter(new FileStream(path, FileMode.CreateNew)))
             {
                 sw.WriteLine("This");
                 sw.WriteLine("is some text");


### PR DESCRIPTION
## Summary

Fixes sample code to use only available APIs.

Fixes dotnet/dotnet-api-docs#3160