### PR TITLE
Snippets build system - update for vs 2022

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   DOTNET_INSTALLER_CHANNEL: '6.0'
-  DOTNET_DO_INSTALL: 'true'
+  DOTNET_DO_INSTALL: 'false'
   EnableNuGetPackageRestore: 'True'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -24,7 +24,7 @@ jobs:
   # This workflow contains a single job called "build-samples"
   build-samples:
     # The type of runner that the job will run on
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
         statuses: write
 

--- a/.github/workflows/dependencies/Get-MSBuildResults.ps1
+++ b/.github/workflows/dependencies/Get-MSBuildResults.ps1
@@ -31,10 +31,11 @@
     None
 
 .NOTES
-    Version:        1.4
+    Version:        1.5
     Author:         adegeo@microsoft.com
     Creation Date:  12/11/2020
-    Purpose/Change: Add support for config file. Select distinct on project files.
+    Update Date:    02/17/2022
+    Purpose/Change: Move to VS 2022.
 #>
 
 [CmdletBinding()]
@@ -152,7 +153,7 @@ foreach ($item in $workingSet) {
                     Write-Host "- Using visual studio as build host"
 
                     # Create the visual studio build command
-                    "CALL `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat`"`n" +
+                    "CALL `"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat`"`n" +
                     "nuget.exe restore `"$projectFile`"`n" +
                     "msbuild.exe `"$projectFile`" -restore:True" `
                     | Out-File ".\run.bat"


### PR DESCRIPTION
## Summary

- Changed the runner to Windows Server 2022
- Updated path to VS developer command prompt to VS 2022
- Disabled custom .NET install flag, as 6.0 is already included.

@BillWagner 
