### PR TITLE
Upgrade projects using EOL version (2.2) to 3.1

### DIFF
--- a/core/console-apps/FibonacciBetterMsBuild/Fibonacci.csproj
+++ b/core/console-apps/FibonacciBetterMsBuild/Fibonacci.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/core/console-apps/HelloMsBuild/Hello.csproj
+++ b/core/console-apps/HelloMsBuild/Hello.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/core/console-apps/NewTypesMsBuild/src/NewTypes/NewTypes.csproj
+++ b/core/console-apps/NewTypesMsBuild/src/NewTypes/NewTypes.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/core/console-apps/NewTypesMsBuild/test/NewTypesTests/NewTypesTests.csproj
+++ b/core/console-apps/NewTypesMsBuild/test/NewTypesTests/NewTypesTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/console-apps/fibonacci-msbuild/Hello.csproj
+++ b/core/console-apps/fibonacci-msbuild/Hello.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/core/getting-started/golden/app/app.csproj
+++ b/core/getting-started/golden/app/app.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/core/getting-started/golden/src/app/app.csproj
+++ b/core/getting-started/golden/src/app/app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\library\library.csproj" />

--- a/core/getting-started/golden/test-library/test-library.csproj
+++ b/core/getting-started/golden/test-library/test-library.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/getting-started/golden/test/test-library/test-library.csproj
+++ b/core/getting-started/golden/test/test-library/test-library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService.Tests.csproj
+++ b/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/core/getting-started/unit-testing-using-mstest/PrimeService.Tests/PrimeService.Tests.csproj
+++ b/core/getting-started/unit-testing-using-mstest/PrimeService.Tests/PrimeService.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/getting-started/unit-testing-vb-dotnet-test/PrimeService.Tests/PrimeService.Tests.vbproj
+++ b/core/getting-started/unit-testing-vb-dotnet-test/PrimeService.Tests/PrimeService.Tests.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-vb-mstest/PrimeService.Tests/PrimeService.Tests.vbproj
+++ b/core/getting-started/unit-testing-vb-mstest/PrimeService.Tests/PrimeService.Tests.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-vb-nunit/PrimeService.Tests/PrimeService.Tests.vbproj
+++ b/core/getting-started/unit-testing-vb-nunit/PrimeService.Tests/PrimeService.Tests.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-with-fsharp-mstest/MathService.Tests/MathService.Tests.fsproj
+++ b/core/getting-started/unit-testing-with-fsharp-mstest/MathService.Tests/MathService.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/MathService.Tests.fsproj
+++ b/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/MathService.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-with-fsharp/MathService.Tests/MathService.Tests.fsproj
+++ b/core/getting-started/unit-testing-with-fsharp/MathService.Tests/MathService.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/linq/csharp/aggregate/aggregate.csproj
+++ b/core/linq/csharp/aggregate/aggregate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/concatenation/concatenation.csproj
+++ b/core/linq/csharp/concatenation/concatenation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/conversion/conversion.csproj
+++ b/core/linq/csharp/conversion/conversion.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/customsequence/customsequence.csproj
+++ b/core/linq/csharp/customsequence/customsequence.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/element/element.csproj
+++ b/core/linq/csharp/element/element.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/equality/equality.csproj
+++ b/core/linq/csharp/equality/equality.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/generation/generation.csproj
+++ b/core/linq/csharp/generation/generation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/grouping/grouping.csproj
+++ b/core/linq/csharp/grouping/grouping.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/join/join.csproj
+++ b/core/linq/csharp/join/join.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/ordering/ordering.csproj
+++ b/core/linq/csharp/ordering/ordering.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/partitioning/partitioning.csproj
+++ b/core/linq/csharp/partitioning/partitioning.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/projection/projection.csproj
+++ b/core/linq/csharp/projection/projection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/quantifier/quantifier.csproj
+++ b/core/linq/csharp/quantifier/quantifier.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/queryexecution/queryexecution.csproj
+++ b/core/linq/csharp/queryexecution/queryexecution.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/restriction/restriction.csproj
+++ b/core/linq/csharp/restriction/restriction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/linq/csharp/setoperators/setoperators.csproj
+++ b/core/linq/csharp/setoperators/setoperators.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/core/tutorials/using-on-mac-vs-full-solution/WordCounter/TestLibrary/TestLibrary.csproj
+++ b/core/tutorials/using-on-mac-vs-full-solution/WordCounter/TestLibrary/TestLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/tutorials/using-on-mac-vs-full-solution/WordCounter/WordCounterApp/WordCounterApp.csproj
+++ b/core/tutorials/using-on-mac-vs-full-solution/WordCounter/WordCounterApp/WordCounterApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/csharp/PatternMatching/PatternMatching.csproj
+++ b/csharp/PatternMatching/PatternMatching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/branches-quickstart/BranchesAndLoops.csproj
+++ b/csharp/branches-quickstart/BranchesAndLoops.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/classes-quickstart/classes.csproj
+++ b/csharp/classes-quickstart/classes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/delegates-and-events/delegates-and-events.csproj
+++ b/csharp/delegates-and-events/delegates-and-events.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/csharp/events/events.csproj
+++ b/csharp/events/events.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/csharp/expression-trees/expression-trees.csproj
+++ b/csharp/expression-trees/expression-trees.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/getting-started/console-linq/console-linq.csproj
+++ b/csharp/getting-started/console-linq/console-linq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/getting-started/console-teleprompter/console-teleprompter.csproj
+++ b/csharp/getting-started/console-teleprompter/console-teleprompter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/indexers/indexers.csproj
+++ b/csharp/indexers/indexers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/iterators/iterators.csproj
+++ b/csharp/iterators/iterators.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/list-quickstart/list-quickstart.csproj
+++ b/csharp/list-quickstart/list-quickstart.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/numbers-quickstart/NumbersInCSharp.csproj
+++ b/csharp/numbers-quickstart/NumbersInCSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/roslyn-sdk/Tutorials/MakeConstTestProject/MakeConstTestProject/MakeConstTestProject.csproj
+++ b/csharp/roslyn-sdk/Tutorials/MakeConstTestProject/MakeConstTestProject/MakeConstTestProject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/safe-efficient-code/benchmark/benchmark.csproj
+++ b/csharp/safe-efficient-code/benchmark/benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/csharp/safe-efficient-code/ref-readonly-struct/ref-readonly-struct.csproj
+++ b/csharp/safe-efficient-code/ref-readonly-struct/ref-readonly-struct.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/csharp/serialization/serialization.csproj
+++ b/csharp/serialization/serialization.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/csharp/tutorials/exploration/csharp6-finished/csharp6-finished.csproj
+++ b/csharp/tutorials/exploration/csharp6-finished/csharp6-finished.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>csharp6_finished</RootNamespace>
     <LangVersion>6</LangVersion>
   </PropertyGroup>

--- a/csharp/tutorials/exploration/csharp6-starter/csharp6-starter.csproj
+++ b/csharp/tutorials/exploration/csharp6-starter/csharp6-starter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>6</LangVersion>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>csharp6_starter</RootNamespace>
   </PropertyGroup>
 

--- a/csharp/unit-testing-best-practices/after/unit-testing-best-practices-after.csproj
+++ b/csharp/unit-testing-best-practices/after/unit-testing-best-practices-after.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/csharp/unit-testing-best-practices/before/unit-testing-best-practices-before.csproj
+++ b/csharp/unit-testing-best-practices/before/unit-testing-best-practices-before.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/csharp/unit-testing-best-practices/unit-testing-best-practices/unit-testing-best-practices.csproj
+++ b/csharp/unit-testing-best-practices/unit-testing-best-practices/unit-testing-best-practices.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/versioning/new/new.csproj
+++ b/csharp/versioning/new/new.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/csharp/versioning/override/override.csproj
+++ b/csharp/versioning/override/override.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/framework/libraries/migrate-library-csproj/tests/Car.Tests/Car.Tests.csproj
+++ b/framework/libraries/migrate-library-csproj/tests/Car.Tests/Car.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/machine-learning/tutorials/IrisFlowerClustering/IrisFlowerClustering.csproj
+++ b/machine-learning/tutorials/IrisFlowerClustering/IrisFlowerClustering.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/machine-learning/tutorials/ProductSalesAnomalyDetection/ProductSalesAnomalyDetection.csproj
+++ b/machine-learning/tutorials/ProductSalesAnomalyDetection/ProductSalesAnomalyDetection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/machine-learning/tutorials/TaxiFarePrediction/TaxiFarePrediction.csproj
+++ b/machine-learning/tutorials/TaxiFarePrediction/TaxiFarePrediction.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/machine-learning/tutorials/TransferLearningTF/TransferLearningTF.csproj
+++ b/machine-learning/tutorials/TransferLearningTF/TransferLearningTF.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 

--- a/mef/simple-calculator/vb/SimpleCalculator2.vbproj
+++ b/mef/simple-calculator/vb/SimpleCalculator2.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>SimpleCalculator2</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationManifest>My Project\app.manifest</ApplicationManifest>
     <StartupObject>SimpleCalculator2.Program</StartupObject>
   </PropertyGroup>


### PR DESCRIPTION
Projects shouldn't be using 2.2 anymore since it's no longer supported

We got a feedback on our dot.net website today about a customer not being able to complete https://docs.microsoft.com/dotnet/csharp/tutorials/working-with-linq#introduction and they were visiting https://dotnet.microsoft.com/download/dotnet-core/2.2/runtime/?utm_source=getdotnetcore&utm_medium=referral

So my hypothesis here is that they ended up there because the code is still using 2.2 but not completely sure
