### PR TITLE
Remove http:// part in proxy host in snippet 5 of WebProxy Constructors

### DIFF
--- a/snippets/cpp/VS_Snippets_Remoting/NCLWebProxy/CPP/nclwebproxy.cpp
+++ b/snippets/cpp/VS_Snippets_Remoting/NCLWebProxy/CPP/nclwebproxy.cpp
@@ -45,7 +45,7 @@ WebProxy^ CreateProxyWithHost()
 //<snippet5>
 WebProxy^ CreateProxyWithHostAndPort()
 {
-   return gcnew WebProxy( "http://contoso",80 );
+   return gcnew WebProxy( "contoso",80 );
 }
 //</snippet5>    
 

--- a/snippets/csharp/VS_Snippets_Remoting/NCLWebProxy/CS/nclwebproxy.cs
+++ b/snippets/csharp/VS_Snippets_Remoting/NCLWebProxy/CS/nclwebproxy.cs
@@ -44,7 +44,7 @@ public class ExampleForWebProxy
         //<snippet5>
         public static WebProxy CreateProxyWithHostAndPort()
         {
-            return new WebProxy("http://contoso", 80);
+            return new WebProxy("contoso", 80);
         }
         //</snippet5>    
         


### PR DESCRIPTION
## Summary

Remove http:// part in proxy host in snippet 5 of WebProxy Constructors.

https://github.com/microsoft/referencesource/blob/bebbd994069d4c3070f114f220b6f4882b3f0244/System/net/System/Net/webproxy.cs#L98 shows the constructor adds http:// unconditionally.