### PR TITLE
Fix age calculation in deconstructing tuples sample

### DIFF
--- a/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-ambiguous.cs
+++ b/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-ambiguous.cs
@@ -15,9 +15,11 @@ public class Person
         fname = FirstName;
         mname = MiddleName;
         lname = LastName;
-        age = DateTime.Now.Year - DateOfBirth.Year;
 
-        if (DateTime.Now.DayOfYear - (new DateTime(DateTime.Now.Year, DateOfBirth.Month, DateOfBirth.Day)).DayOfYear < 0)
+        // calculate the person's age
+        var today = DateTime.Today;
+        age = today.Year - DateOfBirth.Year;
+        if (DateOfBirth.Date > today.AddYears(-age))
             age--;
     }
 


### PR DESCRIPTION
The age calculation in this sample was incorrect, and would fail for Feb 29th birth dates unless the current year is a leap year.

Though age calc is not the primary purpose of the example, it's still good to show it correctly to avoid copy/paste bugs.

The method used is the widely accepted approach from https://stackoverflow.com/questions/9/how-do-i-calculate-someones-age-in-c/1404#1404