### PR TITLE
Testing new macos lane

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -45,11 +45,6 @@ jobs:
         Invoke-WebRequest https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.ps1 -OutFile dotnet-install.ps1
         echo "Installing dotnet version ${{ env.DOTNET_INSTALLER_CHANNEL }}"
         .\dotnet-install.ps1 -InstallDir "c:\program files\dotnet" -Channel "${{ env.DOTNET_INSTALLER_CHANNEL }}"
-    - name: Setup .NET SDK 6 Preview
-      if: ${{ env.DOTNET_DO_INSTALL == 'true' }}
-      run: |
-        echo "Installing dotnet version ${{ env.DOTNET_INSTALLER_CHANNEL }}"
-        .\dotnet-install.ps1 -InstallDir "c:\program files\dotnet" -Version 6.0.100-alpha.1.20529.2
       
     # Install locate projs global tool
     - name: Install LocateProjects tool

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -75,20 +75,3 @@ jobs:
     - name: Report status
       run: |
         ./.github/workflows/dependencies/Out-GithubActionStatus.ps1
-
-  build-mono:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
-    - name: Setup .NET SDK 6
-      if: ${{ env.DOTNET_DO_INSTALL == 'true' }}
-      run: |
-        echo "Downloading dotnet-install.sh"
-        curl https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.sh --output dotnet-install.sh
-        echo "Installing dotnet version ${{ env.DOTNET_INSTALLER_CHANNEL }}"
-        chmod +x ./dotnet-install.sh
-        ./dotnet-install.sh -InstallDir ~/.dotnet -Version 6.0.100-alpha.1.20531.2
-    - name: Publish mono iOS sample
-      run: |
-        cd ./core/mono-samples/iOS
-        dotnet publish /p:RunOnCI=True

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -75,6 +75,20 @@ jobs:
     - name: Report status
       run: |
         ./.github/workflows/dependencies/Out-GithubActionStatus.ps1
-      
-      
-      
+
+  build-mono:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
+    - name: Setup .NET SDK 6
+      if: ${{ env.DOTNET_DO_INSTALL == 'true' }}
+      run: |
+        echo "Downloading dotnet-install.sh"
+        curl https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.sh --output dotnet-install.sh
+        echo "Installing dotnet version ${{ env.DOTNET_INSTALLER_CHANNEL }}"
+        chmod +x ./dotnet-install.sh
+        ./dotnet-install.sh -InstallDir ~/.dotnet -Version 6.0.100-alpha.1.20531.2
+    - name: Publish mono iOS sample
+      run: |
+        cd ./core/mono-samples/iOS
+        dotnet publish /p:RunOnCI=True

--- a/.github/workflows/dependencies/Get-MSBuildResults.ps1
+++ b/.github/workflows/dependencies/Get-MSBuildResults.ps1
@@ -129,11 +129,16 @@ foreach ($item in $workingSet) {
                 
         $data = $item.Split('|')
 
+        if ($data[1].Contains("mono-samples")){
+            Write-Host "Found mono-sample project, Skipping."
+            $counter++
+            Continue
+        }
         # Project found, build it
-        if ([int]$data[0] -eq 0) {
+        elseif ([int]$data[0] -eq 0) {
             $projectFile = Resolve-Path "$RepoRootDir\$($data[2])"
             $configFile = [System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($projectFile), "snippets.5000.json")
-            
+
             # Create the default build command
             "dotnet build `"$projectFile`"" | Out-File ".\run.bat"
 

--- a/.github/workflows/publish-mono-samples.yml
+++ b/.github/workflows/publish-mono-samples.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Publish mono iOS sample
       run: |
         cd ./core/mono-samples/iOS
-        dotnet publish /p:RunOnCI=True
+        dotnet publish /p:RunningOnCI=True

--- a/.github/workflows/publish-mono-samples.yml
+++ b/.github/workflows/publish-mono-samples.yml
@@ -1,0 +1,38 @@
+name: Publish Mono Samples
+
+on:
+  pull_request:
+    paths:
+      - "core/mono-samples/**.c"
+      - "core/mono-samples/**.config"
+      - "core/mono-samples/**.cs"
+      - "core/mono-samples/**.csproj"
+      - "core/mono-samples/**.html"
+      - "core/mono-samples/**.java"
+      - "core/mono-samples/**.js"
+      - "core/mono-samples/**.m"
+      - "core/mono-samples/**.py"
+      - "core/mono-samples/**.txt"
+    branches: [ master ]
+
+env:
+  DOTNET_INSTALLER_CHANNEL: '6.0.100-alpha.1.20531.2'
+  DOTNET_DO_INSTALL: 'true'
+
+jobs:
+  build-mono:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 #@v2
+    - name: Setup .NET SDK 6
+      if: ${{ env.DOTNET_DO_INSTALL == 'true' }}
+      run: |
+        echo "Downloading dotnet-install.sh"
+        curl https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.sh --output dotnet-install.sh
+        echo "Installing dotnet version ${{ env.DOTNET_INSTALLER_CHANNEL }}"
+        chmod +x ./dotnet-install.sh
+        ./dotnet-install.sh -InstallDir ~/.dotnet -Version ${{ env.DOTNET_INSTALLER_CHANNEL }}
+    - name: Publish mono iOS sample
+      run: |
+        cd ./core/mono-samples/iOS
+        dotnet publish /p:RunOnCI=True

--- a/core/mono-samples/iOS/iOSSampleApp.csproj
+++ b/core/mono-samples/iOS/iOSSampleApp.csproj
@@ -44,7 +44,7 @@
     </AppleAppBuilderTask>
   </Target>
 
-  <Target Name="LaunchApp" AfterTargets="BuildAppBundle" Condition="'$(RunOnCI)' == ''">
+  <Target Name="LaunchApp" AfterTargets="BuildAppBundle" Condition="'$(RunningOnCI)' == ''">
     <Message Importance="High" Text="Xcode: $(XcodeProjectPath)" />
     <Message Importance="High" Text="App:   $(AppBundlePath)" />
     <Message Importance="High" Text="Restarting device" />

--- a/core/mono-samples/iOS/iOSSampleApp.csproj
+++ b/core/mono-samples/iOS/iOSSampleApp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Runtime.iOS.Sample.Mono" Version="6.0.0-$(BundledNETCoreAppPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NET.Runtime.iOS.Sample.Mono" Version="$(BundledNETCoreAppPackageVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 
   <UsingTask TaskName="AppleAppBuilderTask"

--- a/core/mono-samples/iOS/iOSSampleApp.csproj
+++ b/core/mono-samples/iOS/iOSSampleApp.csproj
@@ -42,7 +42,9 @@
       <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
       <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />
     </AppleAppBuilderTask>
+  </Target>
 
+  <Target Name="LaunchApp" AfterTargets="BuildAppBundle" Condition="'$(RunOnCI)' == ''">
     <Message Importance="High" Text="Xcode: $(XcodeProjectPath)" />
     <Message Importance="High" Text="App:   $(AppBundlePath)" />
     <Message Importance="High" Text="Restarting device" />


### PR DESCRIPTION
## Summary

With the import of `dotnet/runtime` samples that demonstrate how to build iOS, Android, and wasm apps on top of the mono runtime,  a check to ensure that these have built properly is needed. The mono samples need to pull down a runtime pack to properly build the application, so `dotnet publish` will be used instead of `dotnet build`.

The applications will not be ran for these checks. Ensuring that the applications can be built is the primary goal.

This PR looks to add another GitHub Actions workflow that targets these mono-samples.
When a file that influences the publish process is changed, the original [build](https://github.com/dotnet/samples/blob/master/.github/workflows/build-validation.yml) shall not be ran for the project, instead, the new one will be ran.

As seen in this PR, the original build check does not run for this PR, only `Publish Mono Samples` is ran.