### PR TITLE
Revert bad change from dependabot

### DIFF
--- a/framework/libraries/frameworks-library/src/Library/Library.csproj
+++ b/framework/libraries/frameworks-library/src/Library/Library.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <PackageReference Include="NETStandard.Library" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31348972/71780788-b6cf5c00-2fcf-11ea-954b-f004cfe1e1ef.png)

NETStandard.Library 2.0.3 isn't compatible with net40.
I've reverted it back to 1.6.0 and it builds.

The related dependabot PR is #1309