### PR TITLE
Update msbuild/custom-task-code-generation sample

### DIFF
--- a/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTyped.Test.csproj
+++ b/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.Test/AppSettingStronglyTyped.Test.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />

--- a/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.sln
+++ b/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppSettingStronglyTyped", "AppSettingStronglyTyped\AppSettingStronglyTyped.csproj", "{0EDB0B2F-8086-4F4E-9413-425CB9D47185}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppSettingStronglyTyped.Test", "AppSettingStronglyTyped.Test\AppSettingStronglyTyped.Test.csproj", "{307BBB4B-1FB2-4704-B4B0-E46476D0E779}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppSettingStronglyTyped.Test", "AppSettingStronglyTyped.Test\AppSettingStronglyTyped.Test.csproj", "{307BBB4B-1FB2-4704-B4B0-E46476D0E779}"
 EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.csproj
+++ b/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.csproj
@@ -11,6 +11,10 @@
         <!-- we need the assemblies bundled, so set this so we don't expose any dependencies to the outside world -->
         <GenerateDependencyFile>true</GenerateDependencyFile>
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+        <!-- This property tells MSBuild where the root folder of the package's build assets should be. Because we are not a library package, we should not pack to 'lib'. Instead, we choose 'tasks' by convention. -->
+        <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
+        <!-- NuGet does validation that libraries in a package are exposed as dependencies, but we _explicitly_ do not want that behavior for MSBuild tasks. They are isolated by design. Therefore we ignore this specific warning. -->
+        <NoWarn>NU5100</NoWarn>
         <DebugType>embedded</DebugType>
         <IsPackable>true</IsPackable>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

This change does 3 things:

* Adds a package reference for Microsoft.Build.Utilities.Core 17.0.0 to the AppSettingStronglyTyped.Test project.  Without this change, the test project does not build.  [The AppSettingStronglyTyped project already references this package.](https://github.com/dotnet/samples/blob/37ab1d21d184246eb438c933c3b95b2ad9677207/msbuild/custom-task-code-generation/AppSettingStronglyTyped/AppSettingStronglyTyped/AppSettingStronglyTyped.csproj#L20-L21)
* Updates the project type GUID for the test project.  (Visual Studio made this change automatically.)  See [this](https://github.com/dotnet/project-system/issues/3079#issuecomment-354180353) for details.
* Fixes https://github.com/dotnet/samples/issues/5665.  Changing `lib` to `tasks` is one way to fix the issue of the task not loading; however, [documentation for this sample suggests a better solution](https://learn.microsoft.com/en-us/visualstudio/msbuild/tutorial-custom-task-code-generation?view=vs-2022#bundle-dependencies-into-the-package).