### PR TITLE
Change snippets5000 download location of dotnet-install

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -42,7 +42,7 @@ jobs:
       if: ${{ env.DOTNET_DO_INSTALL == 'true' }}
       run: |
         echo "Downloading dotnet-install.ps1"
-        Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
+        Invoke-WebRequest https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.ps1 -OutFile dotnet-install.ps1
         echo "Installing dotnet version ${{ env.DOTNET_INSTALLER_CHANNEL }}"
         .\dotnet-install.ps1 -InstallDir "c:\program files\dotnet" -Channel "${{ env.DOTNET_INSTALLER_CHANNEL }}"
       


### PR DESCRIPTION
The publicly available dotnet-install powershell script no longer handles the 5.0 release channel. The latest script version in the github repo does. This PR changes the script location.