### PR TITLE
Update File.Create examples to remove redundant File.Exists/Delete call

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR/File Create1/CPP/file create1.cpp
+++ b/snippets/cpp/VS_Snippets_CLR/File Create1/CPP/file create1.cpp
@@ -7,13 +7,7 @@ int main()
 {
    String^ path = "c:\\temp\\MyTest.txt";
    
-   // Delete the file if it exists.
-   if ( File::Exists( path ) )
-   {
-      File::Delete( path );
-   }
-
-   // Create the file.
+   // Create the file, or overwrite if the file exists.
    FileStream^ fs = File::Create( path );
    try
    {

--- a/snippets/cpp/VS_Snippets_CLR/File Create2/CPP/file create2.cpp
+++ b/snippets/cpp/VS_Snippets_CLR/File Create2/CPP/file create2.cpp
@@ -7,13 +7,7 @@ int main()
 {
    String^ path = "c:\\temp\\MyTest.txt";
    
-   // Delete the file if it exists.
-   if ( File::Exists( path ) )
-   {
-      File::Delete( path );
-   }
-   
-   // Create the file.
+   // Create the file, or overwrite if the file exists.
    FileStream^ fs = File::Create( path, 1024 );
    try
    {

--- a/snippets/csharp/VS_Snippets_CLR/File Create1/CS/file create1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File Create1/CS/file create1.cs
@@ -11,22 +11,10 @@ class Test
 
         try
         {
-
-            // Delete the file if it exists.
-            if (File.Exists(path))
-            {
-                // Note that no lock is put on the
-                // file and the possibility exists
-                // that another process could do
-                // something with it between
-                // the calls to Exists and Delete.
-                File.Delete(path);
-            }
-
-            // Create the file.
+            // Create the file, or overwrite if the file exists.
             using (FileStream fs = File.Create(path))
             {
-                Byte[] info = new UTF8Encoding(true).GetBytes("This is some text in the file.");
+                byte[] info = new UTF8Encoding(true).GetBytes("This is some text in the file.");
                 // Add some information to the file.
                 fs.Write(info, 0, info.Length);
             }

--- a/snippets/csharp/VS_Snippets_CLR/File Create2/CS/file create2.cs
+++ b/snippets/csharp/VS_Snippets_CLR/File Create2/CS/file create2.cs
@@ -9,16 +9,10 @@ class Test
     {
         string path = @"c:\temp\MyTest.txt";
 
-        // Delete the file if it exists.
-        if (File.Exists(path)) 
-        {
-            File.Delete(path);
-        }
-
-        // Create the file.
+        // Create the file, or overwrite if the file exists.
         using (FileStream fs = File.Create(path, 1024)) 
         {
-            Byte[] info = new UTF8Encoding(true).GetBytes("This is some text in the file.");
+            byte[] info = new UTF8Encoding(true).GetBytes("This is some text in the file.");
             // Add some information to the file.
             fs.Write(info, 0, info.Length);
         }

--- a/snippets/visualbasic/VS_Snippets_CLR/File Create1/VB/file create1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/File Create1/VB/file create1.vb
@@ -7,16 +7,7 @@ Public Class Test
     Dim path As String = "c:\temp\MyTest.txt"
 
     Try
-
-      ' Delete the file if it exists. 
-      If File.Exists(path) Then
-        ' Note that no lock is put on the file and the possibility exists 
-        ' that another process could do something with it between 
-        ' the calls to Exists and Delete.
-        File.Delete(path)
-      End If
-
-      ' Create the file. 
+      ' Create the file, or overwrite if the file exists.
       Using fs As FileStream = File.Create(path)
         Dim info As Byte() = New UTF8Encoding(True).GetBytes("This is some text in the file.")
 

--- a/snippets/visualbasic/VS_Snippets_CLR/File Create2/VB/file create2.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/File Create2/VB/file create2.vb
@@ -7,16 +7,7 @@ Public Class Test
     Dim path As String = "c:\temp\MyTest.txt"
 
     Try
-
-      ' Delete the file if it exists. 
-      If File.Exists(path) Then
-        ' Note that no lock is put on the file and the possibility exists 
-        ' that another process could do something with it between 
-        ' the calls to Exists and Delete.
-        File.Delete(path)
-      End If
-
-      ' Create the file. 
+      ' Create the file, or overwrite if the file exists.
       Using fs As FileStream = File.Create(path, 1024)
         Dim info As Byte() = New UTF8Encoding(True).GetBytes("This is some text in the file.")
 


### PR DESCRIPTION
## Summary

* Removed `File.Exists` / `File.Delete` call, added comments about its behaviour
  * The `File.Exists` and `File.Delete` calls are unnecessary, since `File.Create` will overwrite the file if the file exists anyway. This behaviour is documented in the docs (`If the specified file does not exist, it is created; if it does exist and it is not read-only, the contents are overwritten.`) The current example can be misleading since it gives the false impression that `File.Create` will throw if the file already exists. In addition, it reduces the "possibility that another process could do something with it between the calls".
* Change the C# examples to use aliases (`byte`) instead of its name (`Byte`); This ensures consistency across the snippet where alias is used for `string` and the name is used for `byte`.
