### PR TITLE
Upgrade to LTS version .NET Core 3.1, 4284 & 4257

### DIFF
--- a/core/encoding/cyrillic-to-latin/cs/CyrillicToLatin.csproj
+++ b/core/encoding/cyrillic-to-latin/cs/CyrillicToLatin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/encoding/cyrillic-to-latin/vb/CyrillicToLatin.vbproj
+++ b/core/encoding/cyrillic-to-latin/vb/CyrillicToLatin.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>vb</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Upgrade to LTS version .NET Core 3.1

Fixes #4284 
Fixes #4257