### PR TITLE
Fix comment and use string interpolation

### DIFF
--- a/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrKeywords/VB/Class2.vb
+++ b/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrKeywords/VB/Class2.vb
@@ -7,17 +7,17 @@ Module Module1
         Dim i As Integer
         Dim b As Boolean
 
-        ' The following statement sets ts.Name to Nothing and ts.Number to 0.
+        ' The following statement sets ts.Name to null and ts.Number to 0.
         ts = Nothing
 
         ' The following statements set i to 0 and b to False.
         i = Nothing
         b = Nothing
 
-        Console.WriteLine("ts.Name: " & ts.Name)
-        Console.WriteLine("ts.Number: " & ts.Number)
-        Console.WriteLine("i: " & i)
-        Console.WriteLine("b: " & b)
+        Console.WriteLine($"ts.Name: {ts.Name}")
+        Console.WriteLine($"ts.Number: {ts.Number}")
+        Console.WriteLine($"i: {i}")
+        Console.WriteLine($"b: {b}")
 
         Console.ReadKey()
     End Sub


### PR DESCRIPTION
The reason for changing `Nothing` to `null` is that `Nothing` in visual basic  may set the variable to `null` or its default value depending on whether the variable is nullable or not.
when setting a struct variable to `Nothing`, it will set the struct variables to `Nothing` as well, for the integer variable it will be set to `0`, but for the string variable it would be `null`