### PR TITLE
Clarify how to get the code onto local machine

### DIFF
--- a/core/diagnostics/DiagnosticScenarios/readme.md
+++ b/core/diagnostics/DiagnosticScenarios/readme.md
@@ -12,6 +12,10 @@ description: "A .NET Core sample with methods that trigger undesirable behaviors
 
 The sample debug target is a simple `webapi` application. The sample triggers undesirable behaviors for the [.NET Core diagnostics tutorials](https://docs.microsoft.com/dotnet/core/diagnostics/index#net-core-diagnostics-tutorials) to diagnose.
 
+## Download the source
+
+To get the code locally on your machine, click on '<> Code' in the top left corner of this page. This will take you to the root of the repo. Once at the root, clone the samples repo onto your local machine and navigate to samples/core/diagnostics/DiagnosticScenarios/.
+
 ## Build and run the target
 
 After downloading the source, you can easily run the webapi using:


### PR DESCRIPTION
I was following a tutorial and finally asked my teammate how to clone the repo because I could not figure it out. The solution was to go to the root of the repo.

## Summary

Clarify the need to go to the root of the repo and clone the entire repo in order to download the source for the tutorial.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
