### PR TITLE
Fix TaskDialogDemo compilation

### DIFF
--- a/windowsforms/TaskDialogDemo/cs/TaskDialogDemo.csproj
+++ b/windowsforms/TaskDialogDemo/cs/TaskDialogDemo.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>


### PR DESCRIPTION
1. Removes WindowsDesktop part of the SDK. [Reference](https://docs.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/5.0/sdk-and-target-framework-change)
2. Fixes compilation error - net5.0-windows is the correct TargetFramework. Won't compile otherwise.

Might want to check the other samples too.😉