### PR TITLE
put interface related samples in cohesive project

### DIFF
--- a/snippets/csharp/interfaces/ExplicitImplementation.cs
+++ b/snippets/csharp/interfaces/ExplicitImplementation.cs
@@ -1,0 +1,143 @@
+using System;
+
+namespace interfaces
+{
+    public class InterfaceSnippets 
+    {
+        public static void TestInterfaces()
+        {
+            InheritMultipleInterfaces.MultipleInterfaceMethods();
+            MultipleExplicitImplementation.CallExplicitImplementation();
+            DefaultInterfaceMethods.CallDefaultImplementation();
+        }
+
+        private static class InheritMultipleInterfaces
+        {
+            // <SnippetDefineTypes>
+            public interface IControl
+            {
+                void Paint();
+            }
+            public interface ISurface
+            {
+                void Paint();
+            }
+            public class SampleClass : IControl, ISurface
+            {
+                // Both ISurface.Paint and IControl.Paint call this method. 
+                public void Paint()
+                {
+                    Console.WriteLine("Paint method in SampleClass");
+                }
+            }
+            // <SnippetDefineTypes>
+
+            public static void MultipleInterfaceMethods()
+            {
+                // <SnippetCallMethods>
+                SampleClass sample = new SampleClass();
+                IControl control = sample;
+                ISurface surface = sample;
+
+                // The following lines all call the same method.
+                sample.Paint();
+                control.Paint();
+                surface.Paint();
+                // Output:
+                // Paint method in SampleClass
+                // Paint method in SampleClass
+                // Paint method in SampleClass
+                // </SnippetCallMethods>
+            }
+        }
+
+        private static class MultipleExplicitImplementation
+        {
+            public interface IControl
+            {
+                void Paint();
+            }
+            public interface ISurface
+            {
+                void Paint();
+            }
+            // <SnippetExplicitImplementation>
+            public class SampleClass : IControl, ISurface
+            {
+                void IControl.Paint()
+                {
+                    System.Console.WriteLine("IControl.Paint");
+                }
+                void ISurface.Paint()
+                {
+                    System.Console.WriteLine("ISurface.Paint");
+                }
+            }
+            // </SnippetExplicitImplementation>
+
+            public static void CallExplicitImplementation()
+            {
+                //<SnippetCallExplicitImplementation>
+                // Call the Paint methods from Main.
+
+                SampleClass obj = new SampleClass();
+                //obj.Paint();  // Compiler error.
+
+                IControl c = obj;
+                c.Paint();  // Calls IControl.Paint on SampleClass.
+
+                ISurface s = obj;
+                s.Paint(); // Calls ISurface.Paint on SampleClass.
+
+                // Output:
+                // IControl.Paint
+                // ISurface.Paint
+                //</SnippetCallExplicitImplementation>
+           }
+        }
+
+        private static class NameCollisions
+        {
+            //<SnippetNameCollision>
+            interface ILeft
+            {
+                int P { get;}
+            }
+            interface IRight
+            {
+                int P();
+            }
+
+            class Middle : ILeft, IRight
+            {
+                public int P() { return 0; }
+                int ILeft.P { get { return 0; } }
+            }
+            //</SnippetNameCollision>
+        }
+
+        private static class DefaultInterfaceMethods
+        {
+            // <SnippetDefaultImplementation>
+            public interface IControl
+            {
+                void Paint() => Console.WriteLine("Default Paint method");
+            }
+            public class SampleClass : IControl
+            {
+                // Paint() is inherited from IControl.
+            }
+            // </SnippetDefaultImplementation>
+            public static void CallDefaultImplementation()
+            {
+                // <SnippetCallDefaultImplementation>
+                var sample = new SampleClass();
+                //sample.Paint();// "Paint" isn't accessible.
+                var control = sample as IControl;
+                control.Paint();
+                // </SnippetCallDefaultImplementation>
+            }
+        }
+    }
+}
+

--- a/snippets/csharp/interfaces/Program.cs
+++ b/snippets/csharp/interfaces/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace interfaces
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            InterfaceSnippets.TestInterfaces();
+            Properties.Examples();
+            Indexers.Examples();
+        }
+    }
+}

--- a/snippets/csharp/interfaces/indexers.cs
+++ b/snippets/csharp/interfaces/indexers.cs
@@ -1,0 +1,74 @@
+namespace interfaces
+{
+    // <SnippetDefineIndexer>
+    public interface ISomeInterface
+    {
+        //...
+
+        // Indexer declaration:
+        string this[int index]
+        {
+            get;
+            set;
+        }
+    }
+    //</SnippetDefineIndexer>
+
+    //<SnippetImplementInterface>
+    // Indexer on an interface:
+    public interface IIndexInterface
+    {
+        // Indexer declaration:
+        int this[int index]
+        {
+            get;
+            set;
+        }
+    }
+
+    // Implementing the interface.
+    class IndexerClass : IIndexInterface
+    {
+        private int[] arr = new int[100];
+        public int this[int index]   // indexer declaration
+        {
+            // The arr object will throw IndexOutOfRange exception.
+            get => arr[index];
+            set => arr[index] = value;
+        }
+    }
+    //</SnippetImplementInterface>
+
+    public class Indexers
+    {
+        public static void Examples()
+        {
+            // <SnippetExampleCode>
+            IndexerClass test = new IndexerClass();
+            System.Random rand = new System.Random();
+            // Call the indexer to initialize its elements.
+            for (int i = 0; i < 10; i++)
+            {
+                test[i] = rand.Next();
+            }
+            for (int i = 0; i < 10; i++)
+            {
+                System.Console.WriteLine($"Element #{i} = {test[i]}");
+            }
+
+            /* Sample output:
+                Element #0 = 360877544
+                Element #1 = 327058047
+                Element #2 = 1913480832
+                Element #3 = 1519039937
+                Element #4 = 601472233
+                Element #5 = 323352310
+                Element #6 = 1422639981
+                Element #7 = 1797892494
+                Element #8 = 875761049
+                Element #9 = 393083859
+            */
+            // </SnippetExampleCode>
+        }
+    }
+}

--- a/snippets/csharp/interfaces/interfaces.csproj
+++ b/snippets/csharp/interfaces/interfaces.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/csharp/interfaces/properties.cs
+++ b/snippets/csharp/interfaces/properties.cs
@@ -1,0 +1,101 @@
+using System;
+
+namespace interfaces
+{
+    // <SnippetDeclareInterfaceProperties>
+    public interface ISampleInterface
+    {
+        // Property declaration:
+        string Name
+        {
+            get;
+            set;
+        }
+    }
+    // </SnippetDeclareInterfaceProperties>
+    interface ICitizen
+    {
+        string Name
+        {
+            get;
+            set;
+        }
+    }
+
+    public class Employee2 : IEmployee, ICitizen
+    {
+        //<SnippetExplicitImplementation>
+        string IEmployee.Name
+        {
+            get { return "Employee Name"; }
+            set { }
+        }
+        //</SnippetExplicitImplementation>
+
+        //<SnippetCitizenImplementation>
+        string ICitizen.Name
+        {
+            get { return "Citizen Name"; }
+            set { }
+        }
+        //</SnippetCitizenImplementation>
+
+        public int Counter => 0;
+    }
+
+    //<SnippetPropertyExample>
+    interface IEmployee
+    {
+        string Name
+        {
+            get;
+            set;
+        }
+
+        int Counter
+        {
+            get;
+        }
+    }
+
+    public class Employee : IEmployee
+    {
+        public static int numberOfEmployees;
+
+        private string _name;
+        public string Name  // read-write instance property
+        {
+            get => _name;                
+            set => _name = value;
+        }
+
+        private int _counter;
+        public int Counter  // read-only instance property
+        {
+            get => _counter;
+        }
+
+        // constructor
+        public Employee() => _counter = ++numberOfEmployees; 
+    }
+    //</SnippetPropertyExample>
+
+    public static class Properties
+    {
+        public static void Examples()
+        {
+            // <SnippetUseProperty>
+            System.Console.Write("Enter number of employees: ");
+            Employee.numberOfEmployees = int.Parse(System.Console.ReadLine());
+
+            Employee e1 = new Employee();
+            System.Console.Write("Enter the name of the new employee: ");
+            e1.Name = System.Console.ReadLine();
+
+            System.Console.WriteLine("The employee information:");
+            System.Console.WriteLine("Employee number: {0}", e1.Counter);
+            System.Console.WriteLine("Employee name: {0}", e1.Name);
+            // </SnippetUseProperty>
+        }
+    }
+}

--- a/snippets/csharp/objectoriented/Inheritance.cs
+++ b/snippets/csharp/objectoriented/Inheritance.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+
+namespace objectoriented
+{
+    //<Classes>
+    // WorkItem implicitly inherits from the Object class.
+    public class WorkItem
+    {
+        // Static field currentID stores the job ID of the last WorkItem that
+        // has been created.
+        private static int currentID;
+
+        //Properties.
+        protected int ID { get; set; }
+        protected string Title { get; set; }
+        protected string Description { get; set; }
+        protected TimeSpan jobLength { get; set; }
+
+        // Default constructor. If a derived class does not invoke a base-
+        // class constructor explicitly, the default constructor is called
+        // implicitly. 
+        public WorkItem()
+        {
+            ID = 0;
+            Title = "Default title";
+            Description = "Default description.";
+            jobLength = new TimeSpan();
+        }
+
+        // Instance constructor that has three parameters.
+        public WorkItem(string title, string desc, TimeSpan joblen)
+        {
+            this.ID = GetNextID();
+            this.Title = title;
+            this.Description = desc;
+            this.jobLength = joblen;
+        }
+
+        // Static constructor to initialize the static member, currentID. This
+        // constructor is called one time, automatically, before any instance
+        // of WorkItem or ChangeRequest is created, or currentID is referenced.
+        static WorkItem() => currentID = 0;
+
+        // currentID is a static field. It is incremented each time a new
+        // instance of WorkItem is created.
+        protected int GetNextID() => ++currentID;
+
+        // Method Update enables you to update the title and job length of an
+        // existing WorkItem object.
+        public void Update(string title, TimeSpan joblen)
+        {
+            this.Title = title;
+            this.jobLength = joblen;
+        }
+
+        // Virtual method override of the ToString method that is inherited
+        // from System.Object.
+        public override string ToString() =>
+            $"{this.ID} - {this.Title}";
+    }
+
+    // ChangeRequest derives from WorkItem and adds a property (originalItemID) 
+    // and two constructors.
+    public class ChangeRequest : WorkItem
+    {
+        protected int originalItemID { get; set; }
+
+        // Constructors. Because neither constructor calls a base-class 
+        // constructor explicitly, the default constructor in the base class
+        // is called implicitly. The base class must contain a default 
+        // constructor.
+
+        // Default constructor for the derived class.
+        public ChangeRequest() { }
+
+        // Instance constructor that has four parameters.
+        public ChangeRequest(string title, string desc, TimeSpan jobLen,
+                             int originalID)
+        {
+            // The following properties and the GetNexID method are inherited 
+            // from WorkItem.
+            this.ID = GetNextID();
+            this.Title = title;
+            this.Description = desc;
+            this.jobLength = jobLen;
+
+            // Property originalItemId is a member of ChangeRequest, but not 
+            // of WorkItem.
+            this.originalItemID = originalID;
+        }
+    }
+    // </SnippetClasses>
+
+
+    // <SnippetPolymorphismOverview>
+    public class Shape
+    {
+        // A few example members
+        public int X { get; private set; }
+        public int Y { get; private set; }
+        public int Height { get; set; }
+        public int Width { get; set; }
+       
+        // Virtual method
+        public virtual void Draw()
+        {
+            Console.WriteLine("Performing base class drawing tasks");
+        }
+    }
+
+    public class Circle : Shape
+    {
+        public override void Draw()
+        {
+            // Code to draw a circle...
+            Console.WriteLine("Drawing a circle");
+            base.Draw();
+        }
+    }
+    public class Rectangle : Shape
+    {
+        public override void Draw()
+        {
+            // Code to draw a rectangle...
+            Console.WriteLine("Drawing a rectangle");
+            base.Draw();
+        }
+    }
+    public class Triangle : Shape
+    {
+        public override void Draw()
+        {
+            // Code to draw a triangle...
+            Console.WriteLine("Drawing a triangle");
+            base.Draw();
+        }
+    }
+    // </SnippetPolymorphismOverview>
+
+    public static class Polymorphism
+    {
+        public static void Example()
+        {
+            // <SnippetUsePolymorphism>
+            // Polymorphism at work #1: a Rectangle, Triangle and Circle
+            // can all be used whereever a Shape is expected. No cast is
+            // required because an implicit conversion exists from a derived 
+            // class to its base class.
+            var shapes = new List<Shape>
+            {
+                new Rectangle(),
+                new Triangle(),
+                new Circle()
+            };
+
+            // Polymorphism at work #2: the virtual method Draw is
+            // invoked on each of the derived classes, not the base class.
+            foreach (var shape in shapes)
+            {
+                shape.Draw();
+            }
+            /* Output:
+                Drawing a rectangle
+                Performing base class drawing tasks
+                Drawing a triangle
+                Performing base class drawing tasks
+                Drawing a circle
+                Performing base class drawing tasks
+            */
+            // </SnippetUsePolymorphism>
+        }
+
+        public static void VirtualExamples()
+        {
+            //<SnippetTestVirtualMethods>
+            DerivedClass B = new DerivedClass();
+            B.DoWork();  // Calls the new method.
+
+            BaseClass A = (BaseClass)B;
+            A.DoWork();  // Also calls the new method.
+            //</SnippetTestVirtualMethods>
+        }
+    }
+
+    //<SnippetVirtualMethods>
+    public class BaseClass
+    {
+        public virtual void DoWork() { }
+        public virtual int WorkProperty
+        {
+            get { return 0; }
+        }
+    }
+    public class DerivedClass : BaseClass
+    {
+        public override void DoWork() { }
+        public override int WorkProperty
+        {
+            get { return 0; }
+        }
+    }
+    //</SnippetVirtualMethods>
+
+    namespace NewMethodHierarchy
+    {
+        //<SnippetNewMethods>
+        public class BaseClass
+        {
+            public void DoWork() { WorkField++; }
+            public int WorkField;
+            public int WorkProperty
+            {
+                get { return 0; }
+            }
+        }
+
+        public class DerivedClass : BaseClass
+        {
+            public new void DoWork() { WorkField++; }
+            public new int WorkField;
+            public new int WorkProperty
+            {
+                get { return 0; }
+            }
+        }
+        //</SnippetNewMethods>
+
+        public static class NewMethods
+        {
+            public static void Example()
+            {
+                //<SnippetUseNewMethods>
+                DerivedClass B = new DerivedClass();
+                B.DoWork();  // Calls the new method.
+
+                BaseClass A = (BaseClass)B;
+                A.DoWork();  // Calls the old method.
+                //</SnippetUseNewMethods>
+            }
+        }
+    }
+
+    static class Inheritance
+    {
+        public static void Example()
+        {
+            // <SnippetUseClasses>
+            // Create an instance of WorkItem by using the constructor in the 
+            // base class that takes three arguments.
+            WorkItem item = new WorkItem("Fix Bugs",
+                                        "Fix all bugs in my code branch",
+                                        new TimeSpan(3, 4, 0, 0));
+
+            // Create an instance of ChangeRequest by using the constructor in
+            // the derived class that takes four arguments.
+            ChangeRequest change = new ChangeRequest("Change Base Class Design",
+                                                    "Add members to the class",
+                                                    new TimeSpan(4, 0, 0),
+                                                    1);
+
+            // Use the ToString method defined in WorkItem.
+            Console.WriteLine(item.ToString());
+
+            // Use the inherited Update method to change the title of the 
+            // ChangeRequest object.
+            change.Update("Change the Design of the Base Class",
+                new TimeSpan(4, 0, 0));
+
+            // ChangeRequest inherits WorkItem's override of ToString.
+            Console.WriteLine(change.ToString());
+            /* Output:
+                1 - Fix Bugs
+                2 - Change the Design of the Base Class
+            */
+            // </SnippetUseClasses>
+        }
+    }
+}

--- a/snippets/csharp/objectoriented/Program.cs
+++ b/snippets/csharp/objectoriented/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace objectoriented
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Inheritance.Example();
+            NestedTypes.Example();
+            Polymorphism.Example();
+            Polymorphism.VirtualExamples();
+            NewMethodHierarchy.NewMethods.Example();
+        }
+    }
+}

--- a/snippets/csharp/objectoriented/accessmodifiers.cs
+++ b/snippets/csharp/objectoriented/accessmodifiers.cs
@@ -1,0 +1,27 @@
+namespace objectoriented
+{
+    //<SnippetPublicAccess>
+    public class Bicycle
+    {
+        public void Pedal() { }
+    }
+    //</SnippetPublicAccess>
+
+    //<SnippetMethodAccess>
+    // public class:
+    public class Tricycle
+    {
+        // protected method:
+        protected void Pedal() { }
+
+        // private field:
+        private int wheels = 3;
+
+        // protected internal property:
+        protected internal int Wheels
+        {
+            get { return wheels; }
+        }
+    }
+    //</SnippetMethodAccess>
+}

--- a/snippets/csharp/objectoriented/hierarchy.cs
+++ b/snippets/csharp/objectoriented/hierarchy.cs
@@ -1,0 +1,44 @@
+namespace Hierarchy
+{
+    // <SnippetFirstHierarchy>
+    public class A
+    {
+        public virtual void DoWork() { }
+    }
+    public class B : A
+    {
+        public override void DoWork() { }
+    }
+    // </SnippetFirstHierarchy>
+
+    // <SnippetSealedOverride>
+    public class C : B
+    {
+        public sealed override void DoWork() { }
+    }
+    // </SnippetSealedOverride>
+
+    // <SnippetNewDeclaration>
+    public class D : C
+    {
+        public new void DoWork() { }
+    }
+    // </SnippetNewDeclaration>
+
+    // <SnippetAccessBase>
+    public class Base
+    {
+        public virtual void DoWork() {/*...*/ }
+    }
+    public class Derived : Base
+    {
+        public override void DoWork()
+        {
+            //Perform Derived's work here
+            //...
+            // Call DoWork on base class
+            base.DoWork();
+        }
+    }
+    // </SnippetAccessBase>
+}

--- a/snippets/csharp/objectoriented/interfaces.cs
+++ b/snippets/csharp/objectoriented/interfaces.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace objectoriented
+{
+    namespace ExampleFromBCL
+    {
+        //<SnippetEquatable>
+        interface IEquatable<T>
+        {
+            bool Equals(T obj);
+        }
+        //</SnippetEquatable>
+    }
+
+    //<SnippetImplementEquatable>
+    public class Car : IEquatable<Car>
+    {
+        public string Make {get; set;}
+        public string Model { get; set; }
+        public string Year { get; set; }
+
+        // Implementation of IEquatable<T> interface
+        public bool Equals(Car car)
+        {
+            return (this.Make, this.Model, this.Year) == 
+                (car.Make, car.Model, car.Year);
+        }
+    }
+    //</SnippetImplementEquatable>
+    
+
+}

--- a/snippets/csharp/objectoriented/nestedtypes.cs
+++ b/snippets/csharp/objectoriented/nestedtypes.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace objectoriented
+{
+    namespace defaultaccess
+    {
+        //<SnippetDeclareNestedClass>
+        public class Container
+        {
+            class Nested
+            {
+                Nested() { }
+            }
+        }
+        //</SnippetDeclareNestedClass>
+    }
+
+    namespace publicaccess
+    {
+        //<SnippetPublicNestedClass>
+        public class Container
+        {
+            public class Nested
+            {
+                Nested() { }
+            }
+        }
+        //</SnippetPublicNestedClass>
+    }
+
+        //<SnippetDeclareNestedInstance>
+    public class Container
+    {
+        public class Nested
+        {
+            private Container parent;
+
+            public Nested()
+            {
+            }
+            public Nested(Container parent)
+            {
+                this.parent = parent;
+            }
+        }
+    }
+    //</SnippetDeclareNestedInstance>
+
+    public static class NestedTypes
+    {
+        public static void Example()
+        {
+            //<SnippetUseNestedInstance>
+            Container.Nested nest = new Container.Nested();
+            //</SnippetUseNestedInstance>
+        }
+    }
+}

--- a/snippets/csharp/objectoriented/objectoriented.csproj
+++ b/snippets/csharp/objectoriented/objectoriented.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
As part of updating the articles in inheritance and interfaces to reflect default interface members, create projects for all included snippets.

While updating those, make minor updates to the code as well.