### PR TITLE
Fix typo

### DIFF
--- a/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs
+++ b/csharp/tutorials/RangesIndexes/IndicesAndRanges.cs
@@ -109,7 +109,7 @@ namespace RangesIndexes
             Span<int> zero_x = numbers[0..x];
             Console.WriteLine($"\t{start_x[0]}..{start_x[^1]} is the same as {zero_x[0]}..{zero_x[^1]}");
             Span<int> z_end = numbers[z..];
-            Span<int> z_zero = numbers[z..];
+            Span<int> z_zero = numbers[z..^0];
             Console.WriteLine($"\t{z_end[0]}..{z_end[^1]} is the same as {z_zero[0]}..{z_zero[^1]}");
             // </SnippetIndicesAndRanges_Semantics>
             return 0;


### PR DESCRIPTION
Intention was to show that `z..` and `z..^0` produce the same range
