### PR TITLE
BufferWidth resize approach.

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.console.windowleft/cs/windowleft1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.console.windowleft/cs/windowleft1.cs
@@ -8,7 +8,7 @@ public class Example
       ConsoleKeyInfo key;
       bool moved = false;
             
-      Console.BufferWidth = 120;
+      Console.BufferWidth += 4;
       Console.Clear();
       
       ShowConsoleStatistics();


### PR DESCRIPTION
The app fails if the current console buffer width is greater than 120 and we try to make it to be 120.
So it is more safe just to increment the current buffer width.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
