### PR TITLE
Fix System.ArgumentOutOfRangeException on Orleans ChatRoom example

### DIFF
--- a/orleans/ChatRoom/ChatRoom.Client/Program.cs
+++ b/orleans/ChatRoom/ChatRoom.Client/Program.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using ChatRoom;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -54,7 +54,7 @@ static async Task ProcessLoopAsync(ClientContext context)
             break;
         }
 
-        var firstTwoCharacters = input[..2];
+        var firstTwoCharacters = input.Length >= 2 ? input[..2] : string.Empty;
         if (firstTwoCharacters is "/n")
         {
             context = context with { UserName = input.Replace("/n", "").Trim() };


### PR DESCRIPTION
## Summary

Fix a System.ArgumentOutOfRangeException throw when one char message are written.

How to reproduce:
- start **CharRoom.Client** and **CharRoom.Service** projects
- join a chat `/j testChat`
- write a single char message and press enter
- **CharRoom.Client** crash with System.ArgumentOutOfRangeException when trying substring message

```
System.ArgumentOutOfRangeException
  HResult=0x80131502
  Message=Index and length must refer to a location within the string. (Parameter 'length')
  Source=System.Private.CoreLib
  StackTrace:
   at System.String.ThrowSubstringArgumentOutOfRange(Int32 startIndex, Int32 length) in /_/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs:line 1878
   at System.String.Substring(Int32 startIndex, Int32 length) in /_/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs:line 1852
   at Program.<<<Main>$>g__ProcessLoopAsync|0_2>d.MoveNext() in C:\Users\mmenegaz\source\repos\m3nax\dotnet-samples\orleans\ChatRoom\ChatRoom.Client\Program.cs:line 57
   at Program.<<Main>$>d__0.MoveNext() in C:\Users\mmenegaz\source\repos\m3nax\dotnet-samples\orleans\ChatRoom\ChatRoom.Client\Program.cs:line 26
   at Program.<Main>(String[] args)
```
