### PR TITLE
Update out1.cs

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.console.out/cs/out1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.console.out/cs/out1.cs
@@ -11,7 +11,7 @@ public class Example
       Array.Sort(files);
       
       // Display the files to the current output source to the console.
-      Console.WriteLine("First display of filenames to the console:");
+      Console.Out.WriteLine("First display of filenames to the console:");
       Array.ForEach(files, s => Console.Out.WriteLine(s));   
       Console.Out.WriteLine();
 


### PR DESCRIPTION
Nothing important at all but it made me wonder if there is any thought that ```.Out.``` is not included in the first ```WriteLine()```, maybe others do too. Or are there any?