### PR TITLE
remove virtual from interface declarations

### DIFF
--- a/csharp/tutorials/mixins-with-interfaces/IBlinkingLight.cs
+++ b/csharp/tutorials/mixins-with-interfaces/IBlinkingLight.cs
@@ -8,7 +8,7 @@ namespace mixins_with_interfaces
     // <SnippetBlinkingLight>
     public interface IBlinkingLight : ILight
     {
-        public virtual async Task Blink(int duration, int repeatCount)
+        public async Task Blink(int duration, int repeatCount)
         {
             Console.WriteLine("Using the default interface method for IBlinkingLight.Blink.");
             for (int count = 0; count < repeatCount; count++)

--- a/csharp/tutorials/mixins-with-interfaces/ILight.cs
+++ b/csharp/tutorials/mixins-with-interfaces/ILight.cs
@@ -22,7 +22,7 @@ namespace mixins_with_interfaces
         void SwitchOn();
         void SwitchOff();
         bool IsOn();
-        public virtual PowerStatus Power() => PowerStatus.NoPower;
+        public PowerStatus Power() => PowerStatus.NoPower;
     }
     // </SnippetILightInterface>
 }

--- a/csharp/tutorials/mixins-with-interfaces/ITimerLight.cs
+++ b/csharp/tutorials/mixins-with-interfaces/ITimerLight.cs
@@ -8,7 +8,7 @@ namespace mixins_with_interfaces
     // <SnippetTimerLightFinal>
     public interface ITimerLight : ILight
     {
-        public virtual async Task TurnOnFor(int duration)
+        public async Task TurnOnFor(int duration)
         {
             Console.WriteLine("Using the default interface method for the ITimerLight.TurnOnFor.");
             SwitchOn();

--- a/csharp/tutorials/mixins-with-interfaces/mixins-with-interfaces.csproj
+++ b/csharp/tutorials/mixins-with-interfaces/mixins-with-interfaces.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <RootNamespace>virtual_interface_methods</RootNamespace>
+    <RootNamespace>mixins_with_interfaces</RootNamespace>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
It's not needed, and it's likely to lead to reader confusion.

mentioned in reviews by @dasmulli, but I lost track of it.