### PR TITLE
Fix sample's readme

### DIFF
--- a/async/async-and-await/vb/readme.md
+++ b/async/async-and-await/vb/readme.md
@@ -1,7 +1,7 @@
 ---
 languages:
 - vb
- products:
+products:
 - dotnet-core
 - windows
 page_type: sample


### PR DESCRIPTION
At the moment, the async await sample still didn't appear at [Samples Explorer](https://docs.microsoft.com/en-us/samples/browse/?languages=vb&term=async) although it's merged to master. I think the problem is caused by the extra space.