### PR TITLE
Updated confusing line numbers on Local functions examples

### DIFF
--- a/snippets/csharp/programming-guide/classes-and-structs/local-functions-async1.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/local-functions-async1.cs
@@ -5,7 +5,7 @@ class Example
 {
    static void Main()
    {
-      int result = GetMultipleAsync(6).Result;
+      int result = GetMultipleAsync(6).Result; //Line 8
       Console.WriteLine($"The returned value is {result:N0}");
    }
 
@@ -13,7 +13,7 @@ class Example
    {
       Console.WriteLine("Executing GetMultipleAsync...");
       if (secondsDelay < 0 || secondsDelay > 5)
-         throw new ArgumentOutOfRangeException("secondsDelay cannot exceed 5.");
+         throw new ArgumentOutOfRangeException("secondsDelay cannot exceed 5."); // Line 16
          
       await Task.Delay(secondsDelay * 1000);
       return secondsDelay * new Random().Next(2,10);
@@ -27,7 +27,7 @@ class Example
 //    Parameter name: secondsDelay cannot exceed 5.) ---> 
 //         System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
 //    Parameter name: secondsDelay cannot exceed 5.
-//       at Example.<GetMultiple>d__1.MoveNext() in Program.cs:line 17
+//       at Example.<GetMultiple>d__1.MoveNext() in Program.cs:line 16
 //       --- End of inner exception stack trace ---
 //       at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
 //       at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)

--- a/snippets/csharp/programming-guide/classes-and-structs/local-functions-async2.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/local-functions-async2.cs
@@ -5,14 +5,14 @@ class Example
 {
    static void Main()
    {
-      int result = GetMultiple(6).Result;
+      int result = GetMultiple(6).Result; // Line 8
       Console.WriteLine($"The returned value is {result:N0}");
    }
 
    static Task<int> GetMultiple(int secondsDelay)
    {
       if (secondsDelay < 0 || secondsDelay > 5)
-         throw new ArgumentOutOfRangeException("secondsDelay cannot exceed 5.");
+         throw new ArgumentOutOfRangeException("secondsDelay cannot exceed 5."); // Line 15
          
       return GetValueAsync();
       
@@ -28,5 +28,5 @@ class Example
 //    Unhandled Exception: System.ArgumentOutOfRangeException: 
 //       Specified argument was out of the range of valid values.
 //    Parameter name: secondsDelay cannot exceed 5.
-//       at Example.GetMultiple(Int32 secondsDelay) in Program.cs:line 17
+//       at Example.GetMultiple(Int32 secondsDelay) in Program.cs:line 15
 //       at Example.Main() in Program.cs:line 8

--- a/snippets/csharp/programming-guide/classes-and-structs/local-functions-iterator1.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/local-functions-iterator1.cs
@@ -8,7 +8,7 @@ class Example
       IEnumerable<int> ienum = OddSequence(50, 110);
       Console.WriteLine("Retrieved enumerator...");
       
-      foreach (var i in ienum)
+      foreach (var i in ienum) //Line 11
       {
          Console.Write($"{i} ");
       }
@@ -19,7 +19,7 @@ class Example
       if (start < 0 || start > 99)
          throw new ArgumentOutOfRangeException("start must be between 0 and 99.");
       if (end > 100)
-         throw new ArgumentOutOfRangeException("end must be less than or equal to 100.");
+         throw new ArgumentOutOfRangeException("end must be less than or equal to 100."); //Line 22
       if (start >= end)
          throw new ArgumentException("start must be less than end.");
          
@@ -35,5 +35,5 @@ class Example
 //    
 //    Unhandled Exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
 //    Parameter name: end must be less than or equal to 100.
-//       at Sequence.<GetNumericRange>d__1.MoveNext() in Program.cs:line 23
-//       at Example.Main() in Program.cs:line 43
+//       at Sequence.<GetNumericRange>d__1.MoveNext() in Program.cs:line 11
+//       at Example.Main() in Program.cs:line 22

--- a/snippets/csharp/programming-guide/classes-and-structs/local-functions-iterator2.cs
+++ b/snippets/csharp/programming-guide/classes-and-structs/local-functions-iterator2.cs
@@ -5,7 +5,7 @@ class Example
 {
    static void Main()
    {
-      IEnumerable<int> ienum = OddSequence(50, 110);
+      IEnumerable<int> ienum = OddSequence(50, 110); //Line 8
       Console.WriteLine("Retrieved enumerator...");
       
       foreach (var i in ienum)
@@ -19,7 +19,7 @@ class Example
       if (start < 0 || start > 99)
          throw new ArgumentOutOfRangeException("start must be between 0 and 99.");
       if (end > 100)
-         throw new ArgumentOutOfRangeException("end must be less than or equal to 100.");
+         throw new ArgumentOutOfRangeException("end must be less than or equal to 100."); //Line 22
       if (start >= end)
          throw new ArgumentException("start must be less than end.");
          
@@ -38,5 +38,5 @@ class Example
 // The example displays the following output:
 //    Unhandled Exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
 //    Parameter name: end must be less than or equal to 100.
-//       at Sequence.<GetNumericRange>d__1.MoveNext() in Program.cs:line 23
-//       at Example.Main() in Program.cs:line 43
+//       at Sequence.<GetNumericRange>d__1.MoveNext() in Program.cs:line 8
+//       at Example.Main() in Program.cs:line 22


### PR DESCRIPTION
Updated confusing line numbers in the code examples on the "[Local functions (C# Programming Guide)](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions) page. 

Comparing local-functions-iterator1.cs to local-functions-iterator2.cs and local-functions-async1.cs to local-functions-async2.cs caused confusion as to where the error was getting thrown, so I updated the line numbers in the exception messages. I couldn't find a way in the documentation to force line numbers to show, so I also added comments to the referenced lines so it was more apparent where and when the exceptions were being thrown. 