### PR TITLE
add sprintf to failwith line in f# array pattern example snippet

### DIFF
--- a/snippets/fsharp/lang-ref-2/snippet4811.fs
+++ b/snippets/fsharp/lang-ref-2/snippet4811.fs
@@ -4,7 +4,7 @@ let vectorLength vec =
     | [| var1 |] -> var1
     | [| var1; var2 |] -> sqrt (var1*var1 + var2*var2)
     | [| var1; var2; var3 |] -> sqrt (var1*var1 + var2*var2 + var3*var3)
-    | _ -> failwith "vectorLength called with an unsupported array size of %d." (vec.Length)
+    | _ -> failwith (sprintf "vectorLength called with an unsupported array size of %d." (vec.Length))
 
 printfn "%f" (vectorLength [| 1. |])
 printfn "%f" (vectorLength [| 1.; 1. |])


### PR DESCRIPTION
Fixes dotnet/docs#17113 