### PR TITLE
Improve Process.Exited sample

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.Diagnostics.Process.EnableExited/CS/processexitedevent.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Diagnostics.Process.EnableExited/CS/processexitedevent.cs
@@ -47,7 +47,7 @@ class PrintProcessClass
     }
 
     public static async Task Main(string[] args)
-    {        
+    {
         // Verify that an argument has been entered.
         if (args.Length <= 0)
         {

--- a/snippets/csharp/VS_Snippets_CLR_System/system.Diagnostics.Process.EnableExited/CS/processexitedevent.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Diagnostics.Process.EnableExited/CS/processexitedevent.cs
@@ -47,8 +47,7 @@ class PrintProcessClass
     }
 
     public static async Task Main(string[] args)
-    {
-        
+    {        
         // Verify that an argument has been entered.
         if (args.Length <= 0)
         {
@@ -58,7 +57,7 @@ class PrintProcessClass
 
         // Create the process and print the document.
         PrintProcessClass myPrintProcess = new PrintProcessClass();
-        await myPrintProcess.PrintDoc(args[0]);        
+        await myPrintProcess.PrintDoc(args[0]);
     }
 }
 //</snippet1>

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.Diagnostics.Process.EnableExited/VB/processexitedevent.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.Diagnostics.Process.EnableExited/VB/processexitedevent.vb
@@ -1,28 +1,24 @@
 ﻿'<snippet1>
 Imports System.Diagnostics
-Imports System.Threading
 
 Class PrintProcessClass
 
     Private WithEvents myProcess As Process
-    Private elapsedTime As Integer
-    Private eventHandled As Boolean
-
-    Public Event Exited As EventHandler
+    Private eventHandled As TaskCompletionSource(Of Boolean)
 
     ' Print a file with any known extension.
-    Sub PrintDoc(ByVal fileName As String)
+    Async Function PrintDoc(ByVal fileName As String) As Task
 
-        elapsedTime = 0
-        eventHandled = False
-
-        Using myProcess = New Process
+        eventHandled = New TaskCompletionSource(Of Boolean)()
+        myProcess = New Process
+        Using myProcess
             Try
                 ' Start a process to print a file and raise an event when done.
                 myProcess.StartInfo.FileName = fileName
                 myProcess.StartInfo.Verb = "Print"
                 myProcess.StartInfo.CreateNoWindow = True
                 myProcess.EnableRaisingEvents = True
+                AddHandler myProcess.Exited, New EventHandler(AddressOf myProcess_Exited)
                 myProcess.Start()
 
             Catch ex As Exception
@@ -30,30 +26,24 @@ Class PrintProcessClass
                 vbCrLf & ex.Message, fileName)
                 Return
             End Try
-        End Using
 
-        ' Wait for Exited event, but not more than 30 seconds.
-        Const SLEEP_AMOUNT As Integer = 100
-        Do While Not eventHandled
-            elapsedTime += SLEEP_AMOUNT
-            If elapsedTime > 30000 Then
-                Exit Do
-            End If
-            Thread.Sleep(SLEEP_AMOUNT)
-        Loop
-    End Sub
+            ' Wait for Exited event, but not more than 30 seconds.
+            Await Task.WhenAny(eventHandled.Task, Task.Delay(30000))
+        End Using
+    End Function
 
     ' Handle Exited event and display process information.
     Private Sub myProcess_Exited(ByVal sender As Object,
-            ByVal e As System.EventArgs) Handles myProcess.Exited
+            ByVal e As System.EventArgs)
 
-        eventHandled = True
         Console.WriteLine("Exit time:    {0}" & vbCrLf &
             "Exit code:    {1}" & vbCrLf & "Elapsed time: {2}",
-            myProcess.ExitTime, myProcess.ExitCode, elapsedTime)
+            myProcess.ExitTime, myProcess.ExitCode,
+            Math.Round((myProcess.ExitTime - myProcess.StartTime).TotalMilliseconds))
+        eventHandled.TrySetResult(True)
     End Sub
 
-    Shared Sub Main(ByVal args() As String)
+    Shared Sub Main(ByVal args As String())
 
         ' Verify that an argument has been entered.
         If args.Length <= 0 Then
@@ -63,7 +53,8 @@ Class PrintProcessClass
 
         ' Create the process and print the document.
         Dim myPrintProcess As New PrintProcessClass
-        myPrintProcess.PrintDoc(args(0))
+        myPrintProcess.PrintDoc(args(0)).Wait()
+
     End Sub
 End Class
 '</snippet1>


### PR DESCRIPTION
## Summary

The current [Process.Exited](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.exited?view=netframework-4.8) example uses while loop to check when background thread sets the boolean field to wait for an event handler execution. This has a race condition, because the field is not marked volatile, and wastes CPU time. I suggested to make methods async and replace a loop with an await on TaskCompletionSource. Also it currently adds the amount of sleeps to calculate the elapsed time, but the simpler and more accurate way would be to simply subtract Process.StartTime from Process.ExitTime.

Replacement for https://github.com/dotnet/dotnet-api-docs/pull/3666 (that PR should be closed)

 
