### PR TITLE
Make hosting sample always show using UnmanagedCallersOnly

### DIFF
--- a/core/hosting/readme.md
+++ b/core/hosting/readme.md
@@ -19,7 +19,7 @@ Additional comments are contained in source and project files.
 
 ## Prerequisites
 
-* [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download) or a later version
+* [.NET Core 6.0 SDK](https://dotnet.microsoft.com/download) or a later version
 
 * C++ compiler
   * Windows: `cl.exe`
@@ -55,6 +55,9 @@ Hello, world! from Lib [count: 3]
 -- message: from host!
 -- number: 2
 Hello, world! from CustomEntryPoint in Lib
+-- message: from host!
+-- number: -1
+Hello, world! from CustomEntryPointUnmanagedCallersOnly in Lib
 -- message: from host!
 -- number: -1
 ```

--- a/core/hosting/src/DotNetLib/Lib.cs
+++ b/core/hosting/src/DotNetLib/Lib.cs
@@ -34,13 +34,12 @@ namespace DotNetLib
             PrintLibArgs(libArgs);
         }
 
-#if NET5_0
         [UnmanagedCallersOnly]
-        public static void CustomEntryPointUnmanaged(LibArgs libArgs)
+        public static void CustomEntryPointUnmanagedCallersOnly(LibArgs libArgs)
         {
-            CustomEntryPoint(libArgs);
+            Console.WriteLine($"Hello, world! from {nameof(CustomEntryPointUnmanagedCallersOnly)} in {nameof(Lib)}");
+            PrintLibArgs(libArgs);
         }
-#endif
 
         private static void PrintLibArgs(LibArgs libArgs)
         {

--- a/core/hosting/src/NativeHost/nativehost.cpp
+++ b/core/hosting/src/NativeHost/nativehost.cpp
@@ -128,22 +128,27 @@ int main(int argc, char *argv[])
         // </SnippetCallManaged>
     }
 
-#ifdef NET5_0
     // Function pointer to managed delegate with non-default signature
     typedef void (CORECLR_DELEGATE_CALLTYPE *custom_entry_point_fn)(lib_args args);
     custom_entry_point_fn custom = nullptr;
+    lib_args args
+    {
+        STR("from host!"),
+        -1
+    };
+
+    // UnmanagedCallersOnly
     rc = load_assembly_and_get_function_pointer(
         dotnetlib_path.c_str(),
         dotnet_type,
-        STR("CustomEntryPointUnmanaged") /*method_name*/,
+        STR("CustomEntryPointUnmanagedCallersOnly") /*method_name*/,
         UNMANAGEDCALLERSONLY_METHOD,
         nullptr,
         (void**)&custom);
     assert(rc == 0 && custom != nullptr && "Failure: load_assembly_and_get_function_pointer()");
-#else
-    // Function pointer to managed delegate with non-default signature
-    typedef void (CORECLR_DELEGATE_CALLTYPE *custom_entry_point_fn)(lib_args args);
-    custom_entry_point_fn custom = nullptr;
+    custom(args);
+
+    // Custom delegate type
     rc = load_assembly_and_get_function_pointer(
         dotnetlib_path.c_str(),
         dotnet_type,
@@ -152,13 +157,6 @@ int main(int argc, char *argv[])
         nullptr,
         (void**)&custom);
     assert(rc == 0 && custom != nullptr && "Failure: load_assembly_and_get_function_pointer()");
-#endif
-
-    lib_args args
-    {
-        STR("from host!"),
-        -1
-    };
     custom(args);
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary

Make hosting sample always show using `UnmanagedCallersOnly` since all supported versions have it now. The portion of the sample using `UnmanagedCallersOnly` was under an ifdef for `NET5_0` when first added - the sample ended up no longer using it when switched to 6.0.