### PR TITLE
Fix compilation error in start `nullable-reference-migration` sample

### DIFF
--- a/csharp/tutorials/nullable-reference-migration/start/SimpleFeedReader/Startup.cs
+++ b/csharp/tutorials/nullable-reference-migration/start/SimpleFeedReader/Startup.cs
@@ -20,7 +20,7 @@ namespace SimpleFeedReader
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddScoped<NewsService>();
-            services.AddAutoMapper();
+            services.AddAutoMapper(typeof(NewsStoryProfile));
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
 


### PR DESCRIPTION
Fixes CS0121:

Severity	Code	Description	Project	File	Line	Suppression State
Error	CS0121	The call is ambiguous between the following methods or properties: 'ServiceCollectionExtensions.AddAutoMapper(IServiceCollection, params Assembly[])' and 'ServiceCollectionExtensions.AddAutoMapper(IServiceCollection, params Type[])'	SimpleFeedReader	C:\samples\csharp\tutorials\nullable-reference-migration\start\SimpleFeedReader\Startup.cs	23	Active

## Summary

Describe your changes here.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
