### PR TITLE
Update assembly Guid and TLB version

### DIFF
--- a/core/extensions/OutOfProcCOM/DllServer/DllServer.cs
+++ b/core/extensions/OutOfProcCOM/DllServer/DllServer.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 // The Assembly GUID and TLB version must match what
 // is defined in Contract.idl when defining the library.
 [assembly: Guid("46F3FEB2-121D-4830-AA22-0CDA9EA90DC3")]
-[assembly: TypeLibVersion(1 ,0)]
+[assembly: TypeLibVersion(1, 0)]
 
 namespace OutOfProcCOM
 {

--- a/core/extensions/OutOfProcCOM/DllServer/DllServer.cs
+++ b/core/extensions/OutOfProcCOM/DllServer/DllServer.cs
@@ -4,6 +4,11 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
+// The Assembly GUID and TLB version must match what
+// is defined in Contract.idl when defining the library.
+[assembly: Guid("46F3FEB2-121D-4830-AA22-0CDA9EA90DC3")]
+[assembly: TypeLibVersion(1 ,0)]
+
 namespace OutOfProcCOM
 {
     [ComVisible(true)]

--- a/core/extensions/OutOfProcCOM/NativeClient/NativeClient.cpp
+++ b/core/extensions/OutOfProcCOM/NativeClient/NativeClient.cpp
@@ -1,4 +1,3 @@
-#include <atlbase.h>
 #include <iostream>
 #include <iomanip>
 
@@ -17,7 +16,7 @@ int main()
         return EXIT_FAILURE;
     }
 
-    CComPtr<IServer> server;
+    IServer* server;
     hr = ::CoCreateInstance(CLSID_Server, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(IServer), (void **)&server);
     if (FAILED(hr))
     {
@@ -27,6 +26,8 @@ int main()
 
     double pi;
     hr = server->ComputePi(&pi);
+    server->Release();
+    server = NULL;
     if (FAILED(hr))
     {
         std::cout << "Failure: " << std::hex << std::showbase << hr << std::endl;

--- a/core/extensions/OutOfProcCOM/Server.Contract/Contract.idl
+++ b/core/extensions/OutOfProcCOM/Server.Contract/Contract.idl
@@ -12,8 +12,10 @@ interface IServer : IDispatch
         [out, retval] double *ret);
 };
 
+// See the matching Guid and TLB version in DllServer.cs
 [
-    uuid(46F3FEB2-121D-4830-AA22-0CDA9EA90DC3)
+    uuid(46F3FEB2-121D-4830-AA22-0CDA9EA90DC3),
+    version( 1.0 )
 ]
 library ServerLib
 {


### PR DESCRIPTION
For other TLB related scenarios, the assembly Guid and defined TLB version must match the generated TLB.
