### PR TITLE
Fix off-by-one error in Stopwatch sample (redux)

### DIFF
--- a/snippets/csharp/VS_Snippets_CLR/StopWatchPerfSample/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StopWatchPerfSample/CS/source.cs
@@ -179,7 +179,7 @@ namespace StopWatchSample
                     {
 
                         // Update operation statistics
-                        // for iterations 1-10001.
+                        // for iterations 1-10000.
                         if (maxTicks < ticksThisTime)
                         {
                             indexSlowest = i;

--- a/snippets/csharp/VS_Snippets_CLR/StopWatchPerfSample/CS/source.cs
+++ b/snippets/csharp/VS_Snippets_CLR/StopWatchPerfSample/CS/source.cs
@@ -182,12 +182,12 @@ namespace StopWatchSample
                         // for iterations 1-10001.
                         if (maxTicks < ticksThisTime)
                         {
-                            indexSlowest = i - 1;
+                            indexSlowest = i;
                             maxTicks = ticksThisTime;
                         }
                         if (minTicks > ticksThisTime)
                         {
-                            indexFastest = i - 1;
+                            indexFastest = i;
                             minTicks = ticksThisTime;
                         }
                         numTicks += ticksThisTime;


### PR DESCRIPTION
## Summary

Original PR: #2002

In the loop, `i` ranges from `0` to `10000`.  We discard iteration `0` for JITting the code.  The output for the statistics starts from `1`, for a total of `10000` iterations that we care about.

```
Slowest time: #1/10000 = 123 ticks
```

In the original fix, I changed the index.  However, it was actually just the comment that was incorrect -- there is no iteration `10001`.
