### PR TITLE
Updated NUnit testing samples for NUnit 4

### DIFF
--- a/core/getting-started/golden/app/app.csproj
+++ b/core/getting-started/golden/app/app.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/core/getting-started/golden/library/library.csproj
+++ b/core/getting-started/golden/library/library.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">

--- a/core/getting-started/golden/test-library/test-library.csproj
+++ b/core/getting-started/golden/test-library/test-library.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService.Tests.csproj
+++ b/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/core/getting-started/unit-testing-using-mstest/PrimeService.Tests/PrimeService.Tests.csproj
+++ b/core/getting-started/unit-testing-using-mstest/PrimeService.Tests/PrimeService.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/getting-started/unit-testing-using-nunit/PrimeService.Tests/PrimeService.Tests.csproj
+++ b/core/getting-started/unit-testing-using-nunit/PrimeService.Tests/PrimeService.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-using-nunit/PrimeService.Tests/PrimeService_IsPrimeShould.cs
+++ b/core/getting-started/unit-testing-using-nunit/PrimeService.Tests/PrimeService_IsPrimeShould.cs
@@ -20,7 +20,7 @@ namespace Prime.UnitTests.Services
         {
             var result = _primeService.IsPrime(1);
 
-            Assert.IsFalse(result, "1 should not be prime");
+            Assert.That(result, Is.False, "1 should not be prime");
         }
         #endregion
         #region Sample_TestCode
@@ -31,7 +31,7 @@ namespace Prime.UnitTests.Services
         {
             var result = _primeService.IsPrime(value);
 
-            Assert.IsFalse(result, $"{value} should not be prime");
+            Assert.That(result, Is.False, $"{value} should not be prime");
         }
         #endregion
     }

--- a/core/getting-started/unit-testing-vb-dotnet-test/PrimeService.Tests/PrimeService.Tests.vbproj
+++ b/core/getting-started/unit-testing-vb-dotnet-test/PrimeService.Tests/PrimeService.Tests.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-vb-mstest/PrimeService.Tests/PrimeService.Tests.vbproj
+++ b/core/getting-started/unit-testing-vb-mstest/PrimeService.Tests/PrimeService.Tests.vbproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/core/getting-started/unit-testing-vb-nunit/PrimeService.Tests/PrimeService.Tests.vbproj
+++ b/core/getting-started/unit-testing-vb-nunit/PrimeService.Tests/PrimeService.Tests.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-vb-nunit/PrimeService.Tests/PrimeService_IsPrimeShould.vb
+++ b/core/getting-started/unit-testing-vb-nunit/PrimeService.Tests/PrimeService_IsPrimeShould.vb
@@ -1,6 +1,7 @@
 ﻿Imports NUnit.Framework
 
 Namespace PrimeService.Tests
+
     '<Sample_TestCode>
     <TestFixture>
     Public Class PrimeService_IsPrimeShould
@@ -12,7 +13,7 @@ Namespace PrimeService.Tests
         Sub IsPrime_ValuesLessThan2_ReturnFalse(value As Integer)
             Dim result As Boolean = _primeService.IsPrime(value)
 
-            Assert.IsFalse(result, $"{value} should not be prime")
+            Assert.That(result, [Is].False, $"{value} should not be prime")
         End Sub
 
         <TestCase(2)>
@@ -22,7 +23,7 @@ Namespace PrimeService.Tests
         Public Sub IsPrime_PrimesLessThan10_ReturnTrue(value As Integer)
             Dim result As Boolean = _primeService.IsPrime(value)
 
-            Assert.IsTrue(result, $"{value} should be prime")
+            Assert.That(result, [Is].True, $"{value} should be prime")
         End Sub
 
         <TestCase(4)>
@@ -32,8 +33,10 @@ Namespace PrimeService.Tests
         Public Sub IsPrime_NonPrimesLessThan10_ReturnFalse(value As Integer)
             Dim result As Boolean = _primeService.IsPrime(value)
 
-            Assert.IsFalse(result, $"{value} should not be prime")
+            Assert.That(result, [Is].False, $"{value} should not be prime")
         End Sub
+
     End Class
+
     '</Sample_TestCode>
 End Namespace

--- a/core/getting-started/unit-testing-with-fsharp-mstest/MathService.Tests/MathService.Tests.fsproj
+++ b/core/getting-started/unit-testing-with-fsharp-mstest/MathService.Tests/MathService.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/MathService.Tests.fsproj
+++ b/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/MathService.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/Tests.fs
+++ b/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/Tests.fs
@@ -6,14 +6,6 @@ open NUnit.Framework
 open MathService
 
 [<Test>]
-let ``My test`` () =
-    Assert.True(true)
-
-//[<Test>]
-//let ``Fail every time`` () = Assert.True(false)
-
-
-[<Test>]
 let ``Sequence of Evens returns empty collection`` () =
     let expected = Seq.empty<int>
     let actual = MyMath.squaresOfOdds [2; 4; 6; 8; 10]

--- a/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/Tests.fs
+++ b/core/getting-started/unit-testing-with-fsharp-nunit/MathService.Tests/Tests.fs
@@ -6,6 +6,13 @@ open NUnit.Framework
 open MathService
 
 [<Test>]
+let ``My test`` () =
+    Assert.That(true, Is.True)
+
+//[<Test>]
+//let ``Fail every time`` () = Assert.That(false, Is.True)
+
+[<Test>]
 let ``Sequence of Evens returns empty collection`` () =
     let expected = Seq.empty<int>
     let actual = MyMath.squaresOfOdds [2; 4; 6; 8; 10]

--- a/core/getting-started/unit-testing-with-fsharp/MathService.Tests/MathService.Tests.fsproj
+++ b/core/getting-started/unit-testing-with-fsharp/MathService.Tests/MathService.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/core/getting-started/unit-testing-with-fsharp/MathService.Tests/Tests.fs
+++ b/core/getting-started/unit-testing-with-fsharp/MathService.Tests/Tests.fs
@@ -6,14 +6,6 @@ open Xunit
 open MathService
 
 [<Fact>]
-let ``My test`` () =
-    Assert.True(true)
-
-//[<Fact>]
-//let ``Fail every time`` () = Assert.True(false)
-
-
-[<Fact>]
 let ``Sequence of Evens returns empty collection`` () =
     let expected = Seq.empty<int>
     let actual = MyMath.squaresOfOdds [2; 4; 6; 8; 10]

--- a/core/getting-started/unit-testing-with-fsharp/MathService.Tests/Tests.fs
+++ b/core/getting-started/unit-testing-with-fsharp/MathService.Tests/Tests.fs
@@ -6,6 +6,13 @@ open Xunit
 open MathService
 
 [<Fact>]
+let ``My test`` () =
+    Assert.True(true)
+
+//[<Fact>]
+//let ``Fail every time`` () = Assert.True(false)
+
+[<Fact>]
 let ``Sequence of Evens returns empty collection`` () =
     let expected = Seq.empty<int>
     let actual = MyMath.squaresOfOdds [2; 4; 6; 8; 10]


### PR DESCRIPTION
## Summary

- I've updated the C#, VB and F# samples that were using NUnit to address the breaking changes in NUnit4.
- All projects in the folder updated to .NET 8
- Misc: .NET Standard version updated for one project, error for duplicate reference to MSTest.TestAdapter resolved
- Ran all projects to validate, all tests passing

Fixes dotnet/docs#40080 
Tagging @IEvangelist for review