### PR TITLE
Remove unneeded exception variables

### DIFF
--- a/csharp/tutorials/patterns/finished/toll-calculator/Program.cs
+++ b/csharp/tutorials/patterns/finished/toll-calculator/Program.cs
@@ -49,7 +49,7 @@ namespace toll_calculator
             {
                 tollCalc.CalculateToll("this will fail");
             }
-            catch (ArgumentException e)
+            catch (ArgumentException)
             {
                 Console.WriteLine("Caught an argument exception when using the wrong type");
             }
@@ -57,7 +57,7 @@ namespace toll_calculator
             {
                 tollCalc.CalculateToll(null);
             }
-            catch (ArgumentNullException e)
+            catch (ArgumentNullException)
             {
                 Console.WriteLine("Caught an argument exception when using null");
             }


### PR DESCRIPTION
remove unneeded exception variables

## Summary

Describe your changes here.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
