### PR TITLE
Update DocComments.cs

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDocComments/CS/DocComments.cs
@@ -357,6 +357,11 @@ namespace Wrap11
     /// </summary>
     /// <typeparam name="T"></typeparam>
     class C<T> { }
+    
+    class Program
+    {
+        static void Main() { }
+    }
     //</Snippet11>
 }
 


### PR DESCRIPTION
This sample is used in <https://docs.microsoft.com/dotnet/csharp/programming-guide/xmldoc/summary>

Without having a `Main` method, running csc with -doc will generate the following error.

> error CS5001: Program does not contain a static 'Main' method suitable for an entry point