### PR TITLE
Update samples for INotifyPropertyChanged (#10675)

### DIFF
--- a/snippets/csharp/VS_Snippets_Wpf/SimpleBinding/CSharp/Person.cs
+++ b/snippets/csharp/VS_Snippets_Wpf/SimpleBinding/CSharp/Person.cs
@@ -1,5 +1,6 @@
 ﻿//<SnippetPersonClass>
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace SDKSample
 {
@@ -29,18 +30,15 @@ namespace SDKSample
           {
               name = value;
               // Call OnPropertyChanged whenever the property is updated
-              OnPropertyChanged("PersonName");
+              OnPropertyChanged();
           }
       }
 
       // Create the OnPropertyChanged method to raise the event
-      protected void OnPropertyChanged(string name)
+      // The calling member's name will be used as the parameter.
+      protected void OnPropertyChanged([CallerMemberName] string name = null)
       {
-          PropertyChangedEventHandler handler = PropertyChanged;
-          if (handler != null)
-          {
-              handler(this, new PropertyChangedEventArgs(name));
-          }
+          PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
       }
   }
 }

--- a/snippets/visualbasic/VS_Snippets_Wpf/SimpleBinding/VisualBasic/Person.vb
+++ b/snippets/visualbasic/VS_Snippets_Wpf/SimpleBinding/VisualBasic/Person.vb
@@ -1,5 +1,6 @@
 ﻿'<SnippetPersonClass>
 Imports System.ComponentModel
+Imports System.Runtime.CompilerServices
 
 ' This class implements INotifyPropertyChanged
 ' to support one-way and two-way bindings
@@ -27,12 +28,13 @@ Public Class Person
         Set(ByVal value As String)
             personName = value
             ' Call OnPropertyChanged whenever the property is updated
-            OnPropertyChanged("Name")
+            OnPropertyChanged()
         End Set
     End Property
 
     ' Create the OnPropertyChanged method to raise the event
-    Protected Sub OnPropertyChanged(ByVal name As String)
+    ' Use the name of the member that called this method in place of name
+    Protected Sub OnPropertyChanged(<CallerMemberName> Optional name As String = Nothing)
         RaiseEvent PropertyChanged(Me, New PropertyChangedEventArgs(name))
     End Sub
 


### PR DESCRIPTION
## Summary

This PR updates the C# and VB .NET samples for `INotifyPropertyChanged`.

This now uses the `CallerMemberName` attribute for the `OnPropertyChanged` method's name parameter.

Additionally, more concise null checking is done on the C# `PropertyChanged` invocation.

I was originally thinking of using `nameof(Name)` instead of using `CallerMemberAttribute`, but this is more concise and the way I would recommend members of the community do so as this is a big part of why this attribute was created.

Fixes dotnet/docs#10675
