### PR TITLE
rename variable

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_UnionWith/cs/Program.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_UnionWith/cs/Program.cs
@@ -36,10 +36,10 @@ class Program
         DisplaySet(numbers);
         //</snippet02>
 
-        void DisplaySet(HashSet<int> set)
+        void DisplaySet(HashSet<int> collection)
         {
             Console.Write("{");
-            foreach (int i in set)
+            foreach (int i in collection)
             {
                 Console.Write(" {0}", i);
             }

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_UnionWith/vb/Program.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_UnionWith/vb/Program.vb
@@ -37,9 +37,9 @@ Class Program
 
     '</snippet02>
 
-    Private Shared Sub DisplaySet(ByVal coll As HashSet(Of Integer))
+    Private Shared Sub DisplaySet(ByVal collection As HashSet(Of Integer))
         Console.Write("{")
-        For Each i As Integer In coll
+        For Each i As Integer In collection
             Console.Write(" {0}", i)
         Next i
         Console.WriteLine(" }")


### PR DESCRIPTION
set is a reserved keyword so it causes the variable name to be highlighted in docs
https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1?view=netcore-3.1#examples

