### PR TITLE
remove snippet tags

### DIFF
--- a/snippets/common/VS_Snippets_WebNet/system.web.ui.clientidmode/common/seasons.ascx
+++ b/snippets/common/VS_Snippets_WebNet/system.web.ui.clientidmode/common/seasons.ascx
@@ -1,6 +1,4 @@
-﻿<!-- <Snippet1> -->
-<%@ Control AutoEventWireup="true" %>
-<!-- <Snippet4> -->
+﻿<%@ Control AutoEventWireup="true" %>
 
 <script type="text/javascript">
   var seasonalSports = new Array("None selected",
@@ -15,11 +13,8 @@
   }    
 </script>
 
-<!-- </Snippet4> -->
-<!-- <Snippet5> --> 
 <asp:DropDownList ID="DropDownList1" runat="server" 
                   onchange="DisplaySport(this.selectedIndex);">
-  <%-- </Snippet5> --%>
   <asp:ListItem Value="Select a season"></asp:ListItem>
   <asp:ListItem Value="Spring"></asp:ListItem>
   <asp:ListItem Value="Summer"></asp:ListItem>
@@ -29,4 +24,3 @@
 <br />
 <asp:Label ID="SelectedSport" runat="server" ClientIDMode="Static">
 </asp:Label>
-<!-- </Snippet1> -->

--- a/snippets/common/VS_Snippets_WebNet/system.web.ui.clientidmode/common/seasons.aspx
+++ b/snippets/common/VS_Snippets_WebNet/system.web.ui.clientidmode/common/seasons.aspx
@@ -1,5 +1,4 @@
-﻿<!-- <Snippet2> -->
-<%@ Page Title="" MasterPageFile="~/Seasons.master" AutoEventWireup="true" %>
+﻿<%@ Page Title="" MasterPageFile="~/Seasons.master" AutoEventWireup="true" %>
 
 <%@ Register Src="Seasons.ascx" TagName="Seasons" TagPrefix="uc1" %>
 <asp:Content ID="Content1" ContentPlaceHolderID="head" runat="Server">
@@ -7,4 +6,3 @@
 <asp:Content ID="Content2" ContentPlaceHolderID="ContentPlaceHolder1" runat="Server">
   <uc1:Seasons ID="Seasons1" runat="server" />
 </asp:Content>
-<!-- </Snippet2> -->

--- a/snippets/common/VS_Snippets_WebNet/system.web.ui.clientidmode/common/seasons.master
+++ b/snippets/common/VS_Snippets_WebNet/system.web.ui.clientidmode/common/seasons.master
@@ -1,5 +1,4 @@
-﻿<!-- <Snippet3> -->
-<%@ Master AutoEventWireup="true" %>
+﻿<%@ Master AutoEventWireup="true" %>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
@@ -19,4 +18,3 @@
     </form>
 </body>
 </html>
-<!-- </Snippet3> -->


### PR DESCRIPTION
I'm fixing an issue with missing snippets on dotnet-api-docs but the snippet reference doesn't hide these, so removing them completely

https://docs.microsoft.com/en-us/dotnet/api/system.web.ui.control.clientid#examples