### PR TITLE
Udpate COMServer sample to show loading in default ALC

### DIFF
--- a/core/extensions/COMServerDemo/COMClient/COMClient.csproj
+++ b/core/extensions/COMServerDemo/COMClient/COMClient.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework Condition="'$(DefaultALC)' == 'True'">net8.0</TargetFramework>
 
     <!-- The application manifest is only needed for RegFree COM scenarios -->
     <ApplicationManifest Condition="'$(RegFree)' == 'True'">COMClient.manifest</ApplicationManifest>

--- a/core/extensions/COMServerDemo/COMServer/COMServer.csproj
+++ b/core/extensions/COMServerDemo/COMServer/COMServer.csproj
@@ -16,6 +16,7 @@
             COMServer.X.manifest
     -->
     <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework Condition="'$(DefaultALC)' == 'True'">net8.0</TargetFramework>
 
     <!-- Indicate the assembly is providing a COM server -->
     <EnableComHosting>True</EnableComHosting>
@@ -27,6 +28,12 @@
   <ItemGroup>
     <!-- Used in lieu of a Primary Interop Assembly (PIA) -->
     <Compile Include="../COMContract/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Condition="'$(DefaultALC)' == 'True'"
+        Include="System.Runtime.InteropServices.COM.LoadComponentInDefaultContext"
+        Value="true" />
   </ItemGroup>
 
   <Target Name="ServerUsage"

--- a/core/extensions/COMServerDemo/README.md
+++ b/core/extensions/COMServerDemo/README.md
@@ -50,6 +50,16 @@ Program should output an estimated value of &#960;.
 
 Program should output an estimated value of &#960;.
 
+### Default AssemblyLoadContext
+
+1. Install .NET 8 or later.
+
+1. Navigate to the root directory and run `dotnet.exe build /p:DefaultALC=True`.
+
+1. Follow the instructions for COM server registration that were emitted during the build.
+
+1. Run the generated binary directly. For example, `COMClient\bin\Debug\net8.0\COMClient.exe`.
+
 **Note** The RegFree COM scenario requires a customized [application manifest](https://docs.microsoft.com/windows/desktop/sbscs/manifests) in the executing binary. This means that attempting to execute through `dotnet.exe` will not work and instead trigger a rebuild of the project.
 
 **Note** Running the "Registered COM" first and then immediately following it by "RegFree COM" will not work, since the build system will not correctly rebuild all files (the simple property change is not detected as a reason for a full rebuild). To fix this, run `dotnet clean` between the two samples.


### PR DESCRIPTION
## Summary

The ability to specify loading a COM component in the default ALC was added in .NET 8. Update the COMServer sample to conditionally use the configuration option that enables it.

cc @AaronRobinsonMSFT @vitek-karas 