### PR TITLE
OutOfProcCOM: Restrict projects to Windows

### DIFF
--- a/core/extensions/OutOfProcCOM/COMRegistration/COMRegistration.csproj
+++ b/core/extensions/OutOfProcCOM/COMRegistration/COMRegistration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/extensions/OutOfProcCOM/DllServer/DllServer.csproj
+++ b/core/extensions/OutOfProcCOM/DllServer/DllServer.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\Contract\Server.Contract.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
 
     <!-- Indicate the assembly is providing a COM server -->
     <EnableComHosting>true</EnableComHosting>

--- a/core/extensions/OutOfProcCOM/ExeServer/ExeServer.csproj
+++ b/core/extensions/OutOfProcCOM/ExeServer/ExeServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
Done to fix the build warnings below for the `COMRegistration` project. The `DllServer` and `ExeServer` client projects also need to be updated accordingly in order to make them build afterwards.

Warnings fixed:
```
core\extensions\OutOfProcCOM\COMRegistration\LocalServer.cs(38,13,38,34): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\LocalServer.cs(38,13,38,87): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.DeleteSubKey(string, bool)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\BasicClassFactory.cs(95,35,95,86): warning CA1416: This call site is reachable on all platforms. 'Marshal.CreateAggregatedObject(nint, object)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\BasicClassFactory.cs(91,31,91,70): warning CA1416: This call site is reachable on all platforms. 'Marshal.GetIUnknownForObject(object)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\BasicClassFactory.cs(96,24,96,62): warning CA1416: This call site is reachable on all platforms. 'Marshal.GetObjectForIUnknown(nint)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\BasicClassFactory.cs(79,37,79,122): warning CA1416: This call site is reachable on all platforms. 'Marshal.GetComInterfaceForObject(object, Type, CustomQueryInterfaceMode)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\BasicClassFactory.cs(76,24,76,57): warning CA1416: This call site is reachable on all platforms. 'Marshal.GetIUnknownForObject(object)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\LocalServer.cs(22,40,22,61): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\LocalServer.cs(23,13,23,43): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.SetValue(string?, object)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\LocalServer.cs(22,40,22,85): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.CreateSubKey(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(46,13,46,86): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.DeleteSubKey(string, bool)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(42,17,42,44): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.DeleteValue(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(40,40,40,61): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(40,40,40,99): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.OpenSubKey(string, bool)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(46,13,46,34): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(19,40,19,61): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(19,40,19,85): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.CreateSubKey(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(20,13,20,58): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.SetValue(string?, object)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(25,13,25,63): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.SetValue(string?, object)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(24,45,24,66): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
core\extensions\OutOfProcCOM\COMRegistration\DllSurrogate.cs(24,45,24,89): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.CreateSubKey(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
```