### PR TITLE
Add empty Form1 load method to avoid auto-generated code causing an error

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideInterop/CS/WinSound.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideInterop/CS/WinSound.cs
@@ -49,6 +49,13 @@ namespace WinSound
                 PlaySound(dialog1.FileName, new System.IntPtr(), PlaySoundFlags.SND_SYNC);
             }
         }
+        
+        private void Form1_Load(object sender, EventArgs e) 
+        { 
+            // Including this empty method in the sample because in the IDE,
+            // when users click on the form, generates code that looks for a default method
+            // with this name. We add it here to prevent confusion for those using the samples.
+        }
     }
 }
 //</Snippet3>
@@ -122,13 +129,6 @@ namespace WinSound
             this.ResumeLayout(false);
             this.PerformLayout();
             //</Snippet4>
-        }
-        
-        private void Form1_Load(object sender, EventArgs e) 
-        { 
-            // Including this empty method in the sample because in the IDE,
-            // when users click on the form, generates code that looks for a default method
-            // with this name. We add it here to prevent confusion for those using the samples.
         }
     }
 }

--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideInterop/CS/WinSound.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideInterop/CS/WinSound.cs
@@ -123,5 +123,12 @@ namespace WinSound
             this.PerformLayout();
             //</Snippet4>
         }
+        
+        private void Form1_Load(object sender, EventArgs e) 
+        { 
+            // Including this empty method in the sample because in the IDE,
+            // when users click on the form, generates code that looks for a default method
+            // with this name. We add it here to prevent confusion for those using the samples.
+        }
     }
 }


### PR DESCRIPTION
## Summary

When users click on the form in the example associated with this code, code will be generated that looks for a load method. Because one is not defined, the sample will then error.

This PR adds that empty method, along with an explanatory comment.

Fixes https://github.com/dotnet/docs/issues/13317