### PR TITLE
Update HostWithHostFxr sample to call a managed function with a non-default signature

### DIFF
--- a/core/hosting/HostWithHostFxr/readme.md
+++ b/core/hosting/HostWithHostFxr/readme.md
@@ -50,6 +50,9 @@ Hello, world! from Lib [count: 2]
 Hello, world! from Lib [count: 3]
 -- message: from host!
 -- number: 2
+Hello, world! from CustomEntryPoint in Lib
+-- message: from host!
+-- number: -1
 ```
 
 Note: The way the sample is built is relatively complicated. The goal is that it's possible to build and run the sample with simple `dotnet run` with minimal requirements on pre-installed tools. Typically, real-world projects that have both managed and native components will use different build systems for each; for example, msbuild/dotnet for managed and CMake for native.

--- a/core/hosting/HostWithHostFxr/src/DotNetLib/Lib.cs
+++ b/core/hosting/HostWithHostFxr/src/DotNetLib/Lib.cs
@@ -13,7 +13,7 @@ namespace DotNetLib
             public IntPtr Message;
             public int Number;
         }
-        
+
         public static int Hello(IntPtr arg, int argLength)
         {
             if (argLength < System.Runtime.InteropServices.Marshal.SizeOf(typeof(LibArgs)))
@@ -22,14 +22,26 @@ namespace DotNetLib
             }
 
             LibArgs libArgs = Marshal.PtrToStructure<LibArgs>(arg);
+            Console.WriteLine($"Hello, world! from {nameof(Lib)} [count: {s_CallCount++}]");
+            PrintLibArgs(libArgs);
+            return 0;
+        }
+
+        public delegate void CustomEntryPointDelegate(LibArgs libArgs);
+        public static void CustomEntryPoint(LibArgs libArgs)
+        {
+            Console.WriteLine($"Hello, world! from {nameof(CustomEntryPoint)} in {nameof(Lib)}");
+            PrintLibArgs(libArgs);
+        }
+
+        private static void PrintLibArgs(LibArgs libArgs)
+        {
             string message = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? Marshal.PtrToStringUni(libArgs.Message)
                 : Marshal.PtrToStringUTF8(libArgs.Message);
 
-            Console.WriteLine($"Hello, world! from {nameof(Lib)} [count: {s_CallCount++}]");
             Console.WriteLine($"-- message: {message}");
             Console.WriteLine($"-- number: {libArgs.Number}");
-            return 0;
         }
     }
 }

--- a/core/hosting/HostWithHostFxr/src/NativeHost/nativehost.cpp
+++ b/core/hosting/HostWithHostFxr/src/NativeHost/nativehost.cpp
@@ -128,6 +128,25 @@ int main(int argc, char *argv[])
         // </SnippetCallManaged>
     }
 
+    // Function pointer to managed delegate with non-default signature
+    typedef void (CORECLR_DELEGATE_CALLTYPE *custom_entry_point_fn)(lib_args args);
+    custom_entry_point_fn custom = nullptr;
+    rc = load_assembly_and_get_function_pointer(
+        dotnetlib_path.c_str(),
+        dotnet_type,
+        STR("CustomEntryPoint") /*method_name*/,
+        STR("DotNetLib.Lib+CustomEntryPointDelegate, DotNetLib") /*delegate_type_name*/,
+        nullptr,
+        (void**)&custom);
+    assert(rc == 0 && custom != nullptr && "Failure: load_assembly_and_get_function_pointer()");
+
+    lib_args args
+    {
+        STR("from host!"),
+        -1
+    };
+    custom(args);
+
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
The HostWithHostFxr sample only showed getting a pointer to a managed function that had the default signature and used the default delegate type. This change updates the sample to also call a managed function with a different signature.