### PR TITLE
Change current process extension from dll to exe

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
@@ -11,11 +11,11 @@ public class PipeClient
 {
     private static int numClients = 4;
 
-    public static void Main(string[] Args)
+    public static void Main(string[] args)
     {
-        if (Args.Length > 0)
+        if (args.Length > 0)
         {
-            if (Args[0] == "spawnclient")
+            if (args[0] == "spawnclient")
             {
                 NamedPipeClientStream pipeClient =
                     new NamedPipeClientStream(".", "testpipe",

--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
@@ -17,7 +17,7 @@ public class PipeClient
         {
             if (args[0] == "spawnclient")
             {
-                NamedPipeClientStream pipeClient =
+                var pipeClient =
                     new NamedPipeClientStream(".", "testpipe",
                         PipeDirection.InOut, PipeOptions.None,
                         TokenImpersonationLevel.Impersonation);
@@ -26,7 +26,7 @@ public class PipeClient
                 pipeClient.Connect();
 
                 //<snippet2>
-                StreamString ss = new StreamString(pipeClient);
+                var ss = new StreamString(pipeClient);
                 // Validate the server's signature string.
                 if (ss.ReadString() == "I am the one true server!")
                 {
@@ -119,7 +119,7 @@ public class StreamString
         int len;
         len = ioStream.ReadByte() * 256;
         len += ioStream.ReadByte();
-        byte[] inBuffer = new byte[len];
+        var inBuffer = new byte[len];
         ioStream.Read(inBuffer, 0, len);
 
         return streamEncoding.GetString(inBuffer);

--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
@@ -1,10 +1,10 @@
 ﻿//<snippet01>
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
-using System.Text;
 using System.Security.Principal;
-using System.Diagnostics;
+using System.Text;
 using System.Threading;
 
 public class PipeClient

--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
@@ -60,6 +60,7 @@ public class PipeClient
     {
         int i;
         string currentProcessName = Environment.CommandLine;
+        currentProcessName = Path.ChangeExtension(currentProcessName, ".exe");
         Process[] plist = new Process[numClients];
 
         Console.WriteLine("Spawning client processes...\n");

--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
@@ -58,7 +58,6 @@ public class PipeClient
     // Helper function to create pipe client processes
     private static void StartClients()
     {
-        int i;
         string currentProcessName = Environment.CommandLine;
         currentProcessName = Path.ChangeExtension(currentProcessName, ".exe");
         Process[] plist = new Process[numClients];
@@ -74,6 +73,7 @@ public class PipeClient
         currentProcessName = currentProcessName.Replace("\\", String.Empty);
         currentProcessName = currentProcessName.Replace("\"", String.Empty);
 
+        int i;
         for (i = 0; i < numClients; i++)
         {
             // Start 'this' program but spawn a named pipe client.

--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
@@ -27,7 +27,7 @@ public class PipeClient
 
                 //<snippet2>
                 StreamString ss = new StreamString(pipeClient);
-                // Validate the server's signature string
+                // Validate the server's signature string.
                 if (ss.ReadString() == "I am the one true server!")
                 {
                     // The client security token is sent with the first write.
@@ -103,7 +103,7 @@ public class PipeClient
     }
 }
 
-// Defines the data protocol for reading and writing strings on our stream
+// Defines the data protocol for reading and writing strings on our stream.
 public class StreamString
 {
     private Stream ioStream;

--- a/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/cs/Program.cs
@@ -87,8 +87,7 @@ public class PipeClient
                 {
                     if (plist[j].HasExited)
                     {
-                        Console.WriteLine("Client process[{0}] has exited.",
-                            plist[j].Id);
+                        Console.WriteLine($"Client process[{plist[j].Id}] has exited.");
                         plist[j] = null;
                         i--;    // decrement the process watch count
                     }

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/vb/program.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.IO.Pipes.NamedPipeClientStream_ImpersonationSample1/vb/program.vb
@@ -60,6 +60,9 @@ Public Class PipeClient
         ' Remove extra characters when launched from Visual Studio
         currentProcessName = currentProcessName.Replace("\", String.Empty)
         currentProcessName = currentProcessName.Replace("""", String.Empty)
+        
+        ' Change extension for .NET Core "dotnet run" returns the DLL, not the host exe:
+        currentProcessName = Path.ChangeExtension(currentProcessName, ".exe")
 
         For i = 0 To numClients - 1
             ' Start 'this' program but spawn a named pipe client.


### PR DESCRIPTION
## Summary

Environment.CommandLine returns the name of the dll on .NET Core. 

Fixes dotnet/docs#15367
