### PR TITLE
console-teleprompter: fix case sensitive bug

### DIFF
--- a/csharp/getting-started/console-teleprompter/Program.cs
+++ b/csharp/getting-started/console-teleprompter/Program.cs
@@ -23,7 +23,7 @@ namespace TeleprompterConsole
 
         private static async Task ShowTeleprompter(TelePrompterConfig config)
         {
-            var words = ReadFrom("SampleQuotes.txt");
+            var words = ReadFrom("sampleQuotes.txt");
             foreach (var word in words)
             {
                 Console.Write(word);


### PR DESCRIPTION
The program has a file in the local directory called sampleQuotes.txt
(lowercase s at the beginning).

The program tried to read it as SampleQuotes.txt (uppercase s at the
beginning). On case sensitive filesystems such as on Linux, the file
couldn't be found.

I didn't rename the file, because it is referred to by
https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/console-teleprompter.

Instead, I fixed the file name that's requested in the program.

