### PR TITLE
Update Interest Rate Sample

### DIFF
--- a/csharp/serialization/Loan.cs
+++ b/csharp/serialization/Loan.cs
@@ -12,7 +12,7 @@ namespace serialization
    public class Loan : INotifyPropertyChanged
     {
         public double LoanAmount { get; set; }
-        public double InterestRate { get; set; }
+        public double InterestRatePercent { get; set; }
 
         // <Snippet4>
         [field:NonSerialized()]
@@ -44,7 +44,7 @@ namespace serialization
                     string customer)
         {
             this.LoanAmount = loanAmount;
-            this.InterestRate = interestRate;
+            this.InterestRatePercent = interestRate;
             this.Term = term;
             this.customer = customer;
         }

--- a/csharp/serialization/Program.cs
+++ b/csharp/serialization/Program.cs
@@ -16,7 +16,7 @@ namespace serialization
             // </Snippet4>
 
             // <Snippet1>
-            Loan TestLoan = new Loan(10000.0, 0.075, 36, "Neil Black");
+            Loan TestLoan = new Loan(10000.0, 7.5, 36, "Neil Black");
             // </Snippet1>
 
             // <Snippet5>

--- a/csharp/serialization/Program.cs
+++ b/csharp/serialization/Program.cs
@@ -35,9 +35,9 @@ namespace serialization
             TestLoan.PropertyChanged += (_, __) => Console.WriteLine($"New customer value: {TestLoan.Customer}");
 
             TestLoan.Customer = "Henry Clay";
-            Console.WriteLine(TestLoan.InterestRate);
-            TestLoan.InterestRate = 7.1;
-            Console.WriteLine(TestLoan.InterestRate);
+            Console.WriteLine(TestLoan.InterestRatePercent);
+            TestLoan.InterestRatePercent = 7.1;
+            Console.WriteLine(TestLoan.InterestRatePercent);
             // </Snippet2>
 
             // <Snippet6>


### PR DESCRIPTION
## Summary

* [x] Change `InterestRate` --> `InterestRatePercent` so that we're not trying to deal with conversion in a way that muddies the sample
* [x] Update the values to `7.5` and `7.1` respectively, rather than `.075` and `.071`

At this point the sample code should be consistent with what is outputted in the docs.

Fixes https://github.com/dotnet/docs/issues/14367