### PR TITLE
Fix date calculation bug in MonthCalendarSelection example

### DIFF
--- a/snippets/cpp/VS_Snippets_Winforms/System.Windows.Forms.MonthCalendarSelection/CPP/form1.cpp
+++ b/snippets/cpp/VS_Snippets_Winforms/System.Windows.Forms.MonthCalendarSelection/CPP/form1.cpp
@@ -2,6 +2,7 @@
 #using <System.dll>
 #using <System.Windows.Forms.dll>
 
+using namespace System;
 using namespace System::Windows::Forms;
 
 public ref class Form1: public System::Windows::Forms::Form
@@ -35,21 +36,13 @@ private:
    // Computes a week one month from today.
    void ShowAWeeksVacationOneMonthFromToday()
    {
-      System::DateTime today = this->MonthCalendar1->TodayDate;
-      int vacationMonth = today.Month + 1;
-      int vacationYear = today.Year;
+      DateTime today = this->MonthCalendar1->TodayDate;
+      DateTime vacationStart = today.AddMonths(1);
+      DateTime vacationEnd = vacationStart.AddDays(7);
 
-      if ( today.Month == 12 )
-      {
-         vacationMonth = 1;
-         ++vacationYear;
-      }
-      
       // Select the week using SelectionStart and SelectionEnd.
-      this->MonthCalendar1->SelectionStart =
-         System::DateTime( today.Year, vacationMonth, today.Day - 1 );
-      this->MonthCalendar1->SelectionEnd =
-         System::DateTime( today.Year, vacationMonth, today.Day + 6 );
+      this->MonthCalendar1->SelectionStart = vacationStart.AddDays(-1);
+      this->MonthCalendar1->SelectionEnd = vacationEnd.AddDays(-1);
    }
    //</snippet1>
 };

--- a/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.MonthCalendarSelection/CS/form1.cs
+++ b/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.MonthCalendarSelection/CS/form1.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
 
 public class Form1:
 	System.Windows.Forms.Form
@@ -30,21 +31,13 @@ public class Form1:
 	// Computes a week one month from today.
 	private void ShowAWeeksVacationOneMonthFromToday()
 	{
-		System.DateTime today = this.MonthCalendar1.TodayDate;
-		int vacationMonth = today.Month + 1;
-		int vacationYear = today.Year;
-
-		if (today.Month == 12)
-		{
-			vacationMonth = 1;
-			++vacationYear;
-		}
+		DateTime today = this.MonthCalendar1.TodayDate;
+		DateTime vacationStart = today.AddMonths(1);
+		DateTime vacationEnd = vacationStart.AddDays(7);
 
 		// Select the week using SelectionStart and SelectionEnd.
-		this.MonthCalendar1.SelectionStart = 
-			new System.DateTime(today.Year, vacationMonth, today.Day-1);
-		this.MonthCalendar1.SelectionEnd = 
-			new System.DateTime(today.Year, vacationMonth, today.Day+6);
+		this.MonthCalendar1.SelectionStart = vacationStart.AddDays(-1);
+		this.MonthCalendar1.SelectionEnd = vacationEnd.AddDays(-1);
 	}
 	//</snippet1>
 	public static void Main()

--- a/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.MonthCalendarSelection/VB/form1.vb
+++ b/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.MonthCalendarSelection/VB/form1.vb
@@ -28,19 +28,12 @@ Public Class Form1
 
     ' Computes a week one month from today.
     Private Sub ShowAWeeksVacationOneMonthFromToday()
-         
         Dim today As Date = monthCalendar1.TodayDate
-        Dim vacationMonth As Integer = today.Month + 1
-        Dim vacationYear As Integer = today.Year
-        If (today.Month = 12) Then
-            vacationYear += 1
-            vacationMonth = 1
-        End If
+        Dim vacationStart = today.AddMonths(1)
+        Dim vacationEnd = vacationStart.AddDays(7)
 
-        Me.monthCalendar1.SelectionStart = _
-            New Date(vacationYear, vacationMonth, today.Day - 1)
-        Me.monthCalendar1.SelectionEnd = _
-            New Date(vacationYear, vacationMonth, today.Day + 6)
+        Me.monthCalendar1.SelectionStart = vacationStart.AddDays(-1)
+        Me.monthCalendar1.SelectionEnd = vacationEnd.AddDays(-1)
     End Sub
     '</snippet1>
 


### PR DESCRIPTION
The date manipulation being performed in these samples was incorrect, and would throw `ArgumentOutOfRangeException` in cases such as when the date was the first day of any month (because `today.Day - 1` would be `0`, which is invalid for the `DateTime` constructor).

The change corrects this by using `AddMonths` and `AddDays` methods.

Aside - it's unclear to me why `SelectionStart` and `SelectionEnd` need to be reduced by one day.  The docs don't spell that out, but the original samples did this and I needed to keep an `AddDays(-1)` to retain the same effect on the control.  Perhaps something here is 0-based instead of 1-based?