### PR TITLE
Fixing typo on Windows Form Control Members

### DIFF
--- a/snippets/cpp/VS_Snippets_Winforms/Windows.Forms.Control Members4/CPP/controlmembers4.cpp
+++ b/snippets/cpp/VS_Snippets_Winforms/Windows.Forms.Control Members4/CPP/controlmembers4.cpp
@@ -188,7 +188,7 @@ namespace ControlMembers4
          {
             treeView1->LabelEdit = true;
             
-            // If there is a TreeNode under the mose cursor, begin editing.
+            // If there is a TreeNode under the mouse cursor, begin editing.
             TreeNode^ editNode = treeView1->GetNodeAt( treeView1->PointToClient( Control::MousePosition ) );
             if ( editNode != nullptr )
             {

--- a/snippets/csharp/VS_Snippets_Winforms/Windows.Forms.Control Members4/CS/controlmembers4.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/Windows.Forms.Control Members4/CS/controlmembers4.cs
@@ -181,7 +181,7 @@ private void treeView1_KeyDown(object sender, KeyEventArgs e)
          
    {
       treeView1.LabelEdit = true;
-      // If there is a TreeNode under the mose cursor, begin editing. 
+      // If there is a TreeNode under the mouse cursor, begin editing. 
       TreeNode editNode = treeView1.GetNodeAt(
          treeView1.PointToClient(System.Windows.Forms.Control.MousePosition));
       if(editNode != null)

--- a/snippets/visualbasic/VS_Snippets_Winforms/Windows.Forms.Control Members4/VB/controlmembers4.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/Windows.Forms.Control Members4/VB/controlmembers4.vb
@@ -138,7 +138,7 @@ Private Sub treeView1_KeyDown(sender As Object, _
    ' allow the user to edit the TreeNode label. 
    If e.Alt And e.KeyCode = Keys.E Then
       treeView1.LabelEdit = True
-      ' If there is a TreeNode under the mose cursor, begin editing. 
+      ' If there is a TreeNode under the mouse cursor, begin editing. 
       Dim editNode As TreeNode = treeView1.GetNodeAt( _
         treeView1.PointToClient(System.Windows.Forms.Control.MousePosition))
       If (editNode IsNot Nothing) Then


### PR DESCRIPTION
## Summary
Fixing typo on Windows Form Control Members  where mose was written instead of mouse


Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)