### PR TITLE
Update Excel Demo Readme

### DIFF
--- a/core/extensions/ExcelDemo/ReadMe.md
+++ b/core/extensions/ExcelDemo/ReadMe.md
@@ -1,3 +1,14 @@
+---
+languages:
+- csharp
+products:
+- dotnet-core
+page_type: sample
+name: "Excel Demo"
+urlFragment: "excel-demo"
+description: "A sample that demonstrates Excel interop in .NET Core"
+---
+
 Excel Demo
 ================
 
@@ -16,7 +27,9 @@ Demonstrates how to consume Office Primary Interop Assemblies (PIA) with .NET Co
 Build and Run
 -------------
 
-To build and run the sample, the project must be loaded in Visual Studio 2019. Build support for `COMReference` elements is not supported in the `dotnet` tool for the Preview 1 release, but the scenario is demoable from within Visual Studio 2019.
+To build and run the sample, you could load it in Visual Studio 2019 or use MSBuild command line. Build support for `COMReference` elements is not supported in the `dotnet` tool for the Preview 1 release, but the scenario is demoable from within Visual Studio 2019.
+
+To build and run this sample using Visual Studio:
 
 1) Install .NET Core 3.1.
 
@@ -28,3 +41,16 @@ To build and run the sample, the project must be loaded in Visual Studio 2019. B
     - Open a Developer Command prompt and open with `devenv.exe ExcelDemo.csproj`.
 
 1) Press <kbd>F5</kbd> to build and debug the project.
+
+To build and run this sample using MSBuild command line:
+
+1) Install .NET Core 3.1.
+
+1) Open a Developer Command prompt in the sample directory
+
+1) Enter the following commands
+
+```cmd
+msbuild -t:Restore;Build ExcelDemo.csproj
+bin\Debug\netcoreapp3.1\ExcelDemo.exe
+```


### PR DESCRIPTION
- Annotate for Sample Browser
- Add information how to build and run project from command line

.NET CLI does not support COM references, but the full MSBuild command line shipped with Visual Studio does. So it might be useful to have build instructions that don't depend on VS GUI.
