### PR TITLE
Temporary fix for file rename

### DIFF
--- a/snippets/core/system-text-json/csharp/ConvertDictionaryTkeyEnumTValue.cs
+++ b/snippets/core/system-text-json/csharp/ConvertDictionaryTkeyEnumTValue.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Text.Json;
+
+namespace SystemTextJsonSamples
+{
+    public class RoundtripDictionaryTkeyEnumTValue
+    {
+        public static void Run()
+        {
+            string jsonString;
+
+            var weatherForecast = WeatherForecastFactories.CreateWeatherForecastWithEnumDictionary();
+
+            // <SnippetRegister>
+            var serializeOptions = new JsonSerializerOptions();
+            serializeOptions.Converters.Add(new DictionaryTKeyEnumTValueConverter());
+            // </SnippetRegister>
+            serializeOptions.WriteIndented = true;
+            jsonString = JsonSerializer.Serialize(weatherForecast, serializeOptions);
+            Console.WriteLine($"JSON output:\n{jsonString}\n");
+
+            // <SnippetDeserialize>
+            var deserializeOptions = new JsonSerializerOptions();
+            deserializeOptions.Converters.Add(new DictionaryTKeyEnumTValueConverter());
+            weatherForecast = JsonSerializer.Deserialize<WeatherForecastWithEnumDictionary>(jsonString, deserializeOptions);
+            // </SnippetDeserialize>
+            weatherForecast.DisplayPropertyValues();
+        }
+    }
+}

--- a/snippets/core/system-text-json/csharp/ConvertInferredTypesToObject.cs
+++ b/snippets/core/system-text-json/csharp/ConvertInferredTypesToObject.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.Json;
+
+namespace SystemTextJsonSamples
+{
+    public class DeserializeInferredTypesToObject
+    {
+        public static void Run()
+        {
+            string jsonString;
+
+            // Serialize to create input JSON
+            var weatherForecast = WeatherForecastFactories.CreateWeatherForecast();
+            var serializeOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+            serializeOptions.WriteIndented = true;
+            jsonString = JsonSerializer.Serialize(weatherForecast, serializeOptions);
+            Console.WriteLine($"JSON input:\n{jsonString}\n");
+
+            // Deserialize without converter
+            // Properties are JsonElement type.
+            WeatherForecastWithObjectProperties weatherForecastWithObjectProperties = JsonSerializer.Deserialize<WeatherForecastWithObjectProperties>(jsonString);
+            weatherForecastWithObjectProperties.DisplayPropertyValues();
+
+            // <SnippetRegister>
+            var deserializeOptions = new JsonSerializerOptions();
+            deserializeOptions.Converters.Add(new ObjectToInferredTypesConverter());
+            // </SnippetRegister>
+            weatherForecastWithObjectProperties = JsonSerializer.Deserialize<WeatherForecastWithObjectProperties>(jsonString, deserializeOptions);
+            weatherForecastWithObjectProperties.DisplayPropertyValues();
+        }
+    }
+}

--- a/snippets/core/system-text-json/csharp/ConvertPolymorphic.cs
+++ b/snippets/core/system-text-json/csharp/ConvertPolymorphic.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Text.Json;
+
+namespace SystemTextJsonSamples
+{
+    class SerializePolymorphic
+    {
+        public static void Run()
+        {
+            string jsonString;
+            var weatherForecastDerived = WeatherForecastFactories.CreateWeatherForecastDerived();
+            WeatherForecast weatherForecast = weatherForecastDerived;
+            weatherForecast.DisplayPropertyValues();
+
+            Console.WriteLine("Base class generic type - derived class properties omitted");
+            // <SnippetSerializeDefault>
+            var serializeOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+            jsonString = JsonSerializer.Serialize<WeatherForecast>(weatherForecast, serializeOptions);
+            // </SnippetSerializeDefault>
+
+            Console.WriteLine($"JSON output:\n{jsonString}\n");
+
+            Console.WriteLine("Object generic type parameter - derived class properties included");
+            // <SnippetSerializeObject>
+            serializeOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+            jsonString = JsonSerializer.Serialize<object>(weatherForecast, serializeOptions);
+            // </SnippetSerializeObject>
+            Console.WriteLine($"JSON output:\n{jsonString}\n");
+
+
+            Console.WriteLine("GetType() type parameter - derived class properties included");
+            // <SnippetSerializeGetType>
+            serializeOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+            jsonString = JsonSerializer.Serialize(weatherForecast, weatherForecast.GetType(), serializeOptions);
+            // </SnippetSerializeGetType>
+            Console.WriteLine($"JSON output:\n{jsonString}\n");
+        }
+    }
+}


### PR DESCRIPTION
Samples and Docs repos are out of sync because I renamed some files in a samples PR and made corresponding changes in a docs PR but I forgot the samples repo changes would immediately affect the existing doc in the docs repo.  So I've created duplicate files with the old names so the existing doc won't be broken.  When the new docs PR merges I'll delete these.