### PR TITLE
Add inline array marshaller sample to our custom marshalling sample.

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -15,7 +15,7 @@ on:
         default: 'Force a snippets build'
 
 env:
-  DOTNET_INSTALLER_CHANNEL: '8.0'
+  DOTNET_INSTALLER_CHANNEL: '7.0'
   DOTNET_DO_INSTALL: 'true' # True to install preview versions, False to use the pre-installed (released) SDK
   EnableNuGetPackageRestore: 'True'
   repo: 'samples'

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -15,7 +15,7 @@ on:
         default: 'Force a snippets build'
 
 env:
-  DOTNET_INSTALLER_CHANNEL: '7.0'
+  DOTNET_INSTALLER_CHANNEL: '8.0'
   DOTNET_DO_INSTALL: 'true' # True to install preview versions, False to use the pre-installed (released) SDK
   EnableNuGetPackageRestore: 'True'
   repo: 'samples'

--- a/core/interop/source-generation/custom-marshalling/README.md
+++ b/core/interop/source-generation/custom-marshalling/README.md
@@ -23,7 +23,7 @@ This sample implements and uses custom marshallers for a built-in type and a use
 
 ## Prerequisites
 
-- [.NET 7 SDK](https://dotnet.microsoft.com/download) Preview 7 or later
+- [.NET 8 SDK](https://dotnet.microsoft.com/download) Preview 7 or later
 
 - C++ compiler
   - Windows: `cl.exe`

--- a/core/interop/source-generation/custom-marshalling/src/custommarshalling/ErrorBuffer.cs
+++ b/core/interop/source-generation/custom-marshalling/src/custommarshalling/ErrorBuffer.cs
@@ -1,0 +1,33 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace CustomMarshalling
+{
+    [NativeMarshalling(typeof(ErrorBufferMarshaller))]
+    [InlineArray(4)]
+    public struct ErrorBuffer
+    {
+        private ErrorData _data;
+    }
+    
+    [CustomMarshaller(typeof(ErrorBuffer), MarshalMode.ManagedToUnmanagedIn, typeof(ErrorBufferMarshaller))]
+    public static class ErrorBufferMarshaller
+    {
+        [InlineArray(4)]
+        public struct ErrorBufferUnmanaged
+        {
+            private ErrorDataMarshaller.ErrorDataUnmanaged _data;
+        }
+
+        public static ErrorBufferUnmanaged ConvertToUnmanaged(ErrorBuffer managed)
+        {
+            ErrorBufferUnmanaged unmanaged = new();
+            for (int i = 0; i < 4; i++)
+            {
+                unmanaged[i] = ErrorDataMarshaller.ConvertToUnmanaged(managed[i]);
+            }
+            return unmanaged;
+        }
+    }
+}

--- a/core/interop/source-generation/custom-marshalling/src/custommarshalling/NativeLib.cs
+++ b/core/interop/source-generation/custom-marshalling/src/custommarshalling/NativeLib.cs
@@ -28,5 +28,8 @@ namespace CustomMarshalling
         [LibraryImport(LibName)]
         [return: MarshalUsing(CountElementName = "len")]
         internal static partial ErrorData[] GetErrors(int[] codes, int len);
+
+        [LibraryImport(LibName)]
+        internal static partial void GetErrorCodes(ErrorBuffer buffer, int[] codes);
     }
 }

--- a/core/interop/source-generation/custom-marshalling/src/custommarshalling/Program.cs
+++ b/core/interop/source-generation/custom-marshalling/src/custommarshalling/Program.cs
@@ -79,11 +79,20 @@ static void MarshalErrorData()
 
     // Marshals ErrorData using ErrorDataMarshaller
     Console.WriteLine($"--- {nameof(NativeLib.GetErrors)}: uses {nameof(ErrorDataMarshaller)}.{nameof(ErrorDataMarshaller.Out)}");
-    int[] codes = new int[] { -3, 2, 5 };
+    int[] codes = new int[] { -3, 2, 5, 12 };
     ErrorData[] errors = NativeLib.GetErrors(codes, codes.Length);
     foreach (ErrorData error in errors)
     {
         error.Print();
         Console.WriteLine();
+    }
+
+    ErrorBuffer errorBuffer = new();
+    errors.AsSpan().CopyTo(errorBuffer);
+    int[] retrievedCodes = new int[4];
+    NativeLib.GetErrorCodes(errorBuffer, retrievedCodes);
+    foreach (int code in retrievedCodes)
+    {
+        Console.WriteLine($"Code from error data: {code}");
     }
 }

--- a/core/interop/source-generation/custom-marshalling/src/custommarshalling/custommarshalling.csproj
+++ b/core/interop/source-generation/custom-marshalling/src/custommarshalling/custommarshalling.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>CustomMarshalling</RootNamespace>

--- a/core/interop/source-generation/custom-marshalling/src/custommarshalling/custommarshalling.csproj
+++ b/core/interop/source-generation/custom-marshalling/src/custommarshalling/custommarshalling.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>CustomMarshalling</RootNamespace>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>Preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/interop/source-generation/custom-marshalling/src/nativelib/nativelib.cpp
+++ b/core/interop/source-generation/custom-marshalling/src/nativelib/nativelib.cpp
@@ -108,3 +108,14 @@ extern "C" DLL_EXPORT error_data* STDMETHODCALLTYPE GetErrors(int* codes, int le
 
     return ret;
 }
+
+struct error_data_buffer
+{
+    error_data data[4];
+};
+
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetErrorCodes(error_data_buffer errors, int* codes)
+{
+    for (int i = 0; i < 4; ++i)
+        codes[i] = errors.data[i].code;
+}

--- a/core/interop/source-generation/custom-marshalling/src/snippets.5000.json
+++ b/core/interop/source-generation/custom-marshalling/src/snippets.5000.json
@@ -1,0 +1,3 @@
+{
+    "host": "visualstudio"
+}


### PR DESCRIPTION
This won't build successfully until the InlineArray feature is out of preview, as the project file doesn't set `LangVersion` to `Preview`.

Fixes dotnet/runtime#86572