### PR TITLE
include a reminder to avoid the 32 bit tooling on windows for the native AOT library sample

### DIFF
--- a/core/nativeaot/NativeLibrary/README.md
+++ b/core/nativeaot/NativeLibrary/README.md
@@ -17,6 +17,7 @@ The above command will drop a shared library (Windows `.dll`, macOS `.dylib`, Li
 ### Loading shared libraries from C and importing methods
 
 For reference, you can read the file LoadLibrary.c.
+Please note that on Windows the platform (x86 and x64) must match between the dotnet aot library and the tool used to compile and link the c code; see [here](https://learn.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?view=msvc-170) for x64. 
 The first thing you'll have to do in order to have a proper "loader" that loads your shared library is to add these directives
 
 ```c

--- a/core/nativeaot/NativeLibrary/README.md
+++ b/core/nativeaot/NativeLibrary/README.md
@@ -16,8 +16,11 @@ The above command will drop a shared library (Windows `.dll`, macOS `.dylib`, Li
 
 ### Loading shared libraries from C and importing methods
 
-For reference, you can read the file LoadLibrary.c.
-Please note that on Windows the platform (x86 and x64) must match between the dotnet aot library and the tool used to compile and link the c code; see [here](https://learn.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?view=msvc-170) for x64.
+For reference, you can read the file _LoadLibrary.c_.
+
+> [!NOTE]
+> On Windows the platform (x86 and x64) must match between the .NET AOT library and the tool used to compile and link the C code. For more information, see [How to: Enable a 64-Bit, x64 hosted MSVC toolset on the command line](https://learn.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?view=msvc-170).
+
 The first thing you'll have to do in order to have a proper "loader" that loads your shared library is to add these directives
 
 ```c

--- a/core/nativeaot/NativeLibrary/README.md
+++ b/core/nativeaot/NativeLibrary/README.md
@@ -17,7 +17,7 @@ The above command will drop a shared library (Windows `.dll`, macOS `.dylib`, Li
 ### Loading shared libraries from C and importing methods
 
 For reference, you can read the file LoadLibrary.c.
-Please note that on Windows the platform (x86 and x64) must match between the dotnet aot library and the tool used to compile and link the c code; see [here](https://learn.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?view=msvc-170) for x64. 
+Please note that on Windows the platform (x86 and x64) must match between the dotnet aot library and the tool used to compile and link the c code; see [here](https://learn.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?view=msvc-170) for x64.
 The first thing you'll have to do in order to have a proper "loader" that loads your shared library is to add these directives
 
 ```c


### PR DESCRIPTION
## Summary

With Visual studio installed the default "developer command prompt" accesses the 32 bit versions of c compile and link (cl.exe). This results in a silent failure of the c sample code calling functions from the native aot library project.

Added the following line to the readme:

Please note that on Windows the platform (x86 and x64) must match between the dotnet aot library and the tool used to compile and link the c code; see [here](https://learn.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line?view=msvc-170) for x64.
