### PR TITLE
keep vb and C# in sync

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_UnionWith/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_UnionWith/cs/Program.cs
@@ -5,7 +5,7 @@ class Program
 {
     static void Main()
     {
-        //<snippet01>
+        //<snippet02>
         //<snippet03>
         HashSet<int> evenNumbers = new HashSet<int>();
         HashSet<int> oddNumbers = new HashSet<int>();
@@ -50,6 +50,6 @@ class Program
         * numbers UnionWith oddNumbers...
         * numbers contains 10 elements: { 0 2 4 6 8 1 3 5 7 9 }
         */
-        //</snippet01>
+        //</snippet02>
     }
 }


### PR DESCRIPTION
The last PR changed the snippet numbers which makes the C# and VB numbers out of sync. Going back to the old number.