### PR TITLE
Bug/flags samples

### DIFF
--- a/snippets/cpp/VS_Snippets_CLR_System/system.FlagsAttribute/CPP/flags1.cpp
+++ b/snippets/cpp/VS_Snippets_CLR_System/system.FlagsAttribute/CPP/flags1.cpp
@@ -1,7 +1,8 @@
 // <Snippet2>
 using namespace System;
 
-[Flags] enum class PhoneService
+[Flags]
+enum class PhoneService
 {
    None = 0,
    LandLine = 1,

--- a/snippets/csharp/VS_Snippets_CLR_System/system.FlagsAttribute/CS/flags1.cs
+++ b/snippets/csharp/VS_Snippets_CLR_System/system.FlagsAttribute/CS/flags1.cs
@@ -1,7 +1,8 @@
 ﻿// <Snippet2>
 using System;
 
-[Flags] public enum PhoneService
+[Flags]
+public enum PhoneService
 {
    None = 0,
    LandLine = 1,

--- a/snippets/visualbasic/VS_Snippets_CLR_System/system.FlagsAttribute/VB/flags1.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR_System/system.FlagsAttribute/VB/flags1.vb
@@ -2,7 +2,8 @@
 Option Strict On
 
 ' <Snippet2>
-<Flags()> Public Enum PhoneService As Integer
+<Flags()>
+Public Enum PhoneService As Integer
    None = 0
    LandLine = 1
    Cell = 2


### PR DESCRIPTION
Changed attribute position to align with other examples

## Summary

Moves the flags attribute to a new line like the other examples in the documentation.

Fixes dotnet/dotnet-api-docs#1000
