### PR TITLE
Add global rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,20 @@
 /snippets/visualbasic/** @BillWagner
 # F# Snippets:
 /snippets/fsharp/** @cartermp
+
+# System.Json samples:
+/snippets/core/system-text-json/** @tdykstra
+
+# Text runes:
+/snippets/core/rune/**  @tdykstra
+
+# WPF folders:
+/snippets/xaml/wpf/**   @thraka
+/snippets/csharp/wpf/**   @thraka
+/snippets/visualbasic/wpf/**   @thraka
+/snippets/desktop-guide/wpf/**   @thraka
+
+# Windows forms areas:
+/winforms/** @thraka
+/snippets/winforms/**  @thraka
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,15 +4,15 @@
 # More details are here: https://help.github.com/articles/about-codeowners/
 
 # The '*' pattern is global owners.
-# Not adding in this PR, but I'd like to try adding a global owner set with the entire team.
-# One interpretation of their docs is that global owners are added only if not removed
-# by a more local rule.
 
 # Order is important. The last matching pattern has the most precedence.
 # The folders are ordered as follows:
 
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
+
+# Global rule:
+*           @dotnet/docs
 
 # C# samples:
 /csharp/**  @BillWagner
@@ -21,8 +21,7 @@
 /machine-learning/**  @natke
 
 #### Snippets (under samples)
-# C++ snippets
-/snippets/cpp/** @rpetrusha
+
 # C# Snippets:
 /snippets/csharp/** @BillWagner
 # Visual Basic snippets:


### PR DESCRIPTION
In this PR, there is now a global rule to add the dotnet/docs team as a reviewer for any PR that isn't otherwise assigned.

Also, remove ron from the C++ snippets.

Notes for reviewers:
- There are a lot of unassigned folders, both for snippets and samples. If there are obvious places where someone should be assigned, let's add them now (.NET Core desktop, JSON, etc). Others, let's wait on the pending samples tasks.
- Who should get the C++ samples?

