### PR TITLE
new snippets

### DIFF
--- a/snippets/standard/reflection/memberinfo/gettypemembers.cpp
+++ b/snippets/standard/reflection/memberinfo/gettypemembers.cpp
@@ -1,0 +1,33 @@
+using namespace System;
+using namespace System::Reflection;
+
+ref class Asminfo1
+{
+public:
+    static void Main()
+    {
+        Console::WriteLine ("\nReflection.MemberInfo");
+
+        // Get the Type and MemberInfo.
+        // Insert the fully qualified class name inside the quotation marks in the
+        // following statement.
+        Type^ MyType = Type::GetType("System.IO.BinaryReader");
+        array<MemberInfo^>^ Mymemberinfoarray = MyType->GetMembers(BindingFlags::Public |
+            BindingFlags::NonPublic | BindingFlags::Static |
+            BindingFlags::Instance | BindingFlags::DeclaredOnly);
+
+        // Get and display the DeclaringType method.
+        Console::Write($"\nThere are {Mymemberinfoarray->Length} documentable members in ");
+        Console::Write($"{MyType->FullName}.");
+
+        for each (MemberInfo^ Mymemberinfo in Mymemberinfoarray)
+        {
+            Console::Write("\n" + Mymemberinfo->Name);
+        }
+    }
+};
+
+int main()
+{
+    Asminfo1::Main();
+}

--- a/snippets/standard/reflection/memberinfo/gettypemembers.cs
+++ b/snippets/standard/reflection/memberinfo/gettypemembers.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+
+class Asminfo1
+{
+    public static void Main()
+    {
+        Console.WriteLine ("\nReflection.MemberInfo");
+
+        // Get the Type and MemberInfo.
+        // Insert the fully qualified class name inside the quotation marks in the
+        // following statement.
+        Type MyType = Type.GetType("System.IO.BinaryReader");
+        MemberInfo[] Mymemberinfoarray = MyType.GetMembers(BindingFlags.Public |
+            BindingFlags.NonPublic | BindingFlags.Static |
+            BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        // Get and display the DeclaringType method.
+        Console.Write($"\nThere are {Mymemberinfoarray.Length} documentable members in ");
+        Console.Write($"{MyType.FullName}.");
+
+        foreach (MemberInfo Mymemberinfo in Mymemberinfoarray)
+        {
+            Console.Write("\n" + Mymemberinfo.Name);
+        }
+    }
+}

--- a/snippets/standard/reflection/memberinfo/gettypemembers.vb
+++ b/snippets/standard/reflection/memberinfo/gettypemembers.vb
@@ -1,0 +1,23 @@
+Imports System.Reflection
+
+Class Asminfo1
+    Public Shared Sub Main()
+        Console.WriteLine ("\nReflection.MemberInfo")
+
+        ' Get the Type and MemberInfo.
+        ' Insert the fully qualified class name inside the quotation marks in the
+        ' following statement.
+        Dim MyType As Type = Type.GetType("System.IO.BinaryReader")
+        Dim Mymemberinfoarray() As MemberInfo = MyType.GetMembers(BindingFlags.Public Or
+            BindingFlags.NonPublic Or BindingFlags.Static Or
+            BindingFlags.Instance Or BindingFlags.DeclaredOnly)
+
+        ' Get and display the DeclaringType method.
+        Console.Write($"\nThere are {Mymemberinfoarray.Length} documentable members in ")
+        Console.Write($"{MyType.FullName}.")
+
+        For Each Mymemberinfo As MemberInfo in Mymemberinfoarray
+            Console.Write("\n" + Mymemberinfo.Name)
+        Next
+    End Sub
+End Class


### PR DESCRIPTION
These snippets were embedded in https://docs.microsoft.com/en-us/dotnet/framework/app-domains/how-to-obtain-type-and-member-information-from-an-assembly, which is being moved and renamed to /framework/reflection-and-codedom/get-type-member-information as part of dotnet/docs PR https://github.com/dotnet/docs/pull/13851. 

@rpetrusha requested the snippets be moved here. 

Overall User Story https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1576023. 