### PR TITLE
#5916 fix multiple drop things

### DIFF
--- a/orleans/Adventure/AdventureGrains/PlayerGrain.cs
+++ b/orleans/Adventure/AdventureGrains/PlayerGrain.cs
@@ -26,8 +26,13 @@ public class PlayerGrain : Grain, IPlayerGrain
     async Task IPlayerGrain.Die()
     {
         // Drop everything
-        var tasks = _things.Select(Drop).ToList();
-        await Task.WhenAll(tasks);
+        var dropTasks = new List<Task>();
+        var copy = new List<Thing>(_things);
+        foreach (var thing in copy)
+        {
+            dropTasks.Add(this.Drop(thing));
+        }
+        await Task.WhenAll(dropTasks);
 
         // Exit the game
         if (_roomGrain is not null && _myInfo is not null)

--- a/orleans/Adventure/AdventureGrains/PlayerGrain.cs
+++ b/orleans/Adventure/AdventureGrains/PlayerGrain.cs
@@ -26,11 +26,10 @@ public class PlayerGrain : Grain, IPlayerGrain
     async Task IPlayerGrain.Die()
     {
         // Drop everything
-        var dropTasks = new List<Task>();
-        var copy = new List<Thing>(_things);
-        foreach (var thing in copy)
+        var dropTasks = new List<Task<string?>>();        
+        foreach (var thing in _things.ToArray() /* New collection */)
         {
-            dropTasks.Add(this.Drop(thing));
+            dropTasks.Add(Drop(thing));
         }
         await Task.WhenAll(dropTasks);
 


### PR DESCRIPTION
## Summary

Creating a copy of the class level `_things` and iterating over the copy to _Drop_ the items instead of the actual original list.