### PR TITLE
Update Benchmark to reflect optimisations

### DIFF
--- a/csharp/safe-efficient-code/benchmark/Program.cs
+++ b/csharp/safe-efficient-code/benchmark/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
@@ -36,9 +36,9 @@ namespace benchmark
 
     public struct MyMutableStruct
     {
-        public double X { get; }
-        public double Y { get; }
-        public double Z { get; }
+        public double X { get => x; set => x = value; }
+        public double Y { get => y; set => y = value; }
+        public double Z { get => z; set => z = value; }
 
         private double a;
         private double b;
@@ -48,19 +48,56 @@ namespace benchmark
         private double f;
         private double g;
         private double h;
+        private double z;
+        private double y;
+        private double x;
+
         public MyMutableStruct(double x, double y = 0, double z = 0)
         {
-            X = x;
-            Y = y;
-            Z = z;
-            a = 1;
-            b = 2;
-            c = 3;
-            d = 4;
-            e = 5;
-            f = 6;
-            g = 7;
-            h = 8;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.a = 1;
+            this.b = 2;
+            this.c = 3;
+            this.d = 4;
+            this.e = 5;
+            this.f = 6;
+            this.g = 7;
+            this.h = 8;
+        }
+    }
+    public struct MyMutableStructReadonly
+    {
+        public double X { readonly get => x; set => x = value; }
+        public double Y { readonly get => y; set => y = value; }
+        public double Z { readonly get => z; set => z = value; }
+
+        private double a;
+        private double b;
+        private double c;
+        private double d;
+        private double e;
+        private double f;
+        private double g;
+        private double h;
+        private double z;
+        private double y;
+        private double x;
+
+        public MyMutableStructReadonly(double x, double y = 0, double z = 0)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.a = 1;
+            this.b = 2;
+            this.c = 3;
+            this.d = 4;
+            this.e = 5;
+            this.f = 6;
+            this.g = 7;
+            this.h = 8;
         }
     }
 
@@ -68,17 +105,18 @@ namespace benchmark
     {
         MyImmutableStruct sStruct = new MyImmutableStruct(1.1, 2.2);
         MyMutableStruct mStruct = new MyMutableStruct(1.1, 2.2);
+        MyMutableStructReadonly mrStruct = new MyMutableStructReadonly(1.1, 2.2);
 
         [Benchmark]
-        public void ImmutableAddByType()
+        public double ImmutableAddByType()
         {
-            add_by_type(sStruct);
+            return add_by_type(sStruct);
         }
 
         [Benchmark]
-        public void ImmutableAddByRefType()
+        public double ImmutableAddByRefType()
         {
-            add_by_reftype(in sStruct);
+            return add_by_reftype(in sStruct);
         }
         public double add_by_type(MyImmutableStruct s)
         {
@@ -90,15 +128,15 @@ namespace benchmark
         }
 
         [Benchmark]
-        public void MutableAddByType()
+        public double MutableAddByType()
         {
-            add_by_type(mStruct);
+            return add_by_type(mStruct);
         }
 
         [Benchmark]
-        public void MutableAddByRefType()
+        public double MutableAddByRefType()
         {
-            add_by_reftype(in mStruct);
+            return add_by_reftype(in mStruct);
         }
 
         public double add_by_type(MyMutableStruct s)
@@ -106,6 +144,27 @@ namespace benchmark
             return s.X + s.Y;
         }
         public double add_by_reftype(in MyMutableStruct s)
+        {
+            return s.X + s.Y;
+        }
+
+        [Benchmark]
+        public double MutableReadOnlyAddByType()
+        {
+            return add_by_type(mrStruct);
+        }
+
+        [Benchmark]
+        public double MutableReadonlyAddByRefType()
+        {
+            return add_by_reftype(in mrStruct);
+        }
+
+        public double add_by_type(MyMutableStructReadonly s)
+        {
+            return s.X + s.Y;
+        }
+        public double add_by_reftype(in MyMutableStructReadonly s)
         {
             return s.X + s.Y;
         }


### PR DESCRIPTION
## Summary

The [docs](https://docs.microsoft.com/en-us/dotnet/csharp/write-safe-efficient-code#avoid-mutable-structs-as-an-in-argument) say that using `in` modifier with non `readonly struct`s can have performance issues. It references this file that should demonstrate this. However when I tested it on *.Net 5* I didn't see any difference.
I also got the warning that some calls could not be distinguished from empty methods. 

This I made following changes:
* _add a return type to benchmark methods_  
  According to the [documentation of Benchmark .Net](https://benchmarkdotnet.org/articles/guides/good-practices.html#avoid-dead-code-elimination) this prevents dead
  code elimination.
* _refactored auto properties to full properties_  
  It seems since the benchmark was written some optimization was done to auto properties, so they are marked as readonly. This no longer demonstrates the effect desired
* _Add a third `MutableReadonly` struct was added_  
  To show that Mutable `structs` do not automatically decrease performance. Which is also important since having a big `readonly struct` where one field needs often to be
  changed, would result in a decrease in performance.

## Resulting Benchmark 

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
  DefaultJob : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT


|                      Method |      Mean |     Error |    StdDev |
|---------------------------- |----------:|----------:|----------:|
|          ImmutableAddByType | 3.1876 ns | 0.0769 ns | 0.0681 ns |
|       ImmutableAddByRefType | 0.2507 ns | 0.0229 ns | 0.0191 ns |
|            MutableAddByType | 3.1468 ns | 0.0454 ns | 0.0402 ns |
|         MutableAddByRefType | 7.7434 ns | 0.1459 ns | 0.1293 ns |
|    MutableReadOnlyAddByType | 3.5987 ns | 0.0570 ns | 0.0533 ns |
| MutableReadonlyAddByRefType | 0.2628 ns | 0.0317 ns | 0.0281 ns |