### PR TITLE
add solution for vs get started

### DIFF
--- a/snippets/csharp/getting_started/ClassLibraryProjects/ClassLibraryProjects.sln
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/ClassLibraryProjects.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShowCase", "ShowCase\ShowCase.csproj", "{F96858A2-D91D-4904-9ADB-13B561C5C6AC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringLibrary", "StringLibrary\StringLibrary.csproj", "{BF190197-7AD1-44A7-BD44-6B4ACF457E8B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringLibraryTest", "StringLibraryTest\StringLibraryTest.csproj", "{1EA13D1F-0D7B-4BF6-8122-DEDBC97BFDE1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F96858A2-D91D-4904-9ADB-13B561C5C6AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F96858A2-D91D-4904-9ADB-13B561C5C6AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F96858A2-D91D-4904-9ADB-13B561C5C6AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F96858A2-D91D-4904-9ADB-13B561C5C6AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF190197-7AD1-44A7-BD44-6B4ACF457E8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF190197-7AD1-44A7-BD44-6B4ACF457E8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF190197-7AD1-44A7-BD44-6B4ACF457E8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF190197-7AD1-44A7-BD44-6B4ACF457E8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EA13D1F-0D7B-4BF6-8122-DEDBC97BFDE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EA13D1F-0D7B-4BF6-8122-DEDBC97BFDE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EA13D1F-0D7B-4BF6-8122-DEDBC97BFDE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EA13D1F-0D7B-4BF6-8122-DEDBC97BFDE1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E4732236-4A31-4BE0-881B-E5EA96608C56}
+	EndGlobalSection
+EndGlobal

--- a/snippets/csharp/getting_started/ClassLibraryProjects/ShowCase/Program.cs
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/ShowCase/Program.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using UtilityLibraries;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        int row = 0; 
+
+        do
+        {
+            if (row == 0 || row >= 25)
+               ResetConsole();
+
+            string input = Console.ReadLine();
+            if (String.IsNullOrEmpty(input)) break;
+            Console.WriteLine($"Input: {input} {"Begins with uppercase? ",30}: " +
+                              $"{(input.StartsWithUpper() ? "Yes" : "No")}\n");
+            row += 3;                  
+        } while (true);
+        return;
+
+        // Declare a ResetConsole local method
+        void ResetConsole()
+        {
+            if (row > 0) {
+               Console.WriteLine("Press any key to continue...");
+               Console.ReadKey();
+            }   
+            Console.Clear();
+            Console.WriteLine("\nPress <Enter> only to exit; otherwise, enter a string and press <Enter>:\n");
+            row = 3;  
+        }
+    }
+}
+

--- a/snippets/csharp/getting_started/ClassLibraryProjects/ShowCase/Program.cs
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/ShowCase/Program.cs
@@ -15,7 +15,7 @@ class Program
             string input = Console.ReadLine();
             if (String.IsNullOrEmpty(input)) break;
             Console.WriteLine($"Input: {input} {"Begins with uppercase? ",30}: " +
-                              $"{(input.StartsWithUpper() ? "Yes" : "No")}\n");
+                              input.StartsWithUpper() ? "Yes\n" : "No\n";
             row += 3;                  
         } while (true);
         return;
@@ -23,7 +23,8 @@ class Program
         // Declare a ResetConsole local method
         void ResetConsole()
         {
-            if (row > 0) {
+            if (row > 0)
+            {
                Console.WriteLine("Press any key to continue...");
                Console.ReadKey();
             }   
@@ -33,4 +34,3 @@ class Program
         }
     }
 }
-

--- a/snippets/csharp/getting_started/ClassLibraryProjects/ShowCase/ShowCase.csproj
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/ShowCase/ShowCase.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/csharp/getting_started/ClassLibraryProjects/StringLibrary/Class1.cs
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/StringLibrary/Class1.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace UtilityLibraries
+{
+    public static class StringLibrary
+    {
+        public static bool StartsWithUpper(this String str)
+        {
+            if (String.IsNullOrWhiteSpace(str))
+                return false;
+
+            Char ch = str[0];
+            return Char.IsUpper(ch);
+        }
+    }
+}

--- a/snippets/csharp/getting_started/ClassLibraryProjects/StringLibrary/StringLibrary.csproj
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/StringLibrary/StringLibrary.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/csharp/getting_started/ClassLibraryProjects/StringLibraryTest/StringLibraryTest.csproj
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/StringLibraryTest/StringLibraryTest.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/snippets/csharp/getting_started/ClassLibraryProjects/StringLibraryTest/StringLibraryTest.csproj
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/StringLibraryTest/StringLibraryTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/snippets/csharp/getting_started/ClassLibraryProjects/StringLibraryTest/UnitTest1.cs
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/StringLibraryTest/UnitTest1.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UtilityLibraries;
+
+namespace StringLibraryTest
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestStartsWithUpper()
+        {
+            // Tests that we expect to return true.
+            string[] words = { "Alphabet", "Zebra", "ABC", "Αθήνα", "Москва" };
+            foreach (var word in words)
+            {
+                bool result = word.StartsWithUpper();
+                Assert.IsTrue(result,
+                       String.Format("Expected for '{0}': true; Actual: {1}",
+                                     word, result));
+            }
+        }
+
+        [TestMethod]
+        public void TestDoesNotStartWithUpper()
+        {
+            // Tests that we expect to return false.
+            string[] words = { "alphabet", "zebra", "abc", "αυτοκινητοβιομηχανία", "государство",
+                               "1234", ".", ";", " " };
+            foreach (var word in words)
+            {
+                bool result = word.StartsWithUpper();
+                Assert.IsFalse(result,
+                       String.Format("Expected for '{0}': false; Actual: {1}",
+                                     word, result));
+            }
+        }
+
+        [TestMethod]
+        public void DirectCallWithNullOrEmpty()
+        {
+            // Tests that we expect to return false.
+            string[] words = { string.Empty, null };
+            foreach (var word in words)
+            {
+                bool result = StringLibrary.StartsWithUpper(word);
+                Assert.IsFalse(result,
+                       String.Format("Expected for '{0}': false; Actual: {1}",
+                                     word == null ? "<null>" : word, result));
+            }
+        }
+    }
+}

--- a/snippets/csharp/getting_started/ClassLibraryProjects/StringLibraryTest/UnitTest1.cs
+++ b/snippets/csharp/getting_started/ClassLibraryProjects/StringLibraryTest/UnitTest1.cs
@@ -16,8 +16,7 @@ namespace StringLibraryTest
             {
                 bool result = word.StartsWithUpper();
                 Assert.IsTrue(result,
-                       String.Format("Expected for '{0}': true; Actual: {1}",
-                                     word, result));
+                       $"Expected for '{word}': true; Actual: {result}");
             }
         }
 
@@ -31,8 +30,7 @@ namespace StringLibraryTest
             {
                 bool result = word.StartsWithUpper();
                 Assert.IsFalse(result,
-                       String.Format("Expected for '{0}': false; Actual: {1}",
-                                     word, result));
+                       $"Expected for '{word}': false; Actual: {result}");
             }
         }
 


### PR DESCRIPTION
The lack of solution files and projects makes much harder to update screenshots

Contributes to https://github.com/dotnet/docs/issues/16046

Same should be done for VB

I'll keep https://github.com/dotnet/docs/pull/16367 using the old files for now.