### PR TITLE
[Nullable introduction] Display question text

### DIFF
--- a/csharp/NullableIntroduction/NullableIntroduction/Program.cs
+++ b/csharp/NullableIntroduction/NullableIntroduction/Program.cs
@@ -26,7 +26,7 @@ namespace NullableIntroduction
                     for (int i = 0; i < surveyRun.Questions.Count; i++)
                     {
                         var answer = participant.Answer(i);
-                        Console.WriteLine($"\t{surveyRun.GetQuestion(i)} : {answer}");
+                        Console.WriteLine($"\t{surveyRun.GetQuestion(i).QuestionText} : {answer}");
                     }
                 }
                 else


### PR DESCRIPTION
## Summary
Display question text instead of `SurveyQuestion` class name by getting `QuestionText` property.  

Currently output of the program looks like this: 
```
Participant: 310665984:
        NullableIntroduction.SurveyQuestion : No
        NullableIntroduction.SurveyQuestion : 24
        NullableIntroduction.SurveyQuestion : Red. No, Green. Wait.. Blue... AAARGGGGGHHH!
```
because `QuestionText` is not used when printing the question to console and `SurveyQuestion` has no `ToString` method. 

After the change:
```
Participant: 310665984:
        Has your code ever thrown a NullReferenceException? : No
        How many times (to the nearest 100) has that happened? : 24
        What is your favorite color? : Red. No, Green. Wait.. Blue... AAARGGGGGHHH!
```