### PR TITLE
Fix parameter order

### DIFF
--- a/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTypedTest.cs
+++ b/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTypedTest.cs
@@ -35,7 +35,7 @@ namespace AppSettingStronglyTyped.Test
 
             //Assert
             Assert.IsTrue(success);
-            Assert.AreEqual(errors.Count, 0);
+            Assert.AreEqual(0, errors.Count);
             Assert.AreEqual("MySettingEmpty.generated.cs", appSettingStronglyTyped.ClassNameFile);
             Assert.IsTrue(File.Exists(appSettingStronglyTyped.ClassNameFile));
             Assert.IsTrue(File.ReadLines(appSettingStronglyTyped.ClassNameFile).SequenceEqual(File.ReadLines(".\\Resources\\empty-class.txt")));


### PR DESCRIPTION
## Summary

The parameter order of the `AreEqual` method is `object expected, object actual`, thus the parameters have to be swapped.

[Docs](https://learn.microsoft.com/en-us/visualstudio/msbuild/tutorial-test-custom-task?view=vs-2022#unit-test) should be updated too.
