### PR TITLE
Fix compile-error

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsNamespace/CS/csrefKeywordsNamespace.cs
@@ -96,7 +96,7 @@ namespace usingstatement
         //</snippet5>
 
             //<snippet6>
-            using (var font3 = new Font("Arial", 10.0f),
+            using (Font font3 = new Font("Arial", 10.0f),
                         font4 = new Font("Arial", 10.0f))
             {
                 // Use font3 and font4.


### PR DESCRIPTION
Other `var`s in the same file should be kept. Only the one `var` changed is causing compile-error because there are two variables declarations within the same statement.

Fixes dotnet/docs#14420
