### PR TITLE
Fix iOSSample package version to match NETCoreAppPackageVersion

### DIFF
--- a/core/mono-samples/iOS/iOSSampleApp.csproj
+++ b/core/mono-samples/iOS/iOSSampleApp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Runtime.iOS.Sample.Mono" Version="6.0.0-*" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Runtime.iOS.Sample.Mono" Version="6.0.0-$(BundledNETCoreAppPackageVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 
   <UsingTask TaskName="AppleAppBuilderTask"


### PR DESCRIPTION
## Summary

In the `mono-samples` iOS sample, the package reference should be fixed to match the the runtime pack version. A version mismatch could lead to the sample breaking.
