### PR TITLE
Correct GetEnvVariable logic for AsyncStreams tutorial

### DIFF
--- a/csharp/tutorials/AsyncStreams/finished/IssuePRreport/IssuePRreport/Program.cs
+++ b/csharp/tutorials/AsyncStreams/finished/IssuePRreport/IssuePRreport/Program.cs
@@ -112,15 +112,15 @@ namespace GitHubActivityReport
             var value = Environment.GetEnvironmentVariable(item);
             if (string.IsNullOrWhiteSpace(value))
             {
+                if (!string.IsNullOrWhiteSpace(defaultValue))
+                {
+                    return defaultValue;
+                }
+                
                 if (!string.IsNullOrWhiteSpace(error))
                 {
                     Console.WriteLine(error);
                     Environment.Exit(0);
-                }
-
-                if (!string.IsNullOrWhiteSpace(defaultValue))
-                {
-                    return defaultValue;
                 }
             }
             return value;

--- a/csharp/tutorials/AsyncStreams/start/IssuePRreport/IssuePRreport/Program.cs
+++ b/csharp/tutorials/AsyncStreams/start/IssuePRreport/IssuePRreport/Program.cs
@@ -137,15 +137,15 @@ namespace GitHubActivityReport
             var value = Environment.GetEnvironmentVariable(item);
             if (string.IsNullOrWhiteSpace(value))
             {
+                if (!string.IsNullOrWhiteSpace(defaultValue))
+                {
+                    return defaultValue;
+                }
+                
                 if (!string.IsNullOrWhiteSpace(error))
                 {
                     Console.WriteLine(error);
                     Environment.Exit(0);
-                }
-
-                if (!string.IsNullOrWhiteSpace(defaultValue))
-                {
-                    return defaultValue;
                 }
             }
             return value;


### PR DESCRIPTION
## Summary

Updated Program.cs for the start and finished samples of the AsyncStreams tutorial.

The github personal token is fetched using the method GetEnvVariable, wherein defaultValue is currently unused and should be returned if supplied and the environment variable is found to be empty.

Fixes #1560 
