### PR TITLE
Add ignore information to dependabot manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,9 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 5
+    ignore:
+     - dependency-name: "Microsoft.AspNetCore.Mvc.NewtonsoftJson"
+       versions: ["5.*"]
   - package-ecosystem: "nuget"
     directory: "/core/mono-samples/iOS" #iOSSampleApp.csproj
     schedule:


### PR DESCRIPTION
This change will remove 5.0 packages for `Microsoft.AspNetCore.Mvc.NewtonsoftJson`, which are 5.0 only. This app is 3.1.