### PR TITLE
Update WinForms project from 4.5 to 4.5.2

### DIFF
--- a/windowsforms/matching-game/net45/cs/MatchingGame.Logic/MatchingGame.Logic.csproj
+++ b/windowsforms/matching-game/net45/cs/MatchingGame.Logic/MatchingGame.Logic.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MatchingGame.Logic</RootNamespace>
     <AssemblyName>MatchingGame.Logic</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/windowsforms/matching-game/net45/cs/MatchingGame/MatchingGame.csproj
+++ b/windowsforms/matching-game/net45/cs/MatchingGame/MatchingGame.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MatchingGame</RootNamespace>
     <AssemblyName>MatchingGame</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/windowsforms/matching-game/net45/vb/MatchingGame.Logic/MatchingGame.Logic.vbproj
+++ b/windowsforms/matching-game/net45/vb/MatchingGame.Logic/MatchingGame.Logic.vbproj
@@ -10,7 +10,7 @@
     <AssemblyName>MatchingGame.Logic</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/windowsforms/matching-game/net45/vb/MatchingGame/MatchingGame.vbproj
+++ b/windowsforms/matching-game/net45/vb/MatchingGame/MatchingGame.vbproj
@@ -11,7 +11,7 @@
     <AssemblyName>MatchingGame</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>WindowsForms</MyType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This project is used as a migration sample. Developer pack support in Visual Studio starts with 4.5.2, it's much harder to use Visual Studio with a 4.5 project. By first upgrading a project to 4.5.2, it makes the migration easier to .NET 6