### PR TITLE
Create no-response.yml

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,10 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 14
+# Label requiring a response
+responseRequiredLabel: needs-more-info
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed due to no response from the original author.
+  Please feel free to reopen it if you have more information that can help us investigate the issue further.


### PR DESCRIPTION
This is a copy from the config file in dotnet/docs.
In #3763, the label was added but wasn't removed automatically when the OP replied. The issue also won't get auto closed if there is no response.

Note: The app needs to be installed in the repository (if not already installed) in order to enable its functionality. It can be installed from [here](https://github.com/apps/no-response).