### PR TITLE
Construct AssemblyName from full path

### DIFF
--- a/core/extensions/AppWithPlugin/AppWithPlugin/Program.cs
+++ b/core/extensions/AppWithPlugin/AppWithPlugin/Program.cs
@@ -79,7 +79,7 @@ namespace AppWithPlugin
             string pluginLocation = Path.GetFullPath(Path.Combine(root, relativePath.Replace('\\', Path.DirectorySeparatorChar)));
             Console.WriteLine($"Loading commands from: {pluginLocation}");
             PluginLoadContext loadContext = new PluginLoadContext(pluginLocation);
-            return loadContext.LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(pluginLocation)));
+            return loadContext.LoadFromAssemblyName(AssemblyName.GetAssemblyName(pluginLocation));
         }
 
         static IEnumerable<ICommand> CreateCommands(Assembly assembly)


### PR DESCRIPTION
## Summary

Even though the assembly resolution based on an inexact assembly name works, i think it's cleaner to use the full assembly information including the version read from the assemblyfile to be loaded.

Inside the `PluginLoadContext` class you can see the difference in the properties `FullName` and `Version` of the `AssemblyName`-object, used to load the desired assembly:

**before**
![before](https://user-images.githubusercontent.com/19730957/119704834-6244af00-be58-11eb-991a-92dd84c74d32.png)

**after**
![after](https://user-images.githubusercontent.com/19730957/119704886-6f619e00-be58-11eb-8648-26cf21616741.png)

