### PR TITLE
Remove not correct comment

### DIFF
--- a/snippets/csharp/how-to/safelycast/nullablepatternmatching/Program.cs
+++ b/snippets/csharp/how-to/safelycast/nullablepatternmatching/Program.cs
@@ -7,9 +7,6 @@ namespace nullablepatternmatching
     {
         static void Main(string[] args)
         {
-            // Use the as operator with a value type.
-            // Note the implicit conversion to int? in 
-            // the method body.
             int i = 5;
             PatternMatchingNullable(i);
 


### PR DESCRIPTION
The article in question:
https://docs.microsoft.com/en-us/dotnet/csharp/how-to/safely-cast-using-pattern-matching-is-and-as-operators

`PatternMatchingNullable` doesn't use the `as` operator as the comment says. It looks like that comment has been copied from another snippet:
https://github.com/dotnet/samples/blob/876733cac352d3497130c94a335e8eefa0812d3f/snippets/csharp/how-to/safelycast/asandis/Program.cs#L38-L42

