### PR TITLE
C# reference snippets: target .NET Core 3.1

### DIFF
--- a/csharp/language-reference/builtin-types/builtin-types.csproj
+++ b/csharp/language-reference/builtin-types/builtin-types.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <StartupObject>builtin_types.Program</StartupObject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/csharp/language-reference/operators/operators.csproj
+++ b/csharp/language-reference/operators/operators.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <StartupObject>operators.Program</StartupObject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Target .NET Core 3.1 for the snippets here:
https://github.com/dotnet/samples/tree/master/csharp/language-reference
