### PR TITLE
Fix YAML in README.md

### DIFF
--- a/iot/cheesecave.net/README.md
+++ b/iot/cheesecave.net/README.md
@@ -1,4 +1,4 @@
-﻿---
+---
 languages:
 - csharp
 products:


### PR DESCRIPTION
Realized this sample (which is over a year old) was never properly indexed for the sample browser. Removed leading space in the YAML block to fix.