### PR TITLE
Corrected bad language ID

### DIFF
--- a/async/async-and-await/cs/readme.md
+++ b/async/async-and-await/cs/readme.md
@@ -1,6 +1,6 @@
 ---
 languages:
-- cs
+- csharp
 products:
 - dotnet-core
 - windows


### PR DESCRIPTION
## Corrected bad language ID

The correct language ID is **csharp** rather than the orginal **cs**.
