### PR TITLE
Modify references to PluginBase with ExcludeAssets

### DIFF
--- a/core/extensions/AppWithPlugin/FrenchPlugin/FrenchPlugin.csproj
+++ b/core/extensions/AppWithPlugin/FrenchPlugin/FrenchPlugin.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PluginBase\PluginBase.csproj">
       <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
 

--- a/core/extensions/AppWithPlugin/HelloPlugin/HelloPlugin.csproj
+++ b/core/extensions/AppWithPlugin/HelloPlugin/HelloPlugin.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PluginBase\PluginBase.csproj">
       <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
 

--- a/core/extensions/AppWithPlugin/JsonPlugin/JsonPlugin.csproj
+++ b/core/extensions/AppWithPlugin/JsonPlugin/JsonPlugin.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PluginBase\PluginBase.csproj">
       <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
 

--- a/core/extensions/AppWithPlugin/OldJsonPlugin/OldJsonPlugin.csproj
+++ b/core/extensions/AppWithPlugin/OldJsonPlugin/OldJsonPlugin.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PluginBase\PluginBase.csproj">
       <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
 

--- a/core/extensions/AppWithPlugin/UVPlugin/UVPlugin.csproj
+++ b/core/extensions/AppWithPlugin/UVPlugin/UVPlugin.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PluginBase\PluginBase.csproj">
       <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
 

--- a/core/extensions/AppWithPlugin/XcopyablePlugin/XcopyablePlugin.csproj
+++ b/core/extensions/AppWithPlugin/XcopyablePlugin/XcopyablePlugin.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PluginBase\PluginBase.csproj">
       <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Private=false is not enough to not include the references assets in the output if the referenced project references packages in its closure. In that case the same effect is achieved by ExcludeAssets=runtime.

So the best approach to is to specify both. Note that this change is not needed for the sample to work (as the PluginBase doesn't reference packages), but it's a good practice for samples as it will make customr code work if they do have package references.

Fixes #1760 
