### PR TITLE
There is a small typo in the error message when loading secrets

### DIFF
--- a/orleans/Streaming/Common/Secrets.cs
+++ b/orleans/Streaming/Common/Secrets.cs
@@ -19,7 +19,7 @@ public class Secrets
                 "Must provide a dataConnectionString", nameof(dataConnectionString));
         EventHubConnectionString = eventHubConnectionString
             ?? throw new ArgumentException(
-                "Must provide am eventHubConnectionString", nameof(eventHubConnectionString));
+                "Must provide an eventHubConnectionString", nameof(eventHubConnectionString));
     }
 
     public static Secrets? LoadFromFile(string filename = "Secrets.json")


### PR DESCRIPTION
fixes small typo

## Summary

There is a small typo in the error message of the event hub connection string loader.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
