### PR TITLE
Fix off-by-one error in the Stopwatch example

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/StopWatchPerfSample/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StopWatchPerfSample/CS/source.cs
@@ -182,12 +182,12 @@ namespace StopWatchSample
                         // for iterations 1-10001.
                         if (maxTicks < ticksThisTime)
                         {
-                            indexSlowest = i;
+                            indexSlowest = i - 1;
                             maxTicks = ticksThisTime;
                         }
                         if (minTicks > ticksThisTime)
                         {
-                            indexFastest = i;
+                            indexFastest = i - 1;
                             minTicks = ticksThisTime;
                         }
                         numTicks += ticksThisTime;


### PR DESCRIPTION
## Summary

Since we discard the first run, the index needs to be adjusted for the printed output to be correct.

For example, if the last run is the slowest, it should say

```
Slowest time:  #10000/10000 = 123 ticks
```

not

```
Slowest time:  #10001/10000 = 123 ticks
```