### PR TITLE
Remove INCLUDE from readme.md

### DIFF
--- a/core/getting-started/unit-testing-using-dotnet-test/README.md
+++ b/core/getting-started/unit-testing-using-dotnet-test/README.md
@@ -16,6 +16,8 @@ dotnet test
 ```
 
 `dotnet restore` restores the packages of both projects.
+
 `dotnet test` builds both projects and runs all of the configured tests.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/core/getting-started/unit-testing-using-mstest/README.md
+++ b/core/getting-started/unit-testing-using-mstest/README.md
@@ -16,7 +16,9 @@ dotnet test
 ```
 
 `dotnet restore` restores the packages of both projects.
+
 `dotnet test` builds both projects and runs all of the configured tests.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.
 

--- a/csharp/delegates-and-events/README.md
+++ b/csharp/delegates-and-events/README.md
@@ -1,26 +1,27 @@
-C# Delegates and Events Sample
-================
+# C# Delegates and Events Sample
 
 This sample is created during the [Delegates and Events topic](https://docs.microsoft.com/dotnet/csharp/delegates-events)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
-Key Features
-------------
+## Key Features
 
 This sample demonstrates defining delegate types, creating
 lambda expressions that map to delegates, and using single and
 using multicast delegates.
 
-Build and Run
--------------
+## Build and Run
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](~/docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/delegates-and-events/README.md
+++ b/csharp/delegates-and-events/README.md
@@ -23,5 +23,5 @@ dotnet run
 
 `dotnet run` builds the sample and runs the output assembly.
 
-**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](~/docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
 It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/events/README.md
+++ b/csharp/events/README.md
@@ -1,25 +1,26 @@
-C# Events Sample
-================
+# C# Events Sample
 
 This sample is created during the [Delegates and Events topic](../../../docs/csharp/delegates-events.md)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
-Key Features
-------------
+## Key Features
 
 This sample demonstrates defining and raising events, subscribing to
 events, and release event handlers.
 
-Build and Run
--------------
+## Build and Run
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/expression-trees/README.md
+++ b/csharp/expression-trees/README.md
@@ -1,26 +1,27 @@
-C# Expression Trees Sample
-================
+# C# Expression Trees Sample
 
 This sample is created during the [Expression Trees topic](https://docs.microsoft.com/dotnet/csharp/expression-trees)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
-Key Features
-------------
+## Key Features
 
 This sample demonstrates creating expression trees, parsing expression
 trees, and understanding the relationship between expression trees and
 the code you write every day in C#.
 
-Build and Run
--------------
+## Build and Run
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/getting-started/console-linq/README.md
+++ b/csharp/getting-started/console-linq/README.md
@@ -10,10 +10,14 @@ This sample demonstrates querying data sources and processing them using Languag
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/getting-started/console-webapiclient/README.md
+++ b/csharp/getting-started/console-webapiclient/README.md
@@ -1,25 +1,26 @@
-C# REST Client Sample
-================
+# C# REST Client Sample
 
 This sample is created during the [REST client tutorial](https://docs.microsoft.com/dotnet/csharp/tutorials/console-webapiclient)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
-Key Features
-------------
+## Key Features
 
 This sample demonstrates making HTTP requests to a web server, using `async`
 and `await`, converting JSON objects into C# objects, and terminal output.
 
-Build and Run
--------------
+## Build and Run
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/indexers/README.md
+++ b/csharp/indexers/README.md
@@ -1,26 +1,27 @@
-C# Indexers Sample
-================
+# C# Indexers Sample
 
 This sample is created during the [Indexers](https://docs.microsoft.com/dotnet/csharp/indexers)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
-Key Features
-------------
+## Key Features
 
 This sample contains four different samples involving
 indexers. You'll learn different C# idioms where indexers can be
 used to express your design intent.
 
-Build and Run
--------------
+## Build and Run
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/iterators/README.md
+++ b/csharp/iterators/README.md
@@ -1,25 +1,26 @@
-C# Iterators Sample
-================
+# C# Iterators Sample
 
 This sample is created during the [Iterators topic](https://docs.microsoft.com/dotnet/csharp/iterators)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
-Key Features
-------------
+## Key Features
 
 This sample demonstrates iterating across a data source, and creating
 iterator methods to control how a data source is visited (or iterated).
 
-Build and Run
--------------
+## Build and Run
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/versioning/new/README.md
+++ b/csharp/versioning/new/README.md
@@ -1,25 +1,26 @@
-C# Versioning Sample
-================
+# C# Versioning Sample
 
 This sample is created during the [Versioning](https://docs.microsoft.com/dotnet/csharp/versioning)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
-Key Features
-------------
+## Key Features
 
 This sample contains code demonstrating the use of 
 the `new` modifier when versioning .NET libraries
 
-Build and Run
--------------
+## Build and Run
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/csharp/versioning/override/README.md
+++ b/csharp/versioning/override/README.md
@@ -1,25 +1,26 @@
-C# Versioning Sample
-================
+# C# Versioning Sample
 
 This sample is created during the [Versioning](https://docs.microsoft.com/dotnet/csharp/versioning)
 for learning C# features. Please see that topic for detailed steps on the code
 for this sample.
 
-Key Features
-------------
+## Key Features
 
 This sample contains code demonstrating the use of 
 the `override` modifier when versioning .NET libraries
 
-Build and Run
--------------
+## Build and Run
 
 To build and run the sample, type the following two commands:
 
-`dotnet restore`
-`dotnet run`
+```
+dotnet restore
+dotnet run
+```
 
 `dotnet restore` restores the dependencies for this sample.
+
 `dotnet run` builds the sample and runs the output assembly.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+**Note:** Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](https://docs.microsoft.com/dotnet/core/tools/dotnet-restore) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.


### PR DESCRIPTION
the INCLUDE markdown syntax is a docs.microsoft.com extension, and it's not supported by github.
They shouldn't be used in samples repo (perhaps, except for samples in samples browser). I've also made some minor changes.