### PR TITLE
Add out-of-process COM server demo

### DIFF
--- a/core/extensions/OutOfProcCOM/COMRegistration/BasicClassFactory.cs
+++ b/core/extensions/OutOfProcCOM/COMRegistration/BasicClassFactory.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace COMRegistration
+{
+    // https://docs.microsoft.com/windows/win32/api/unknwn/nn-unknwn-iclassfactory
+    [ComImport]
+    [ComVisible(false)]
+    [Guid("00000001-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IClassFactory
+    {
+        void CreateInstance(
+            [MarshalAs(UnmanagedType.Interface)] object pUnkOuter,
+            ref Guid riid,
+            out IntPtr ppvObject);
+
+        void LockServer([MarshalAs(UnmanagedType.Bool)] bool fLock);
+    }
+
+    [ComVisible(true)]
+    internal class BasicClassFactory<T> : IClassFactory where T : new()
+    {
+        public void CreateInstance(
+            [MarshalAs(UnmanagedType.Interface)] object pUnkOuter,
+            ref Guid riid,
+            out IntPtr ppvObject)
+        {
+            Type interfaceType = GetValidatedInterfaceType(typeof(T), ref riid, pUnkOuter);
+
+            object obj = new T();
+            if (pUnkOuter != null)
+            {
+                obj = CreateAggregatedObject(pUnkOuter, obj);
+            }
+
+            ppvObject = GetObjectAsInterface(obj, interfaceType);
+        }
+
+        public void LockServer([MarshalAs(UnmanagedType.Bool)] bool fLock) { }
+
+        private static readonly Guid IID_IUnknown = Guid.Parse("00000000-0000-0000-C000-000000000046");
+
+        private static Type GetValidatedInterfaceType(Type classType, ref Guid riid, object outer)
+        {
+            if (riid == IID_IUnknown)
+            {
+                return typeof(object);
+            }
+
+            // Aggregation can only be done when requesting IUnknown.
+            if (outer != null)
+            {
+                const int CLASS_E_NOAGGREGATION = unchecked((int)0x80040110);
+                throw new COMException(string.Empty, CLASS_E_NOAGGREGATION);
+            }
+
+            // Verify the class implements the desired interface
+            foreach (Type i in classType.GetInterfaces())
+            {
+                if (i.GUID == riid)
+                {
+                    return i;
+                }
+            }
+
+            // E_NOINTERFACE
+            throw new InvalidCastException();
+        }
+
+        private static IntPtr GetObjectAsInterface(object obj, Type interfaceType)
+        {
+            // If the requested "interface type" is type object then return as IUnknown
+            if (interfaceType == typeof(object))
+            {
+                return Marshal.GetIUnknownForObject(obj);
+            }
+
+            IntPtr interfaceMaybe = Marshal.GetComInterfaceForObject(obj, interfaceType, CustomQueryInterfaceMode.Ignore);
+            if (interfaceMaybe == IntPtr.Zero)
+            {
+                // E_NOINTERFACE
+                throw new InvalidCastException();
+            }
+
+            return interfaceMaybe;
+        }
+
+        private static object CreateAggregatedObject(object pUnkOuter, object comObject)
+        {
+            IntPtr outerPtr = Marshal.GetIUnknownForObject(pUnkOuter);
+
+            try
+            {
+                IntPtr innerPtr = Marshal.CreateAggregatedObject(outerPtr, comObject);
+                return Marshal.GetObjectForIUnknown(innerPtr);
+            }
+            finally
+            {
+                // Decrement the above 'Marshal.GetIUnknownForObject()'
+                Marshal.Release(outerPtr);
+            }
+        }
+    }
+}

--- a/core/extensions/OutOfProcCOM/COMRegistration/COMRegistration.csproj
+++ b/core/extensions/OutOfProcCOM/COMRegistration/COMRegistration.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="[4.7.0, )" />
+  </ItemGroup>
+</Project>

--- a/core/extensions/OutOfProcCOM/COMRegistration/DllSurrogate.cs
+++ b/core/extensions/OutOfProcCOM/COMRegistration/DllSurrogate.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Win32;
+
+namespace COMRegistration
+{
+    public static class DllSurrogate
+    {
+        public static void Register(Guid clsid, string tlbPath)
+        {
+            Trace.WriteLine($"Registering server with system-supplied DLL surrogate:");
+            Trace.Indent();
+            Trace.WriteLine($"CLSID: {clsid:B}");
+            Trace.Unindent();
+
+            string serverKey = string.Format(KeyFormat.CLSID, clsid);
+
+            // Register App ID - use the CLSID as the App ID
+            using RegistryKey regKey = Registry.LocalMachine.CreateSubKey(serverKey);
+            regKey.SetValue("AppID", clsid.ToString("B"));
+
+            // Register DLL surrogate - empty string for system-supplied surrogate
+            string appIdKey = string.Format(KeyFormat.AppID, clsid);
+            using RegistryKey appIdRegKey = Registry.LocalMachine.CreateSubKey(appIdKey);
+            appIdRegKey.SetValue("DllSurrogate", string.Empty);
+
+            // Register type library
+            TypeLib.Register(tlbPath);
+        }
+
+        public static void Unregister(Guid clsid, string tlbPath)
+        {
+            Trace.WriteLine($"Unregistering server:");
+            Trace.Indent();
+            Trace.WriteLine($"CLSID: {clsid:B}");
+            Trace.Unindent();
+
+            // Remove the App ID value
+            string serverKey = string.Format(KeyFormat.CLSID, clsid);
+            using RegistryKey regKey = Registry.LocalMachine.OpenSubKey(serverKey, writable: true);
+            if (regKey != null)
+                regKey.DeleteValue("AppID");
+
+            // Remove the App ID key
+            string appIdKey = string.Format(KeyFormat.AppID, clsid);
+            Registry.LocalMachine.DeleteSubKey(appIdKey, throwOnMissingSubKey: false);
+
+            // Unregister type library
+            TypeLib.Unregister(tlbPath);
+        }
+    }
+}

--- a/core/extensions/OutOfProcCOM/COMRegistration/KeyFormat.cs
+++ b/core/extensions/OutOfProcCOM/COMRegistration/KeyFormat.cs
@@ -1,0 +1,10 @@
+﻿namespace COMRegistration
+{
+    internal static class KeyFormat
+    {
+        public const string CLSID = @"SOFTWARE\Classes\CLSID\{0:B}";
+        public const string AppID = @"SOFTWARE\Classes\AppID\{0:B}";
+
+        public static readonly string LocalServer32 = @$"{CLSID}\LocalServer32";
+    }
+}

--- a/core/extensions/OutOfProcCOM/COMRegistration/LocalServer.cs
+++ b/core/extensions/OutOfProcCOM/COMRegistration/LocalServer.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32;
+
+namespace COMRegistration
+{
+    public sealed class LocalServer : IDisposable
+    {
+        public static void Register(Guid clsid, string exePath, string tlbPath)
+        {
+            // Register local server
+            Trace.WriteLine($"Registering server:");
+            Trace.Indent();
+            Trace.WriteLine($"CLSID: {clsid:B}");
+            Trace.WriteLine($"Executable: {exePath}");
+            Trace.Unindent();
+
+            string serverKey = string.Format(KeyFormat.LocalServer32, clsid);
+            using RegistryKey regKey = Registry.LocalMachine.CreateSubKey(serverKey);
+            regKey.SetValue(null, exePath);
+
+            // Register type library
+            TypeLib.Register(tlbPath);
+        }
+
+        public static void Unregister(Guid clsid, string tlbPath)
+        {
+            Trace.WriteLine($"Unregistering server:");
+            Trace.Indent();
+            Trace.WriteLine($"CLSID: {clsid:B}");
+            Trace.Unindent();
+
+            // Unregister local server
+            string serverKey = string.Format(KeyFormat.LocalServer32, clsid);
+            Registry.LocalMachine.DeleteSubKey(serverKey, throwOnMissingSubKey: false);
+
+            // Unregister type library
+            TypeLib.Unregister(tlbPath);
+        }
+
+        private readonly List<int> registrationCookies = new List<int>();
+
+        public void RegisterClass<T>(Guid clsid) where T : new()
+        {
+            Trace.WriteLine($"Registering class object:");
+            Trace.Indent();
+            Trace.WriteLine($"CLSID: {clsid:B}");
+            Trace.WriteLine($"Type: {typeof(T)}");
+
+            int cookie;
+            int hr = Ole32.CoRegisterClassObject(ref clsid, new BasicClassFactory<T>(), Ole32.CLSCTX_LOCAL_SERVER, Ole32.REGCLS_MULTIPLEUSE | Ole32.REGCLS_SUSPENDED, out cookie);
+            if (hr < 0)
+            {
+                Marshal.ThrowExceptionForHR(hr);
+            }
+
+            registrationCookies.Add(cookie);
+            Trace.WriteLine($"Cookie: {cookie}");
+            Trace.Unindent();
+
+            hr = Ole32.CoResumeClassObjects();
+            if (hr < 0)
+            {
+                Marshal.ThrowExceptionForHR(hr);
+            }
+        }
+
+        public void Run()
+        {
+            // This sample does not handle lifetime management of the server.
+            // For details around ref counting and locking of out-of-proc COM servers, see
+            // https://docs.microsoft.com/windows/win32/com/out-of-process-server-implementation-helpers
+            Console.ReadLine();
+        }
+
+        public void Dispose()
+        {
+            Trace.WriteLine($"Revoking class object registrations:");
+            Trace.Indent();
+            foreach (int cookie in registrationCookies)
+            {
+                Trace.WriteLine($"Cookie: {cookie}");
+                int hr = Ole32.CoRevokeClassObject(cookie);
+                Debug.Assert(hr >= 0, $"CoRevokeClassObject failed ({hr:x}). Cookie: {cookie}");
+            }
+
+            Trace.Unindent();
+        }
+
+        private class Ole32
+        {
+            // https://docs.microsoft.com/windows/win32/api/wtypesbase/ne-wtypesbase-clsctx
+            public const int CLSCTX_LOCAL_SERVER = 0x4;
+
+            // https://docs.microsoft.com/windows/win32/api/combaseapi/ne-combaseapi-regcls
+            public const int REGCLS_MULTIPLEUSE = 1;
+            public const int REGCLS_SUSPENDED = 4;
+
+            // https://docs.microsoft.com/windows/win32/api/combaseapi/nf-combaseapi-coregisterclassobject
+            [DllImport(nameof(Ole32))]
+            public static extern int CoRegisterClassObject(ref Guid guid, [MarshalAs(UnmanagedType.IUnknown)] object obj, int context, int flags, out int register);
+
+            // https://docs.microsoft.com/windows/win32/api/combaseapi/nf-combaseapi-coresumeclassobjects
+            [DllImport(nameof(Ole32))]
+            public static extern int CoResumeClassObjects();
+
+            // https://docs.microsoft.com/windows/win32/api/combaseapi/nf-combaseapi-corevokeclassobject
+            [DllImport(nameof(Ole32))]
+            public static extern int CoRevokeClassObject(int register);
+        }
+    }
+}

--- a/core/extensions/OutOfProcCOM/COMRegistration/TypeLib.cs
+++ b/core/extensions/OutOfProcCOM/COMRegistration/TypeLib.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using ComTypes = System.Runtime.InteropServices.ComTypes;
+
+namespace COMRegistration
+{
+    internal static class TypeLib
+    {
+        public static void Register(string tlbPath)
+        {
+            Trace.WriteLine($"Registering type library:");
+            Trace.Indent();
+            Trace.WriteLine(tlbPath);
+            Trace.Unindent();
+
+            int hr = OleAut32.LoadTypeLibEx(tlbPath, OleAut32.REGKIND.REGKIND_REGISTER, out ComTypes.ITypeLib _);
+            if (hr < 0)
+            {
+                Marshal.ThrowExceptionForHR(hr);
+            }
+        }
+
+        public static void Unregister(string tlbPath)
+        {
+            Trace.WriteLine($"Unregistering type library:");
+            Trace.Indent();
+            Trace.WriteLine(tlbPath);
+            Trace.Unindent();
+
+            ComTypes.ITypeLib typeLib;
+            int hr = OleAut32.LoadTypeLibEx(tlbPath, OleAut32.REGKIND.REGKIND_NONE, out typeLib);
+            if (hr < 0)
+            {
+                Trace.WriteLine($"Unregistering type library failed: 0x{hr:x}");
+                return;
+            }
+
+            IntPtr attrPtr = IntPtr.Zero;
+            try
+            {
+                typeLib.GetLibAttr(out attrPtr);
+                if (attrPtr != IntPtr.Zero)
+                {
+                    ComTypes.TYPELIBATTR attr = Marshal.PtrToStructure<ComTypes.TYPELIBATTR>(attrPtr);
+                    hr = OleAut32.UnRegisterTypeLib(ref attr.guid, attr.wMajorVerNum, attr.wMinorVerNum, attr.lcid, attr.syskind);
+                    if (hr < 0)
+                    {
+                        Trace.WriteLine($"Unregistering type library failed: 0x{hr:x}");
+                    }
+                }
+            }
+            finally
+            {
+                if (attrPtr != IntPtr.Zero)
+                {
+                    typeLib.ReleaseTLibAttr(attrPtr);
+                }
+            }
+        }
+
+        private class OleAut32
+        {
+            // https://docs.microsoft.com/windows/api/oleauto/ne-oleauto-regkind
+            public enum REGKIND
+            {
+                REGKIND_DEFAULT = 0,
+                REGKIND_REGISTER = 1,
+                REGKIND_NONE = 2
+            }
+
+            // https://docs.microsoft.com/windows/api/oleauto/nf-oleauto-loadtypelibex
+            [DllImport(nameof(OleAut32), CharSet = CharSet.Unicode, ExactSpelling = true)]
+            public static extern int LoadTypeLibEx(
+                [In, MarshalAs(UnmanagedType.LPWStr)] string fileName,
+                REGKIND regKind,
+                out ComTypes.ITypeLib typeLib);
+
+            // https://docs.microsoft.com/windows/api/oleauto/nf-oleauto-unregistertypelib
+            [DllImport(nameof(OleAut32))]
+            public static extern int UnRegisterTypeLib(
+                ref Guid id,
+                short majorVersion,
+                short minorVersion,
+                int lcid,
+                ComTypes.SYSKIND sysKind);
+        }
+    }
+}

--- a/core/extensions/OutOfProcCOM/Contract/Constants.cs
+++ b/core/extensions/OutOfProcCOM/Contract/Constants.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Contract
+{
+    internal sealed class Constants
+    {
+        public const string ServerClass = "AF080472-F173-4D9D-8BE7-435776617347";
+        public static readonly Guid ServerClassGuid = Guid.Parse(ServerClass);
+
+        public const string ServerInterface = "F586D6F4-AF37-441E-80A6-3D33D977882D";
+
+        public const string TypeLibraryName = "Server.Contract.tlb";
+    }
+}

--- a/core/extensions/OutOfProcCOM/Contract/IServer.cs
+++ b/core/extensions/OutOfProcCOM/Contract/IServer.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+[ComVisible(true)]
+[Guid(Contract.Constants.ServerInterface)]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IServer
+{
+    /// <summary>
+    /// Compute the value of the constant Pi.
+    /// </summary>
+    double ComputePi();
+}

--- a/core/extensions/OutOfProcCOM/Contract/Server.Contract.props
+++ b/core/extensions/OutOfProcCOM/Contract/Server.Contract.props
@@ -1,0 +1,23 @@
+<Project>
+  <PropertyGroup>
+    <ContractOutputDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)</ContractOutputDirectory>
+    <TypeLibraryName>Server.Contract.tlb</TypeLibraryName>
+    <TypeLibraryPath>$(ContractOutputDirectory)\$(TypeLibraryName)</TypeLibraryPath>
+    <TypeLibraryCompiledResourcePath>$(ContractOutputDirectory)\Server.TypeLib.res</TypeLibraryCompiledResourcePath>
+  </PropertyGroup>
+
+  <!-- Embed the type library as a resource -->
+  <PropertyGroup Condition="'$(EmbedTypeLibrary)' == 'true'">
+    <DefineConstants>$(DefineConstants);EMBEDDED_TYPE_LIBRARY</DefineConstants>
+    <Win32Resource>$(TypeLibraryCompiledResourcePath)</Win32Resource>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <!-- Used in lieu of a Primary Interop Assembly (PIA) -->
+    <Compile Include="../Contract/*.cs" />
+    <Content Include="$(TypeLibraryPath)" Condition="'$(EmbedTypeLibrary)' != 'true'">
+      <Visible>false</Visible>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/core/extensions/OutOfProcCOM/DllServer/DllServer.cs
+++ b/core/extensions/OutOfProcCOM/DllServer/DllServer.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace OutOfProcCOM
+{
+    [ComVisible(true)]
+    [Guid(Contract.Constants.ServerClass)]
+    public sealed class DllServer : IServer
+    {
+        double IServer.ComputePi()
+        {
+            Trace.WriteLine($"Running {nameof(DllServer)}.{nameof(IServer.ComputePi)}");
+            double sum = 0.0;
+            int sign = 1;
+            for (int i = 0; i < 1024; ++i)
+            {
+                sum += sign / (2.0 * i + 1.0);
+                sign *= -1;
+            }
+
+            return 4.0 * sum;
+        }
+
+#if EMBEDDED_TYPE_LIBRARY
+        private static readonly string tlbPath = Assembly.GetExecutingAssembly().Location;
+#else
+        private static readonly string tlbPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), Contract.Constants.TypeLibraryName);
+#endif
+
+        [ComRegisterFunction]
+        internal static void RegisterFunction(Type t)
+        {
+            if (t != typeof(DllServer))
+                return;
+
+            // Register DLL surrogate and type library
+            COMRegistration.DllSurrogate.Register(Contract.Constants.ServerClassGuid, tlbPath);
+        }
+
+        [ComUnregisterFunction]
+        internal static void UnregisterFunction(Type t)
+        {
+            if (t != typeof(DllServer))
+                return;
+
+            // Unregister DLL surrogate and type library
+            COMRegistration.DllSurrogate.Unregister(Contract.Constants.ServerClassGuid, tlbPath);
+        }
+    }
+}

--- a/core/extensions/OutOfProcCOM/DllServer/DllServer.csproj
+++ b/core/extensions/OutOfProcCOM/DllServer/DllServer.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Contract\Server.Contract.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <!-- Indicate the assembly is providing a COM server -->
+    <EnableComHosting>true</EnableComHosting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\COMRegistration\COMRegistration.csproj" />
+  </ItemGroup>
+
+  <Target Name="ServerUsage" AfterTargets="Build" DependsOnTargets="AssignTargetPaths">
+    <Message Importance="High" Text="%0a************************************%0a*** $(MSBuildProjectName) usage instructions ***%0a************************************" />
+    <Message Importance="High" Text="The server must be COM registered in order to activate.%0aThe following commands must be executed from an elevated command prompt." />
+    <Message Importance="High" Text="Register:%0a    regsvr32.exe &quot;$(ProjectDir)$(OutputPath)$(ComHostFileName)&quot;" />
+    <Message Importance="High" Text="Unregister:%0a    regsvr32.exe /u &quot;$(ProjectDir)$(OutputPath)$(ComHostFileName)&quot;" />
+  </Target>
+
+</Project>

--- a/core/extensions/OutOfProcCOM/ExeServer/ExeServer.cs
+++ b/core/extensions/OutOfProcCOM/ExeServer/ExeServer.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace OutOfProcCOM
+{
+    [ComVisible(true)]
+    [Guid(Contract.Constants.ServerClass)]
+    public sealed class ExeServer : IServer
+    {
+        double IServer.ComputePi()
+        {
+            Trace.WriteLine($"Running {nameof(ExeServer)}.{nameof(IServer.ComputePi)}");
+            double sum = 0.0;
+            int sign = 1;
+            for (int i = 0; i < 1024; ++i)
+            {
+                sum += sign / (2.0 * i + 1.0);
+                sign *= -1;
+            }
+
+            return 4.0 * sum;
+        }
+    }
+}

--- a/core/extensions/OutOfProcCOM/ExeServer/ExeServer.csproj
+++ b/core/extensions/OutOfProcCOM/ExeServer/ExeServer.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Contract\Server.Contract.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\COMRegistration\COMRegistration.csproj" />
+  </ItemGroup>
+
+  <Target Name="ServerUsage" AfterTargets="Build" DependsOnTargets="AssignTargetPaths">
+    <Message Importance="High" Text="%0a************************************%0a*** $(MSBuildProjectName) usage instructions ***%0a************************************" />
+    <Message Importance="High" Text="The server must be COM registered in order to activate.%0aThe following commands must be executed from an elevated command prompt." />
+    <Message Importance="High" Text="Register:%0a    &quot;$(ProjectDir)$(OutputPath)$(TargetName)&quot; /regserver" />
+    <Message Importance="High" Text="Unregister:%0a     &quot;$(ProjectDir)$(OutputPath)$(TargetName)&quot; /unregserver" />
+  </Target>
+
+</Project>

--- a/core/extensions/OutOfProcCOM/ExeServer/Program.cs
+++ b/core/extensions/OutOfProcCOM/ExeServer/Program.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace OutOfProcCOM
+{
+    class Program
+    {
+        private static readonly string exePath = Path.Combine(AppContext.BaseDirectory, "ExeServer.exe");
+
+#if EMBEDDED_TYPE_LIBRARY
+        private static readonly string tlbPath = exePath;
+#else
+        private static readonly string tlbPath = Path.Combine(AppContext.BaseDirectory, Contract.Constants.TypeLibraryName);
+#endif
+
+        static void Main(string[] args)
+        {
+            using var consoleTrace = new ConsoleTraceListener();
+            Trace.Listeners.Add(consoleTrace);
+
+            if (args.Length == 1)
+            {
+                string regCommandMaybe = args[0];
+                if (regCommandMaybe.Equals("/regserver", StringComparison.OrdinalIgnoreCase) || regCommandMaybe.Equals("-regserver", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Register local server and type library
+                    COMRegistration.LocalServer.Register(Contract.Constants.ServerClassGuid, exePath, tlbPath);
+                    return;
+                }
+                else if (regCommandMaybe.Equals("/unregserver", StringComparison.OrdinalIgnoreCase) || regCommandMaybe.Equals("-unregserver", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Unregister local server and type library
+                    COMRegistration.LocalServer.Unregister(Contract.Constants.ServerClassGuid, tlbPath);
+                    return;
+                }
+            }
+
+            using var server = new COMRegistration.LocalServer();
+            server.RegisterClass<ExeServer>(Contract.Constants.ServerClassGuid);
+
+            server.Run();
+        }
+    }
+}

--- a/core/extensions/OutOfProcCOM/ManagedClient/ManagedClient.csproj
+++ b/core/extensions/OutOfProcCOM/ManagedClient/ManagedClient.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Used in lieu of a Primary Interop Assembly (PIA) -->
+    <Compile Include="../Contract/*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/core/extensions/OutOfProcCOM/ManagedClient/Program.cs
+++ b/core/extensions/OutOfProcCOM/ManagedClient/Program.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ManagedClient
+{
+    class Program
+    {
+        static void Main(string[] _)
+        {
+            // If the COM server is registered as an in-proc server (as is the case when using
+            // a DLL surrogate), activation through the Activator will only use the out-of-proc
+            // server if the client and the registered COM server are not the same bitness.
+            //
+            // Type t = Type.GetTypeFromCLSID(Contract.Constants.ServerClassGuid);
+            // var server = (IServer)Activator.CreateInstance(t);
+            //
+            // This demo explicitly calls CoCreateInstance with CLSCTX_LOCAL_SERVER to force
+            // usage of the out-of-proc server.
+            object obj;
+            int hr = Ole32.CoCreateInstance(Contract.Constants.ServerClassGuid, IntPtr.Zero, Ole32.CLSCTX_LOCAL_SERVER, typeof(IServer).GUID, out obj);
+            if (hr < 0)
+            {
+                Marshal.ThrowExceptionForHR(hr);
+            }
+
+            var server = (IServer)obj;
+            double pi = server.ComputePi();
+            Console.WriteLine($"\u03C0 = {pi}");
+        }
+
+        private class Ole32
+        {
+            // https://docs.microsoft.com/windows/win32/api/wtypesbase/ne-wtypesbase-clsctx
+            public const int CLSCTX_LOCAL_SERVER = 0x4;
+
+            // https://docs.microsoft.com/windows/win32/api/combaseapi/nf-combaseapi-cocreateinstance
+            [DllImport(nameof(Ole32))]
+            public static extern int CoCreateInstance(
+                [In, MarshalAs(UnmanagedType.LPStruct)] Guid rclsid,
+                IntPtr pUnkOuter,
+                uint dwClsContext,
+                [In, MarshalAs(UnmanagedType.LPStruct)] Guid riid,
+                [MarshalAs(UnmanagedType.IUnknown)] out object ppv);
+        }
+    }
+}

--- a/core/extensions/OutOfProcCOM/NativeClient/NativeClient.cpp
+++ b/core/extensions/OutOfProcCOM/NativeClient/NativeClient.cpp
@@ -1,0 +1,41 @@
+#include <atlbase.h>
+#include <iostream>
+#include <iomanip>
+
+#include <Contract_h.h>
+#include <Contract_i.c>
+
+int main()
+{
+    ::SetConsoleOutputCP(CP_UTF8);
+
+    HRESULT hr;
+    hr = ::CoInitializeEx(0, COINITBASE_MULTITHREADED);
+    if (FAILED(hr))
+    {
+        std::cout << "CoInitializeEx failure: " << std::hex << std::showbase << hr << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    CComPtr<IServer> server;
+    hr = ::CoCreateInstance(CLSID_Server, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(IServer), (void **)&server);
+    if (FAILED(hr))
+    {
+        std::cout << "CoCreateInstance failure: " << std::hex << std::showbase << hr << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    double pi;
+    hr = server->ComputePi(&pi);
+    if (FAILED(hr))
+    {
+        std::cout << "Failure: " << std::hex << std::showbase << hr << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << u8"\u03C0 = " << std::setprecision(16) << pi << std::endl;
+
+    ::CoUninitialize();
+
+    return EXIT_SUCCESS;
+}

--- a/core/extensions/OutOfProcCOM/NativeClient/NativeClient.vcxproj
+++ b/core/extensions/OutOfProcCOM/NativeClient/NativeClient.vcxproj
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{8d4c2f17-a4bc-4349-9485-7db6741ebdac}</ProjectGuid>
+    <RootNamespace>NativeClient</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <LinkIncremental>true</LinkIncremental>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <LinkIncremental>false</LinkIncremental>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <Import Project="..\Contract\Server.Contract.props" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(ContractOutputDirectory)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="NativeClient.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Server.Contract\Server.Contract.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/core/extensions/OutOfProcCOM/NativeClient/NativeClient.vcxproj.filters
+++ b/core/extensions/OutOfProcCOM/NativeClient/NativeClient.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="NativeClient.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/core/extensions/OutOfProcCOM/OutOfProcCOM.sln
+++ b/core/extensions/OutOfProcCOM/OutOfProcCOM.sln
@@ -1,0 +1,116 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30321.6
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NativeClient", "NativeClient\NativeClient.vcxproj", "{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}"
+	ProjectSection(ProjectDependencies) = postProject
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74} = {197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ManagedClient", "ManagedClient\ManagedClient.csproj", "{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DllServer", "DllServer\DllServer.csproj", "{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}"
+	ProjectSection(ProjectDependencies) = postProject
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74} = {197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "COMRegistration", "COMRegistration\COMRegistration.csproj", "{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Server.Contract", "Server.Contract\Server.Contract.vcxproj", "{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExeServer", "ExeServer\ExeServer.csproj", "{230F076F-915D-4578-A9AA-275AA83E35C7}"
+	ProjectSection(ProjectDependencies) = postProject
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74} = {197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Debug|Any CPU.Build.0 = Debug|x64
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Debug|x64.ActiveCfg = Debug|x64
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Debug|x64.Build.0 = Debug|x64
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Debug|x86.ActiveCfg = Debug|Win32
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Debug|x86.Build.0 = Debug|Win32
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Release|Any CPU.ActiveCfg = Release|x64
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Release|Any CPU.Build.0 = Release|x64
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Release|x64.ActiveCfg = Release|x64
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Release|x64.Build.0 = Release|x64
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Release|x86.ActiveCfg = Release|Win32
+		{8D4C2F17-A4BC-4349-9485-7DB6741EBDAC}.Release|x86.Build.0 = Release|Win32
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Debug|x64.Build.0 = Debug|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Debug|x86.Build.0 = Debug|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Release|x64.ActiveCfg = Release|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Release|x64.Build.0 = Release|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1CD5425-C9BB-4F57-B205-E4DC7B9B6FAE}.Release|x86.Build.0 = Release|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Debug|x64.Build.0 = Debug|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Debug|x86.Build.0 = Debug|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Release|x64.ActiveCfg = Release|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Release|x64.Build.0 = Release|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Release|x86.ActiveCfg = Release|Any CPU
+		{744F9D0F-62D5-4E9E-8ABF-7B4CE5942EDE}.Release|x86.Build.0 = Release|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Debug|x64.Build.0 = Debug|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Debug|x86.Build.0 = Debug|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Release|x64.ActiveCfg = Release|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Release|x64.Build.0 = Release|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Release|x86.ActiveCfg = Release|Any CPU
+		{48BA0B1A-18EC-4B45-8AF3-2A16DD3993F0}.Release|x86.Build.0 = Release|Any CPU
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Debug|Any CPU.Build.0 = Debug|x64
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Debug|x64.ActiveCfg = Debug|x64
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Debug|x64.Build.0 = Debug|x64
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Debug|x86.ActiveCfg = Debug|Win32
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Debug|x86.Build.0 = Debug|Win32
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Release|Any CPU.ActiveCfg = Release|x64
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Release|Any CPU.Build.0 = Release|x64
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Release|x64.ActiveCfg = Release|x64
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Release|x64.Build.0 = Release|x64
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Release|x86.ActiveCfg = Release|Win32
+		{197EFA7E-92F1-44ED-9CCD-E32ECC7C9D74}.Release|x86.Build.0 = Release|Win32
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Debug|x64.Build.0 = Debug|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Debug|x86.Build.0 = Debug|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Release|x64.ActiveCfg = Release|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Release|x64.Build.0 = Release|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Release|x86.ActiveCfg = Release|Any CPU
+		{230F076F-915D-4578-A9AA-275AA83E35C7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6C209895-D207-41CB-AAC7-B5ABCD4CACA9}
+	EndGlobalSection
+EndGlobal

--- a/core/extensions/OutOfProcCOM/README.md
+++ b/core/extensions/OutOfProcCOM/README.md
@@ -1,0 +1,47 @@
+---
+languages:
+- csharp
+- cpp
+products:
+- dotnet-core
+page_type: sample
+name: "Out-of-process COM Server Demo"
+urlFragment: "out-of-process-com-server"
+description: "An implementation of an out-of-process COM server in .NET Core."
+---
+
+# Out-of-process COM Server Demo
+
+This sample demonstrates a way to create an out-of-process COM server in .NET Core 3.1 or later. The .NET SDK and runtime support [exposing an in-process COM server](https://docs.microsoft.com/dotnet/core/native-interop/expose-components-to-com). While there is no built-in support for exposing an out-of-process COM server, it is possible to achieve.
+
+The projects in this sample show a way to provide an out-of-process COM server with the system-supplied [DLL Surrogate](https://docs.microsoft.com/windows/win32/com/dll-surrogates) or using an executable built by the developer. Since .NET Core does not support generating a [type library](https://docs.microsoft.com/windows/win32/midl/com-dcom-and-type-libraries#type-library) from a .NET Core assembly, this sample uses [MIDL](https://docs.microsoft.com/windows/win32/com/midl-compilation) to compile an IDL file into a type library, which the COM server then [registers](https://docs.microsoft.com/windows/win32/com/loading-and-registering-a-type-library).
+
+## Prerequisites
+
+This sample will only build and run on the Windows platform.
+
+* [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download) or later
+* C++ build tools for Windows ([installation instructions](https://docs.microsoft.com/cpp/build/building-on-the-command-line#download-and-install-the-tools))
+
+## Build and Run
+
+1. Open a [Developer Command Prompt for Visual Studio](https://docs.microsoft.com/cpp/build/building-on-the-command-line#developer_command_prompt_shortcuts).
+1. Navigate to the root directory and build the solution:
+    * `msbuild OutOfProcCOM.sln -restore`.
+1. Show the instructions for COM server registration:
+    * DLL surrogate: `dotnet msbuild -target:ServerUsage DllServer`
+    * Executable server: `dotnet msbuild -target:ServerUsage ExeServer`
+1. Follow the instructions for registering the server.
+1. Run the client:
+    * Native: run the `NativeClient.exe` binary
+        * Example: `x64\Debug\NativeClient.exe`
+    * Managed: run the `ManagedClient.exe` binary
+        * Example: `ManagedClient\bin\Debug\netcoreapp3.1\ManagedClient.exe`
+
+The client program should output an estimated value of &#960;:
+
+```
+π = 3.140616091322624
+```
+
+**Note:** Remember to unregister the COM server when the demo is complete.

--- a/core/extensions/OutOfProcCOM/Server.Contract/Contract.idl
+++ b/core/extensions/OutOfProcCOM/Server.Contract/Contract.idl
@@ -1,0 +1,29 @@
+import "oaidl.idl";
+import "ocidl.idl";
+
+[
+    object,
+    oleautomation,
+    uuid(F586D6F4-AF37-441E-80A6-3D33D977882D)
+]
+interface IServer : IUnknown
+{
+    HRESULT ComputePi(
+        [out, retval] double *ret);
+};
+
+[
+    uuid(46F3FEB2-121D-4830-AA22-0CDA9EA90DC3)
+]
+library ServerLib
+{
+    importlib("stdole2.tlb");
+
+    [
+        uuid(AF080472-F173-4D9D-8BE7-435776617347)
+    ]
+    coclass Server
+    {
+        [default] interface IServer;
+    }
+}

--- a/core/extensions/OutOfProcCOM/Server.Contract/Server.Contract.vcxproj
+++ b/core/extensions/OutOfProcCOM/Server.Contract/Server.Contract.vcxproj
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{197efa7e-92f1-44ed-9ccd-e32ecc7c9d74}</ProjectGuid>
+    <RootNamespace>ServerContract</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType Condition="'$(EmbedTypeLibrary)' == 'true'">DynamicLibrary</ConfigurationType>
+    <ConfigurationType Condition="'$(EmbedTypeLibrary)' != 'true'">Utility</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <Import Project="..\Contract\Server.Contract.props" />
+  <ItemGroup>
+    <Midl Include="Contract.idl">
+      <OutputDirectory>$(ContractOutputDirectory)</OutputDirectory>
+      <TypeLibraryName>$(TypeLibraryPath)</TypeLibraryName>
+    </Midl>
+  </ItemGroup>
+  <ItemGroup Condition="'$(EmbedTypeLibrary)' == 'true'">
+    <ResourceCompile Include="Server.TypeLib.rc">
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(ContractOutputDirectory)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SERVER_CONTRACT_TLB_NAME=$(TypeLibraryName)</PreprocessorDefinitions>
+      <LinkCompiled>false</LinkCompiled>
+      <ResourceOutputFileName>$(TypeLibraryCompiledResourcePath)</ResourceOutputFileName>
+    </ResourceCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/core/extensions/OutOfProcCOM/Server.Contract/Server.Contract.vcxproj.filters
+++ b/core/extensions/OutOfProcCOM/Server.Contract/Server.Contract.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="Contract.idl">
+      <Filter>Source Files</Filter>
+    </Midl>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Server.TypeLib.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/core/extensions/OutOfProcCOM/Server.Contract/Server.TypeLib.rc
+++ b/core/extensions/OutOfProcCOM/Server.Contract/Server.TypeLib.rc
@@ -1,0 +1,7 @@
+// Microsoft Visual C++ generated resource script.
+//
+
+//
+#include "winres.h"
+
+1 TYPELIB SERVER_CONTRACT_TLB_NAME

--- a/core/extensions/OutOfProcCOM/snippets.5000.json
+++ b/core/extensions/OutOfProcCOM/snippets.5000.json
@@ -1,0 +1,3 @@
+{
+    "host": "visualstudio"
+}


### PR DESCRIPTION
## Summary

Add out-of-process COM server demo.

`DllServer` : uses `[ComRegisterFunction]` and `[ComUnregisterFunction]` with the existing comhost support to register and unregister the DLL surrogate (system-supplied) and type library
`ExeServer` : self-registering - run with `/regserver` or `/unregserver` to register or unregister the executable server and type library

cc @AaronRobinsonMSFT @jkoritzinsky 