### PR TITLE
Unify sequence step delimiter with guide

### DIFF
--- a/winforms/formatting-utility/cs/readme.md
+++ b/winforms/formatting-utility/cs/readme.md
@@ -30,9 +30,9 @@ The source code includes an MSBuild project file for C# (a .csproj file) that ta
 
 4. If you are using Visual Studio 2019:
 
-   1. In Visual Studio, select **Open a project or solution** (or **File** -> **Open** --> **Project/Solution** from the Visual Studio menu.
+   1. In Visual Studio, select **Open a project or solution** (or **File** > **Open** > **Project/Solution** from the Visual Studio menu.
 
-   2. Select **Debug** --> **Start Debugging** from the Visual Studio menu to build and launch the application.
+   2. Select **Debug** > **Start Debugging** from the Visual Studio menu to build and launch the application.
 
 4. If you are working from the command line:
 

--- a/winforms/formatting-utility/cs/readme.md
+++ b/winforms/formatting-utility/cs/readme.md
@@ -34,7 +34,7 @@ The source code includes an MSBuild project file for C# (a .csproj file) that ta
 
    2. Select **Debug** > **Start Debugging** from the Visual Studio menu to build and launch the application.
 
-4. If you are working from the command line:
+5. If you are working from the command line:
 
    1. Navigate to the directory that contains the sample.
 

--- a/winforms/formatting-utility/vb/readme.md
+++ b/winforms/formatting-utility/vb/readme.md
@@ -29,16 +29,15 @@ The source code includes an MSBuild project file for Visual Basic (a .vbproj fil
 
 4. If you are using Visual Studio 2019:
 
-   1. In Visual Studio, select **Open a project or solution** (or **File** -> **Open** --> **Project/Solution** from the Visual Studio menu.
+   1. In Visual Studio, select **Open a project or solution** (or **File** > **Open** > **Project/Solution** from the Visual Studio menu.
 
-   2. Select **Debug** --> **Start Debugging** from the Visual Studio menu to build and launch the application.
+   2. Select **Debug** > **Start Debugging** from the Visual Studio menu to build and launch the application.
 
-4. If you are working from the command line:
+5. If you are working from the command line:
 
    1. Navigate to the directory that contains the sample.
 
    2. Type in the command `dotnet run` to build and launch the application.
-
 
 ## Format strings in .NET
 


### PR DESCRIPTION
## Summary

Altered the sequence progression characters to be all the same. In this case, I aligned them to just `>` to match the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/procedures-instructions/writing-step-by-step-instructions#simple-instructions-with-right-angle-brackets).