### PR TITLE
Sync the console-teleprompter sample with the docs

### DIFF
--- a/csharp/getting-started/console-teleprompter/Program.cs
+++ b/csharp/getting-started/console-teleprompter/Program.cs
@@ -1,10 +1,10 @@
-﻿namespace TeleprompterConsole;
+namespace TeleprompterConsole;
 
 public class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
-        RunTeleprompter().Wait();
+        await RunTeleprompter();
     }
 
     private static async Task RunTeleprompter()

--- a/csharp/getting-started/console-teleprompter/config.cs
+++ b/csharp/getting-started/console-teleprompter/config.cs
@@ -4,17 +4,13 @@ namespace TeleprompterConsole;
 
 internal class TelePrompterConfig
 {
-    private object lockHandle = new object();
     public int DelayInMilliseconds { get; private set; } = 200;
 
     public void UpdateDelay(int increment) // negative to speed up
     {
         var newDelay = Min(DelayInMilliseconds + increment, 1000);
         newDelay = Max(newDelay, 20);
-        lock (lockHandle)
-        {
-            DelayInMilliseconds = newDelay;
-        }
+        DelayInMilliseconds = newDelay;
     }
 
     public bool Done { get; private set; }


### PR DESCRIPTION
This pull request updates the console-teleprompter sample to make it up-to-date with the [tutorial article](https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/console-teleprompter).

As far as I could tell, two changes needed to be reproduced:
- Removing unnecessary locks: https://github.com/dotnet/docs/pull/11434
- Changing the Main method to async: https://github.com/dotnet/docs/pull/31333/
