### PR TITLE
Update interop samples to match .NET 5.0 RTM

### DIFF
--- a/core/interop/comwrappers/IDispatch/ComWrappersIDispatch.csproj
+++ b/core/interop/comwrappers/IDispatch/ComWrappersIDispatch.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/core/interop/comwrappers/IDispatch/README.md
+++ b/core/interop/comwrappers/IDispatch/README.md
@@ -15,7 +15,7 @@ This is already fully supported by the built-in COM interop system, but this dem
 Build and Run
 -------------
 
-1) Install .NET Core 5.0 or later.
+1) Install .NET 5.0 or later.
 
 1) Load `ComWrappersIDispatch.csproj` in Visual Studio 2019 or build from the command line.
     - Double click on `ComWrappersIDispatch.csproj` in File Explorer.

--- a/core/interop/comwrappers/IDispatch/README.md
+++ b/core/interop/comwrappers/IDispatch/README.md
@@ -1,7 +1,7 @@
 `ComWrappers` API Demo
 ================
 
-The [`ComWrappers` API](https://github.com/dotnet/runtime/issues/1845) was introduced in .NET 5.0 Preview 4 to help users build custom COM interop scenarios.
+The [`ComWrappers` API](https://github.com/dotnet/runtime/issues/1845) was introduced in .NET 5.0 to help users build custom COM interop scenarios.
 
 Key Features
 ------------
@@ -15,7 +15,7 @@ This is already fully supported by the built-in COM interop system, but this dem
 Build and Run
 -------------
 
-1) Install .NET Core 5.0 Preview 4 or later.
+1) Install .NET Core 5.0 or later.
 
 1) Load `ComWrappersIDispatch.csproj` in Visual Studio 2019 or build from the command line.
     - Double click on `ComWrappersIDispatch.csproj` in File Explorer.


### PR DESCRIPTION
## Summary
Use `Microsoft.NET.Sdk` and target `net5.0-windows` to match recommendations from .NET SDK
Without that dotnet build produce error

Relates to #4069