### PR TITLE
Use string interpolation in snippet7

### DIFF
--- a/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
+++ b/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs
@@ -67,7 +67,7 @@ namespace Coding_Conventions_Examples
             {
                 manyPhrases.Append(phrase);
             }
-            //Console.WriteLine("tra" + manyPhrases);
+            //Console.WriteLine($"tra{manyPhrases}");
             //</snippet7>
 
             //<snippet8>


### PR DESCRIPTION
Snippet 7 reads:
`//Console.WriteLine("tra" + manyPhrases);`

In accordance with snippet6 it should read to be consistent:
`//Console.WriteLine($"tra{manyPhrases}");`

Unless part of the point of snippet7 is to also highlight performance differences between `System.String.Concat` (IL generated when using '+') and `System.String.Format` (IL generated when using string interpolation), in which case this pull request should be rejected.

## Summary

Describe your changes here.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
