### PR TITLE
Add snippet tags

### DIFF
--- a/snippets/fsharp/VS_Snippets_CLR/console.windowLT/FS/wlt.fs
+++ b/snippets/fsharp/VS_Snippets_CLR/console.windowLT/FS/wlt.fs
@@ -1,3 +1,4 @@
+//<snippet1>
 // This example demonstrates the Console.WindowLeft and
 //                               Console.WindowTop properties.
 open System
@@ -84,3 +85,4 @@ let main argv =
         Console.SetBufferSize(saveBufferWidth, saveBufferHeight)
         Console.SetWindowSize(saveWindowWidth, saveWindowHeight)
         Console.CursorVisible <- saveCursorVisible
+//</snippet1>


### PR DESCRIPTION
## Summary

Add snippet tags to allow references from https://github.com/dotnet/dotnet-api-docs/pull/3460 to accurately reference the snippet. This also brings the snippet into alignment with the C# example.
