### PR TITLE
Example for "SortedSet<T>" does not compile.

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.collections.generic.sortedset/cs/program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.collections.generic.sortedset/cs/program.cs
@@ -111,7 +111,6 @@ class Program
     {
         s = s.ToLower();
         return (s.EndsWith(".txt") ||
-            s.EndsWith(".doc") ||
             s.EndsWith(".xls") ||
             s.EndsWith(".xlsx") ||
             s.EndsWith(".pdf") ||
@@ -130,7 +129,7 @@ public class ByFileExtension : IComparer<string>
 {
     string xExt, yExt;
 
-	var caseiComp = new CaseInsensitiveComparer();
+	CaseInsensitiveComparer caseiComp = new CaseInsensitiveComparer();
 
     public int Compare(string x, string y)
     {


### PR DESCRIPTION
'var' may only appear within a local variable:
```
public class ByFileExtension : IComparer<string>
{
    ...
    var caseiComp = new CaseInsensitiveComparer();

```
Use 'CaseInsensitiveComparer', or move into:
```
public int Compare(string x, string y)
{
    ...
```

While I was on it, also double rows of ```s.EndsWith(".doc")```.