### PR TITLE
Pipe Complete() -> CompleteAsync()

### DIFF
--- a/snippets/csharp/pipelines/Pipe.cs
+++ b/snippets/csharp/pipelines/Pipe.cs
@@ -52,7 +52,7 @@ namespace Pipes
                 }
             }
 
-            // Tell the PipeReader that there's no more data coming.
+             // By completing PipeWriter, tell the PipeReader that there's no more data coming.
             await writer.CompleteAsync();
         }
 

--- a/snippets/csharp/pipelines/Pipe.cs
+++ b/snippets/csharp/pipelines/Pipe.cs
@@ -53,7 +53,7 @@ namespace Pipes
             }
 
             // Tell the PipeReader that there's no more data coming.
-            writer.Complete();
+            await writer.CompleteAsync();
         }
 
         async Task ReadPipeAsync(PipeReader reader)
@@ -80,7 +80,7 @@ namespace Pipes
             }
 
             // Mark the PipeReader as complete.
-            reader.Complete();
+            await reader.CompleteAsync();
         }
 
         bool TryReadLine(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> line)


### PR DESCRIPTION
- CompleteAsync() is the newer, better API that avoids sync-over-async

See https://github.com/dotnet/docs/pull/14414#discussion_r333309579