### PR TITLE
We need to persist the build-env layer from the SDK

### DIFF
--- a/github-actions/DotNet.GitHubAction/Dockerfile
+++ b/github-actions/DotNet.GitHubAction/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 # Copy everything and restore
 COPY . ./
@@ -14,7 +14,5 @@ LABEL com.github.actions.description="A Github action that maintains a CODE_METR
 LABEL com.github.actions.icon="sliders"
 LABEL com.github.actions.color="purple"
 
-# Build the runtime image
-FROM mcr.microsoft.com/dotnet/runtime:5.0
-COPY --from=build-env /out .
-ENTRYPOINT [ "dotnet", "/DotNet.GitHubAction.dll" ]
+COPY /out /app
+ENTRYPOINT [ "dotnet", "./app/DotNet.GitHubAction.dll" ]


### PR DESCRIPTION
## Summary

We need to persist the build-env layer from the SDK, so that MSBuild bits are discoverable. Instead of building the final image layer as the runtime, instead leave it as the SDK (which includes the runtime), but also has the msbuild bits...

Related to #4431 and #4435
