### PR TITLE
Use dotnetcli in DiagnosticScenarios/readme.md

### DIFF
--- a/core/diagnostics/DiagnosticScenarios/readme.md
+++ b/core/diagnostics/DiagnosticScenarios/readme.md
@@ -27,24 +27,32 @@ The target triggers undesirable behaviors when hitting specific URLs.
 
 ### Deadlock
 
-`http://localhost:5000/api/diagscenario/deadlock`
+```http
+http://localhost:5000/api/diagscenario/deadlock
+```
 
 This method will cause the target to hang and accumulate many threads.
 
 ### High CPU usage
 
-`http://localhost:5000/api/diagscenario/highcpu/{milliseconds}`
+```http
+http://localhost:5000/api/diagscenario/highcpu/{milliseconds}
+```
 
 The method will cause to target to heavily use the CPU for a duration specified by {milliseconds}.
 
 ### Memory leak
 
-`http://localhost:5000/api/diagscenario/memleak/{kb}`
+```http
+http://localhost:5000/api/diagscenario/memleak/{kb}
+```
 
 This method will cause the target to leak memory (amount specified by {kb}).
 
 ### Memory usage spike
 
-`http://localhost:5000/api/diagscenario/memspike/{seconds}`
+```http
+http://localhost:5000/api/diagscenario/memspike/{seconds}
+```
 
 This method will cause intermittent memory spikes over the specified number of seconds. Memory will go from base line to spike and back to baseline several times.

--- a/core/diagnostics/DiagnosticScenarios/readme.md
+++ b/core/diagnostics/DiagnosticScenarios/readme.md
@@ -4,13 +4,13 @@ languages:
 products:
 - dotnet-core
 page_type: sample
-name: "Diagnostic Scenarios"
+name: "DiagnosticScenarios sample debug target"
 urlFragment: "diagnostic-scenarios"
 description: "A .NET Core sample with methods that trigger undesirable behaviors to diagnose."
 ---
 # DiagnosticScenarios sample debug target
 
-This sample is for the [diagnostics tutorials](https://docs.microsoft.com/dotnet/core/diagnostics/tutorial/diagnostic-scenarios) in the .NET Core Guide.
+This sample is for the [diagnostics tutorials](https://docs.microsoft.com/dotnet/core/diagnostics/) in the .NET Core Guide.
 
 The scenarios are implemented using a `webapi` target with methods that trigger undesirable behaviors for us to diagnose.
 

--- a/core/diagnostics/DiagnosticScenarios/readme.md
+++ b/core/diagnostics/DiagnosticScenarios/readme.md
@@ -16,7 +16,7 @@ The sample debug target is a simple `webapi` application. The sample triggers un
 
 After downloading the source, you can easily run the webapi using:
 
-```console
+```dotnetcli
 dotnet build
 dotnet run
 ```


### PR DESCRIPTION
Fixes dotnet/docs#16283.

I've also updated the "name" in the metadata because the h1 seems to be ignored, and the "name" is used as the h1.

![image](https://user-images.githubusercontent.com/31348972/71016013-310d6e80-20fd-11ea-8608-4b997862c6b1.png)
