### PR TITLE
Downgrade OldJsonPlugin to be older than JsonPlugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -191,6 +191,9 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 5
+    ignore:
+     - dependency-name: "Newtonsoft.Json"
+       versions: ["12.*"]
   - package-ecosystem: "nuget"
     directory: "/core/extensions/AppWithPlugin/UVPlugin" #UVPlugin.csproj
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -193,7 +193,6 @@ updates:
     open-pull-requests-limit: 5
     ignore:
      - dependency-name: "Newtonsoft.Json"
-       versions: ["12.*"]
   - package-ecosystem: "nuget"
     directory: "/core/extensions/AppWithPlugin/UVPlugin" #UVPlugin.csproj
     schedule:

--- a/core/extensions/AppWithPlugin/OldJsonPlugin/OldJsonPlugin.csproj
+++ b/core/extensions/AppWithPlugin/OldJsonPlugin/OldJsonPlugin.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

The intent of OldJsonPlugin is to demonstrate that this plugin architecture can handle multiple dependencies of differing versions, but dependabot in its wisdom bumped both to the same version, making this example useless.

Obsoletes #4472 