### PR TITLE
Revert "Add `extendedZipContent`"

### DIFF
--- a/windowsforms/matching-game/net5-windows/cs/readme.md
+++ b/windowsforms/matching-game/net5-windows/cs/readme.md
@@ -9,9 +9,6 @@ page_type: sample
 name: "Matching Game Sample (.NET 5 C#)"
 urlFragment: "matching-game-net-csharp"
 description: "A simple matching game written for Windows Forms"
-extendedZipContent:
-- path: /LICENSE
-  target: /LICENSE
 ---
 # Matching game
 


### PR DESCRIPTION
Reverts dotnet/samples#4943

@gewarren It seems the sample has completely disappeared from samples browser.

![image](https://user-images.githubusercontent.com/31348972/159998760-2bf0648e-be9f-4f84-a33e-3f34eaf37e35.png)

I can't really explain how can this happen given:

- https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/keyvault/samples/sharelink/README.md
- https://docs.microsoft.com/en-us/samples/azure/azure-sdk-for-net/share-link/
