### PR TITLE
Snippets add NuGet ENV VAR to automatically trigger restore

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -23,6 +23,7 @@ on:
 env:
   DOTNET_INSTALLER_CHANNEL: 'release/5.0.1xx-preview7'
   DOTNET_DO_INSTALL: 'true'
+  EnableNuGetPackageRestore: 'True'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
@BillWagner
This should automatically trigger nuget restore on Visual Studio MSBUILD processes, at least according to the docs here: https://docs.microsoft.com/en-us/nuget/consume-packages/package-restore#restore-packages-manually-using-visual-studio

Should fix the problem with #3745