### PR TITLE
Add snippets for EventLogInformation.Attributes

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/System.Diagnostics.Eventing.Reader.EventLogInformation/cs/attributes.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/System.Diagnostics.Eventing.Reader.EventLogInformation/cs/attributes.cs
@@ -1,0 +1,7 @@
+﻿// <snippet1>
+using System.Diagnostics.Eventing.Reader;
+using System.IO;
+
+EventLogInformation eventLogInformation;
+FileAttributes? fileAttributes = (FileAttributes?)eventLogInformation.Attributes;
+// </snippet1>

--- a/snippets/visualbasic/VS_Snippets_CLR_System/System.Diagnostics.Eventing.Reader.EventLogInformation/vb/attributes.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/System.Diagnostics.Eventing.Reader.EventLogInformation/vb/attributes.vb
@@ -1,0 +1,7 @@
+﻿' <snippet1>
+Imports System.Diagnostics.Eventing.Reader
+Imports System.IO
+
+Dim eventLogInformation As EventLogInformation
+Dim fileAttributes = CType(eventLogInformation.Attributes, FileAttributes?)
+' </snippet1>


### PR DESCRIPTION
## Summary

Added cs and vb snippets demonstrating how to cast `System.Diagnostics.Eventing.Reader.EventLogInformation.Attributes` to `System.IO.FileAttributes`.

Contributes to dotnet/dotnet-api-docs#1126
