### PR TITLE
Delete MakeConst from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -318,12 +318,6 @@ updates:
       day: "wednesday"
     open-pull-requests-limit: 5
   - package-ecosystem: "nuget"
-    directory: "/csharp/roslyn-sdk/Tutorials/MakeConst/MakeConst" #MakeConst.csproj
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-    open-pull-requests-limit: 5
-  - package-ecosystem: "nuget"
     directory: "/csharp/roslyn-sdk/Tutorials/MakeConst/MakeConst.Test" #MakeConst.Test.csproj
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Updating dependencies for this analyzer sample isn't so good as it new CodeAnalysis packages will require higher version of Visual Studio and/or SDK.
