### PR TITLE
Fix indentation and formatting syntax

### DIFF
--- a/snippets/csharp/concepts/linq/how-to-perform-custom-join-operations_1.cs
+++ b/snippets/csharp/concepts/linq/how-to-perform-custom-join-operations_1.cs
@@ -25,16 +25,16 @@
 
                 // Specify the second data source.
                 List<Product> products = new List<Product>()
-               {
-                  new Product{Name="Tea",  CategoryID=001},
-                  new Product{Name="Mustard", CategoryID=002},
-                  new Product{Name="Pickles", CategoryID=002},
-                  new Product{Name="Carrots", CategoryID=003},
-                  new Product{Name="Bok Choy", CategoryID=003},
-                  new Product{Name="Peaches", CategoryID=005},
-                  new Product{Name="Melons", CategoryID=005},
-                  new Product{Name="Ice Cream", CategoryID=007},
-                  new Product{Name="Mackerel", CategoryID=012},
+                {
+                    new Product{Name="Tea",  CategoryID=001},
+                    new Product{Name="Mustard", CategoryID=002},
+                    new Product{Name="Pickles", CategoryID=002},
+                    new Product{Name="Carrots", CategoryID=003},
+                    new Product{Name="Bok Choy", CategoryID=003},
+                    new Product{Name="Peaches", CategoryID=005},
+                    new Product{Name="Melons", CategoryID=005},
+                    new Product{Name="Ice Cream", CategoryID=007},
+                    new Product{Name="Mackerel", CategoryID=012},
                 };
                 #endregion
 

--- a/snippets/csharp/concepts/linq/how-to-perform-custom-join-operations_1.cs
+++ b/snippets/csharp/concepts/linq/how-to-perform-custom-join-operations_1.cs
@@ -17,25 +17,25 @@
 
                 // Specify the first data source.
                 List<Category> categories = new List<Category>()
-        { 
-            new Category(){Name="Beverages", ID=001},
-            new Category(){ Name="Condiments", ID=002},
-            new Category(){ Name="Vegetables", ID=003},         
-        };
+                { 
+                    new Category(){Name="Beverages", ID=001},
+                    new Category(){ Name="Condiments", ID=002},
+                    new Category(){ Name="Vegetables", ID=003},         
+                };
 
                 // Specify the second data source.
                 List<Product> products = new List<Product>()
-       {
-          new Product{Name="Tea",  CategoryID=001},
-          new Product{Name="Mustard", CategoryID=002},
-          new Product{Name="Pickles", CategoryID=002},
-          new Product{Name="Carrots", CategoryID=003},
-          new Product{Name="Bok Choy", CategoryID=003},
-          new Product{Name="Peaches", CategoryID=005},
-          new Product{Name="Melons", CategoryID=005},
-          new Product{Name="Ice Cream", CategoryID=007},
-          new Product{Name="Mackerel", CategoryID=012},
-        };
+               {
+                  new Product{Name="Tea",  CategoryID=001},
+                  new Product{Name="Mustard", CategoryID=002},
+                  new Product{Name="Pickles", CategoryID=002},
+                  new Product{Name="Carrots", CategoryID=003},
+                  new Product{Name="Bok Choy", CategoryID=003},
+                  new Product{Name="Peaches", CategoryID=005},
+                  new Product{Name="Melons", CategoryID=005},
+                  new Product{Name="Ice Cream", CategoryID=007},
+                  new Product{Name="Mackerel", CategoryID=012},
+                };
                 #endregion
 
                 static void Main()
@@ -58,7 +58,7 @@
                     Console.WriteLine("Cross Join Query:");
                     foreach (var v in crossJoinQuery)
                     {
-                        Console.WriteLine($"{v.ID:-5}{v.Name}");
+                        Console.WriteLine($"{v.ID,-5}{v.Name}");
                     }
                 }
 
@@ -74,7 +74,7 @@
                     Console.WriteLine("Non-equijoin query:");
                     foreach (var v in nonEquijoinQuery)
                     {
-                        Console.WriteLine($"{v.CategoryID:-5}{v.Product}");
+                        Console.WriteLine($"{v.CategoryID,-5}{v.Product}");
                     }
                 }
             }


### PR DESCRIPTION
`{v.ID:-5}` -> `{v.ID,-5}`

Fix https://github.com/dotnet/docs.zh-cn/issues/499