### PR TITLE
Updated the part with calling set-output

### DIFF
--- a/github-actions/DotNet.GitHubAction/DotNet.GitHubAction/Program.cs
+++ b/github-actions/DotNet.GitHubAction/DotNet.GitHubAction/Program.cs
@@ -71,9 +71,14 @@ static async Task StartAnalysisAsync(ActionInputs inputs, IHost host)
     }
 
     // https://docs.github.com/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
-    Console.WriteLine($"::set-output name=updated-metrics::{updatedMetrics}");
-    Console.WriteLine($"::set-output name=summary-title::{title}");
-    Console.WriteLine($"::set-output name=summary-details::{summary}");
+    // ::set-output deprecated as mentioned in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+    var githubOutputFile = Environment.GetEnvironmentVariable("GITHUB_OUTPUT", EnvironmentVariableTarget.Process);
+    using (var textWriter = new StreamWriter(githubOutputFile!, true, Encoding.UTF8))
+    {
+        textWriter.WriteLine($"updated-metrics={updatedMetrics}");
+        textWriter.WriteLine($"summary-title={title}");
+        textWriter.WriteLine($"summary-details={summary}");
+    }
 
     Environment.Exit(0);
 }
@@ -86,7 +91,7 @@ parser.WithNotParsed(
             .CreateLogger("DotNet.GitHubAction.Program")
             .LogError(
                 string.Join(Environment.NewLine, errors.Select(error => error.ToString())));
-        
+
         Environment.Exit(2);
     });
 

--- a/github-actions/DotNet.GitHubAction/DotNet.GitHubAction/Program.cs
+++ b/github-actions/DotNet.GitHubAction/DotNet.GitHubAction/Program.cs
@@ -73,11 +73,20 @@ static async Task StartAnalysisAsync(ActionInputs inputs, IHost host)
     // https://docs.github.com/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
     // ::set-output deprecated as mentioned in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
     var githubOutputFile = Environment.GetEnvironmentVariable("GITHUB_OUTPUT", EnvironmentVariableTarget.Process);
-    using (var textWriter = new StreamWriter(githubOutputFile!, true, Encoding.UTF8))
+    if (!string.IsNullOrWhiteSpace(githubOutputFile))
     {
-        textWriter.WriteLine($"updated-metrics={updatedMetrics}");
-        textWriter.WriteLine($"summary-title={title}");
-        textWriter.WriteLine($"summary-details={summary}");
+        using (var textWriter = new StreamWriter(githubOutputFile!, true, Encoding.UTF8))
+        {
+            textWriter.WriteLine($"updated-metrics={updatedMetrics}");
+            textWriter.WriteLine($"summary-title={title}");
+            textWriter.WriteLine($"summary-details={summary}");
+        }
+    }
+    else
+    {
+        Console.WriteLine($"::set-output name=updated-metrics::{updatedMetrics}");
+        Console.WriteLine($"::set-output name=summary-title::{title}");
+        Console.WriteLine($"::set-output name=summary-details::{summary}");
     }
 
     Environment.Exit(0);


### PR DESCRIPTION
## Summary

After GitHub deprecated the `set-output` command, the sample code should be updated to set the output parameters using the environment file pointed to by GITHUB_OUTPUT.

The method works - I have used it successfully in another GitHub action, and it runs also in Docker container in the other GitHub action

Fixes #5495, dotnet/docs/issues/32600
