### PR TITLE
remove outdated metadata files

### DIFF
--- a/snippets/common/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/creator.txt
+++ b/snippets/common/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\erikre

--- a/snippets/common/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/description.txt
+++ b/snippets/common/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/description.txt
@@ -1,1 +1,0 @@
-Demonstrates how to use the Sys.CultureInfo.CurrentCulture class.

--- a/snippets/common/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/keywords.txt
+++ b/snippets/common/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/keywords.txt
@@ -1,4 +1,0 @@
-1 CultureInfo
-2 CurrentCulture
-3 InvariantCulture
-4 numberFormat

--- a/snippets/common/VS_Snippets_Atlas/Sys.Net.WebRequest/creator.txt
+++ b/snippets/common/VS_Snippets_Atlas/Sys.Net.WebRequest/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/common/VS_Snippets_Atlas/Sys.Net.WebRequestManager/creator.txt
+++ b/snippets/common/VS_Snippets_Atlas/Sys.Net.WebRequestManager/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/common/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
+++ b/snippets/common/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/common/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
+++ b/snippets/common/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
@@ -1,1 +1,0 @@
-System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/common/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
+++ b/snippets/common/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
@@ -1,1 +1,0 @@
-1 System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/common/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
+++ b/snippets/common/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
@@ -1,1 +1,0 @@
-Demonstrates CreateObject(Type,Object), and differences from CreateObject(Type).

--- a/snippets/common/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
+++ b/snippets/common/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
@@ -1,2 +1,0 @@
-1 - System.Reflection.Emit.DynamicMethod.CreateDelegate(Type,Object)
-1 - System.Reflection.Emit.DynamicMethod.#ctor(String,Type,Type[],Type)

--- a/snippets/common/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
+++ b/snippets/common/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/common/VS_Snippets_CLR/conceptual.threadpool/metatdata/creator.txt
+++ b/snippets/common/VS_Snippets_CLR/conceptual.threadpool/metatdata/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\a-galen

--- a/snippets/common/VS_Snippets_CLR/conceptual.threadpool/metatdata/description.txt
+++ b/snippets/common/VS_Snippets_CLR/conceptual.threadpool/metatdata/description.txt
@@ -1,1 +1,0 @@
-Thread Pool conceptual examples.

--- a/snippets/common/VS_Snippets_CLR/conceptual.threadpool/metatdata/keywords.txt
+++ b/snippets/common/VS_Snippets_CLR/conceptual.threadpool/metatdata/keywords.txt
@@ -1,3 +1,0 @@
-1 System.Threading.ThreadPool
-2 System.Threading.ThreadPool
-3 System.Threading.ThreadPool

--- a/snippets/common/VS_Snippets_WebNet/Sys.Net.WebRequestManagerOrcas/creator.txt
+++ b/snippets/common/VS_Snippets_WebNet/Sys.Net.WebRequestManagerOrcas/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/common/VS_Snippets_WebNet/System.ComponentModel.DataAnnotations2/creator.txt
+++ b/snippets/common/VS_Snippets_WebNet/System.ComponentModel.DataAnnotations2/creator.txt
@@ -1,1 +1,0 @@
-redmond\a-riAnde

--- a/snippets/cpp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
+++ b/snippets/cpp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/cpp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
+++ b/snippets/cpp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
@@ -1,1 +1,0 @@
-System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/cpp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
+++ b/snippets/cpp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
@@ -1,1 +1,0 @@
-1 System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/cpp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
+++ b/snippets/cpp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
@@ -1,1 +1,0 @@
-Demonstrates CreateObject(Type,Object), and differences from CreateObject(Type).

--- a/snippets/cpp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
+++ b/snippets/cpp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
@@ -1,2 +1,0 @@
-1 - System.Reflection.Emit.DynamicMethod.CreateDelegate(Type,Object)
-1 - System.Reflection.Emit.DynamicMethod.#ctor(String,Type,Type[],Type)

--- a/snippets/cpp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
+++ b/snippets/cpp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/cpp/VS_Snippets_WebNet/Sys.Net.WebRequestManagerOrcas/creator.txt
+++ b/snippets/cpp/VS_Snippets_WebNet/Sys.Net.WebRequestManagerOrcas/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/cpp/VS_Snippets_WebNet/System.ComponentModel.DataAnnotations2/creator.txt
+++ b/snippets/cpp/VS_Snippets_WebNet/System.ComponentModel.DataAnnotations2/creator.txt
@@ -1,1 +1,0 @@
-redmond\a-riAnde

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid1/creator.txt.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid1/creator.txt.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_autogencolumns/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_autogencolumns/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_cellselection/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_cellselection/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_cellstyle/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_cellstyle/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_columnsmanipulation/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_columnsmanipulation/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_customcolumns/creator.txt.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_customcolumns/creator.txt.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_frozencolumn/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_frozencolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_rowheader/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_rowheader/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_templatecolumn/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_templatecolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/datagrid_textcolumn/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/datagrid_textcolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/cpp/VS_Snippets_Wpf/wpfcustomdictionary/creator.txt
+++ b/snippets/cpp/VS_Snippets_Wpf/wpfcustomdictionary/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/creator.txt
+++ b/snippets/csharp/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\erikre

--- a/snippets/csharp/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/description.txt
+++ b/snippets/csharp/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/description.txt
@@ -1,1 +1,0 @@
-Demonstrates how to use the Sys.CultureInfo.CurrentCulture class.

--- a/snippets/csharp/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/keywords.txt
+++ b/snippets/csharp/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/keywords.txt
@@ -1,4 +1,0 @@
-1 CultureInfo
-2 CurrentCulture
-3 InvariantCulture
-4 numberFormat

--- a/snippets/csharp/VS_Snippets_Atlas/Sys.Net.WebRequest/creator.txt
+++ b/snippets/csharp/VS_Snippets_Atlas/Sys.Net.WebRequest/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/csharp/VS_Snippets_Atlas/Sys.Net.WebRequestManager/creator.txt
+++ b/snippets/csharp/VS_Snippets_Atlas/Sys.Net.WebRequestManager/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/csharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
+++ b/snippets/csharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/csharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
+++ b/snippets/csharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
@@ -1,1 +1,0 @@
-System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/csharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
+++ b/snippets/csharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
@@ -1,1 +1,0 @@
-1 System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/csharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
+++ b/snippets/csharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
@@ -1,1 +1,0 @@
-Demonstrates CreateObject(Type,Object), and differences from CreateObject(Type).

--- a/snippets/csharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
+++ b/snippets/csharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
@@ -1,2 +1,0 @@
-1 - System.Reflection.Emit.DynamicMethod.CreateDelegate(Type,Object)
-1 - System.Reflection.Emit.DynamicMethod.#ctor(String,Type,Type[],Type)

--- a/snippets/csharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
+++ b/snippets/csharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/csharp/VS_Snippets_WebNet/Sys.Net.WebRequestManagerOrcas/creator.txt
+++ b/snippets/csharp/VS_Snippets_WebNet/Sys.Net.WebRequestManagerOrcas/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/csharp/VS_Snippets_WebNet/System.ComponentModel.DataAnnotations2/creator.txt
+++ b/snippets/csharp/VS_Snippets_WebNet/System.ComponentModel.DataAnnotations2/creator.txt
@@ -1,1 +1,0 @@
-redmond\a-riAnde

--- a/snippets/csharp/VS_Snippets_Wpf/ClassHandling/CSharp/XAMLAPP/Creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/ClassHandling/CSharp/XAMLAPP/Creator.txt
@@ -1,1 +1,0 @@
-wingroup\micwein

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid1/creator.txt.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid1/creator.txt.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_autogencolumns/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_autogencolumns/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_cellselection/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_cellselection/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_cellstyle/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_cellstyle/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_columnsmanipulation/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_columnsmanipulation/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_customcolumns/creator.txt.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_customcolumns/creator.txt.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_frozencolumn/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_frozencolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_rowheader/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_rowheader/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_templatecolumn/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_templatecolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/datagrid_textcolumn/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/datagrid_textcolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/csharp/VS_Snippets_Wpf/wpfcustomdictionary/creator.txt
+++ b/snippets/csharp/VS_Snippets_Wpf/wpfcustomdictionary/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/fsharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/fsharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
@@ -1,1 +1,0 @@
-System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/fsharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
@@ -1,1 +1,0 @@
-1 System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/fsharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
@@ -1,1 +1,0 @@
-Demonstrates CreateObject(Type,Object), and differences from CreateObject(Type).

--- a/snippets/fsharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
@@ -1,2 +1,0 @@
-1 - System.Reflection.Emit.DynamicMethod.CreateDelegate(Type,Object)
-1 - System.Reflection.Emit.DynamicMethod.#ctor(String,Type,Type[],Type)

--- a/snippets/fsharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/fsharp/VS_Snippets_CLR/conceptual.threadpool/metatdata/creator.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/conceptual.threadpool/metatdata/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\a-galen

--- a/snippets/fsharp/VS_Snippets_CLR/conceptual.threadpool/metatdata/description.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/conceptual.threadpool/metatdata/description.txt
@@ -1,1 +1,0 @@
-Thread Pool conceptual examples.

--- a/snippets/fsharp/VS_Snippets_CLR/conceptual.threadpool/metatdata/keywords.txt
+++ b/snippets/fsharp/VS_Snippets_CLR/conceptual.threadpool/metatdata/keywords.txt
@@ -1,3 +1,0 @@
-1 System.Threading.ThreadPool
-2 System.Threading.ThreadPool
-3 System.Threading.ThreadPool

--- a/snippets/visualbasic/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\erikre

--- a/snippets/visualbasic/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/description.txt
+++ b/snippets/visualbasic/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/description.txt
@@ -1,1 +1,0 @@
-Demonstrates how to use the Sys.CultureInfo.CurrentCulture class.

--- a/snippets/visualbasic/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/keywords.txt
+++ b/snippets/visualbasic/VS_Snippets_Atlas/Sys.CultureInfo.CurrentCulture.numberFormat/keywords.txt
@@ -1,4 +1,0 @@
-1 CultureInfo
-2 CurrentCulture
-3 InvariantCulture
-4 numberFormat

--- a/snippets/visualbasic/VS_Snippets_Atlas/Sys.Net.WebRequest/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Atlas/Sys.Net.WebRequest/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/visualbasic/VS_Snippets_Atlas/Sys.Net.WebRequestManager/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Atlas/Sys.Net.WebRequestManager/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/visualbasic/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/visualbasic/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
+++ b/snippets/visualbasic/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/description.txt
@@ -1,1 +1,0 @@
-System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/visualbasic/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
+++ b/snippets/visualbasic/VS_Snippets_CLR/FieldInfo_GetFieldFromHandle2/keywords.txt
@@ -1,1 +1,0 @@
-1 System.Reflection.FieldInfo.GetFieldFromHandle(RuntimeFieldHandle,RuntimeTypeHandle)

--- a/snippets/visualbasic/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
+++ b/snippets/visualbasic/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/description.txt
@@ -1,1 +1,0 @@
-Demonstrates CreateObject(Type,Object), and differences from CreateObject(Type).

--- a/snippets/visualbasic/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
+++ b/snippets/visualbasic/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/keywords.txt
@@ -1,2 +1,0 @@
-1 - System.Reflection.Emit.DynamicMethod.CreateDelegate(Type,Object)
-1 - System.Reflection.Emit.DynamicMethod.#ctor(String,Type,Type[],Type)

--- a/snippets/visualbasic/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
+++ b/snippets/visualbasic/VS_Snippets_CLR/Reflection.DynamicMethod.ClosedOver/owner.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha

--- a/snippets/visualbasic/VS_Snippets_WebNet/Sys.Net.WebRequestManagerOrcas/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_WebNet/Sys.Net.WebRequestManagerOrcas/creator.txt
@@ -1,1 +1,0 @@
-REDMOND\mmiele 

--- a/snippets/visualbasic/VS_Snippets_WebNet/System.ComponentModel.DataAnnotations2/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_WebNet/System.ComponentModel.DataAnnotations2/creator.txt
@@ -1,1 +1,0 @@
-redmond\a-riAnde

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid1/creator.txt.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid1/creator.txt.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_autogencolumns/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_autogencolumns/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_cellselection/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_cellselection/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_cellstyle/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_cellstyle/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_columnsmanipulation/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_columnsmanipulation/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_customcolumns/creator.txt.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_customcolumns/creator.txt.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_frozencolumn/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_frozencolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_rowheader/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_rowheader/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_templatecolumn/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_templatecolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/datagrid_textcolumn/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/datagrid_textcolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/visualbasic/VS_Snippets_Wpf/wpfcustomdictionary/creator.txt
+++ b/snippets/visualbasic/VS_Snippets_Wpf/wpfcustomdictionary/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid1/creator.txt.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid1/creator.txt.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_autogencolumns/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_autogencolumns/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_cellselection/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_cellselection/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_cellstyle/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_cellstyle/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_columnsmanipulation/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_columnsmanipulation/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_customcolumns/creator.txt.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_customcolumns/creator.txt.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_frozencolumn/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_frozencolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_rowheader/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_rowheader/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_templatecolumn/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_templatecolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/datagrid_textcolumn/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/datagrid_textcolumn/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xaml/VS_Snippets_Wpf/wpfcustomdictionary/creator.txt
+++ b/snippets/xaml/VS_Snippets_Wpf/wpfcustomdictionary/creator.txt
@@ -1,1 +1,0 @@
-redmond\margp

--- a/snippets/xml/VS_Snippets_Misc/timerSelfCtor/Common/owner.txt
+++ b/snippets/xml/VS_Snippets_Misc/timerSelfCtor/Common/owner.txt
@@ -1,1 +1,0 @@
-REDMOND\glennha


### PR DESCRIPTION
I've noticed in PR #1856, that we still have some old metadata stuff in the samples repo from our Parsnip days. I'll be creating three different PRs for this.