### PR TITLE
config updates for required actions

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -1,25 +1,12 @@
 # This is a basic workflow to help you get started with Actions
-name: Snippets 5000
+name: 'Snippets 5000'
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch
 on:
-  pull_request:
-    paths:
-      - "**.cs"
-      - "**.vb"
-      - "**.fs"
-      - "**.xaml"
-      - "**.razor"
-      - "**.cshtml"
-      - "**.vbhtml"
-      - "**.csproj"
-      - "**.vbproj"
-      - "**.fsproj"
-      - "**.sln"
-      - "**global.json"
-      - "**snippets.5000.json"
+  pull_request_target:
     branches: [ main ]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       reason:
@@ -34,8 +21,8 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  # This workflow contains a single job called "build-samples"
+  build-samples:
     # The type of runner that the job will run on
     runs-on: windows-latest
 


### PR DESCRIPTION
see dotnet/docs#27056 for details

In order for an action to be required for PRs to be merged, required actions must be triggered. If filters prevent them from starting, the action stays in the "pending" state forever.

