### PR TITLE
Fix native library sample

### DIFF
--- a/core/nativeaot/NativeLibrary/Class1.cs
+++ b/core/nativeaot/NativeLibrary/Class1.cs
@@ -46,7 +46,7 @@ namespace NativeLibrary
             string sum = my1String + my2String;
 
             // Assign pointer of the concatenated string to sumPointer
-            IntPtr sumPointer = Marshal.StringToHGlobalAnsi(sum);
+            IntPtr sumPointer = Marshal.StringToCoTaskMemAnsi(sum);
 
             // Return pointer
             return sumPointer;

--- a/core/nativeaot/NativeLibrary/LoadLibrary.c
+++ b/core/nativeaot/NativeLibrary/LoadLibrary.c
@@ -5,20 +5,22 @@
 
 //Set this value accordingly to your workspace settings
 #if defined(_WIN32)
-#define PathToLibrary "bin\\Debug\\net6.0\\win-x64\\native\\NativeLibrary.dll"
+#define PathToLibrary "bin\\Debug\\net7.0\\win-x64\\publish\\NativeLibrary.dll"
 #elif defined(__APPLE__)
-#define PathToLibrary "./bin/Debug/net6.0/osx-x64/native/NativeLibrary.dylib"
+#define PathToLibrary "./bin/Debug/net7.0/osx-x64/publish/NativeLibrary.dylib"
 #else
-#define PathToLibrary "./bin/Debug/net6.0/linux-x64/native/NativeLibrary.so"
+#define PathToLibrary "./bin/Debug/net7.0/linux-x64/publish/NativeLibrary.so"
 #endif
 
 #ifdef _WIN32
 #include "windows.h"
 #define symLoad GetProcAddress
+#pragma comment (lib, "ole32.lib")
 #else
 #include "dlfcn.h"
 #include <unistd.h>
 #define symLoad dlsym
+#define CoTaskMemFree free
 #endif
 
 #include <stdlib.h>
@@ -49,7 +51,7 @@ int main()
     printf("The concatenated string is %s \n", sumstring);
 
     // Free string
-    free(sumstring);
+    CoTaskMemFree(sumstring);
 }
 
 int callSumFunc(char *path, char *funcName, int firstInt, int secondInt)

--- a/core/nativeaot/NativeLibrary/README.md
+++ b/core/nativeaot/NativeLibrary/README.md
@@ -12,7 +12,7 @@ Create a .NET class library project using `dotnet new classlib -o NativeLibrary`
 > dotnet publish /p:NativeLib=Shared -r <RID> -c <Configuration>
 ```
 
-The above command will drop a shared library (Windows `.dll`, OSX `.dylib`, Linux `.so`) in `./bin/[configuration]/netstandard2.0/[RID]/publish/` folder and will have the same name as the folder in which your source file is present.
+The above command will drop a shared library (Windows `.dll`, OSX `.dylib`, Linux `.so`) in `./bin/[configuration]/net7.0/[RID]/publish/` folder and will have the same name as the folder in which your source file is present.
 
 ### Loading shared libraries from C and importing methods
 
@@ -95,7 +95,7 @@ where `<Configuration>` is your project configuration (such as Debug or Release)
 > dotnet publish /p:NativeLib=Static -r win-x64 -c release
 ```
 
-The above command will drop a static library (Windows `.lib`, OSX/Linux `.a`) in `./bin/[configuration]/netstandard2.0/[RID]/publish/` folder and will have the same name as the folder in which your source file is present.
+The above command will drop a static library (Windows `.lib`, OSX/Linux `.a`) in `./bin/[configuration]/net7.0/[RID]/publish/` folder and will have the same name as the folder in which your source file is present.
 
 <!-- markdownlint-disable MD033 -->
 <details>


### PR DESCRIPTION
- Use matching allocators on managed and unmanaged side
- Fix directories to match current SDK

## Summary

Describe your changes here.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
