### PR TITLE
nit: update url of palindrome sample data

### DIFF
--- a/snippets/csharp/VS_Snippets_Misc/tpldataflow_palindromes/cs/dataflowpalindromes.cs
+++ b/snippets/csharp/VS_Snippets_Misc/tpldataflow_palindromes/cs/dataflowpalindromes.cs
@@ -87,7 +87,7 @@ static class DataflowReversedWords
 
       // <snippet6>
       // Process "The Iliad of Homer" by Homer.
-      downloadString.Post("http://www.gutenberg.org/files/6130/6130-0.txt");
+      downloadString.Post("http://www.gutenberg.org/cache/epub/16452/pg16452.txt");
       // </snippet6>
 
       // <snippet7>
@@ -102,7 +102,7 @@ static class DataflowReversedWords
    }
 }
 /* Sample output:
-   Downloading 'http://www.gutenberg.org/files/6130/6130-0.txt'...
+   Downloading 'http://www.gutenberg.org/cache/epub/16452/pg16452.txt'...
    Creating word list...
    Filtering word list...
    Finding reversed words...

--- a/snippets/visualbasic/VS_Snippets_Misc/tpldataflow_palindromes/vb/dataflowpalindromes.vb
+++ b/snippets/visualbasic/VS_Snippets_Misc/tpldataflow_palindromes/vb/dataflowpalindromes.vb
@@ -78,7 +78,7 @@ Module DataflowReversedWords
 
       ' <snippet6>
       ' Process "The Iliad of Homer" by Homer.
-      downloadString.Post("http://www.gutenberg.org/files/6130/6130-0.txt")
+      downloadString.Post("http://www.gutenberg.org/cache/epub/16452/pg16452.txt")
       ' </snippet6>
 
       ' <snippet7>
@@ -95,7 +95,7 @@ Module DataflowReversedWords
 End Module
 
 ' Sample output:
-'Downloading 'http://www.gutenberg.org/files/6130/6130-0.txt'...
+'Downloading 'http://www.gutenberg.org/cache/epub/16452/pg16452.txt'...
 'Creating word list...
 'Filtering word list...
 'Finding reversed words...


### PR DESCRIPTION
## Summary

This resolves dotnet/docs#14911.

The previous e-book URL used here looked to be a pretty broken OCR of
the original text. At first glance, I was able to find at least one
instance where the text includes "idealizedÃ¢â¬", which is either bad
OCR or some kind of encoding error.

The OP on the dotnet/docs issue requested the changed URL, which also
appears to be the most recommended version of Iliad on Gutenberg's
website.

I've updated the strings in both the csharp and vb example, per the
dotnet/docs issue.
