### PR TITLE
HostWithHostFxr: Fix sample startup for net5.0

### DIFF
--- a/core/hosting/HostWithHostFxr/src/DotNetLib/DotNetLib.csproj
+++ b/core/hosting/HostWithHostFxr/src/DotNetLib/DotNetLib.csproj
@@ -7,6 +7,7 @@
 
   <PropertyGroup>
     <OutputPath>$(BinRoot)/$(Configuration)/</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Automatically appended TFM resulted in wrong output path.

Fixes
The specified runtimeconfig.json [samples\core\hosting\HostWithHostFxr\bin\Debug\DotNetLib.runtimeconfig.json] does not exist
Init failed: 0x80008093
Assertion failed: load_assembly_and_get_function_pointer != nullptr && "Failure: get_dotnet_load_assembly()", file samples\core\hosting\HostWithHostFxr\src\NativeHost\nativehost.cpp, line 89
