### PR TITLE
Updated documentation url in Orleans ChatRoom sample

### DIFF
--- a/orleans/ChatRoom/README.md
+++ b/orleans/ChatRoom/README.md
@@ -14,7 +14,7 @@ description: "An Orleans sample chat room app."
 
 ![A screenshot of the chat client](screenshot.png)
 
-This sample uses [Orleans Streaming](http://dotnet.github.io/orleans/docs/streaming/index.html) to build a basic chat application. In this application, each client can:
+This sample uses [Orleans Streaming](https://learn.microsoft.com/dotnet/orleans/streaming) to build a basic chat application. In this application, each client can:
 
 * Set their name
 * Join and leave a channel


### PR DESCRIPTION
## Summary

Updated documentation url of ChatRoom sample to point to https://learn.microsoft.com/dotnet/orleans/streaming
