### PR TITLE
Remove incorrect comment

### DIFF
--- a/snippets/csharp/language-reference/keywords/switch/switch4.cs
+++ b/snippets/csharp/language-reference/keywords/switch/switch4.cs
@@ -7,8 +7,7 @@ public class Example
       int caseSwitch = 1;
       // <Snippet1>
       switch (caseSwitch)  
-      {  
-          // The following switch section causes an error.  
+      {
           case 1:  
               Console.WriteLine("Case 1...");  
               break;  


### PR DESCRIPTION
Comment incorrectly stated that the switch section causes an error, which it does not. It would also contradict the assertion in docs/csharp/language-reference/keywords/switch.md that the code is valid.
