### PR TITLE
Fix probable bug in sample snippet

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/conceptual.choosingdates/cs/datetimereplacement1.cs
+++ b/snippets/csharp/VS_Snippets_CLR/conceptual.choosingdates/cs/datetimereplacement1.cs
@@ -31,7 +31,7 @@ public struct StoreInfo
             delta = local.GetAdjustmentRules()[local.GetAdjustmentRules().Length - 1].DaylightDelta;
 
          if (tz.IsDaylightSavingTime(TimeZoneInfo.ConvertTime(DateTime.Now.Date + time, local, tz)))
-            storeDelta = tz.GetAdjustmentRules()[local.GetAdjustmentRules().Length - 1].DaylightDelta;
+            storeDelta = tz.GetAdjustmentRules()[tz.GetAdjustmentRules().Length - 1].DaylightDelta;
 
          TimeSpan comparisonTime = time + (offset - tz.BaseUtcOffset).Negate() + (delta - storeDelta).Negate();
          return comparisonTime >= open & comparisonTime <= close;


### PR DESCRIPTION
I am pretty sure this is a bug, which was likely caused by copying code when this was made.
I think it is a bug because I think it could lead to using the wrong adjustment rule when the two time zones in question have different numbers of adjustment rules, and could even cause an index out of range error if local has more adjustment rules than tz.

## Summary

Use length of tz adjustment rules for indexing into tz adjustment rules (rather than using length of local adjustment rules for indexing into tz adjustment rules).