### PR TITLE
Fix F# snippet 1506

### DIFF
--- a/snippets/fsharp/lang-ref-1/snippet1506.fs
+++ b/snippets/fsharp/lang-ref-1/snippet1506.fs
@@ -1,1 +1,1 @@
-seq { for n in 1 .. 100 -> if isprime n then n }
+seq { for n in 1 .. 100 do if isprime n then n }


### PR DESCRIPTION
The `->` shortcut (which stands for `do yield`) is not valid in this spot, because it lifts the `if` out of the sequence expression and it causes the F# compiler to complain about a missing `else`.

The sample got updated for F# 4.7, which allows eliding `yield`s. However, the full example with `yield` is:

```fsharp
seq { for n in 1 .. 100 do if isprime n then yield n }
```

You see that the `do` and `yield` are too far apart to be shortened to `->`.

## Summary

Describe your changes here.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
