### PR TITLE
Update link to Contributing Guide to point to new location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in contributing to the .NET documentation!
 
-This repository contains the samples used in the .NET documentation. The main repository for .NET documentation is the [.NET Docs repository](https://github.com/dotnet/docs). See the [Readme](README.md) and the [Contributing Guide](https://github.com/dotnet/docs/tree/master/CONTRIBUTING.md) for information on contributing samples and topics to the .NET documentation.
+This repository contains the samples used in the .NET documentation. The main repository for .NET documentation is the [.NET Docs repository](https://github.com/dotnet/docs). See the [Readme](README.md) and the [Contributing Guide](https://docs.microsoft.com/contribute/dotnet/dotnet-contribute) for information on contributing samples and topics to the .NET documentation.


### PR DESCRIPTION
The Contributing Guide moved moved into a site-wide contribution guide.