### PR TITLE
update yield parameter name

### DIFF
--- a/snippets/csharp/tour/statements/Program.cs
+++ b/snippets/csharp/tour/statements/Program.cs
@@ -138,9 +138,9 @@ namespace Statements
            return;
         }
 
-        static System.Collections.Generic.IEnumerable<int> Range(int from, int to) 
+        static System.Collections.Generic.IEnumerable<int> Range(int start, int end) 
         {
-            for (int i = from; i < to; i++) 
+            for (int i = start; i < end; i++) 
             {
                 yield return i;
             }


### PR DESCRIPTION
## Summary

Change parameters "from" and "to" to "start" and "end" to prevent syntax highlighting confusion.

Fixes dotnet/docs#14979
