### PR TITLE
Only auto merge on the main repo

### DIFF
--- a/.github/workflows/dependabot-approve-and-automerge.yml
+++ b/.github/workflows/dependabot-approve-and-automerge.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.repository_owner == 'dotnet' }}
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
The automerge bot for dependabot PRs has been running on forks as well as the main repo. That makes syncing forks with the main repo much more difficult.

So, follow the practice from dotnet/docs and only merge on the main repo.

