### PR TITLE
Add comments about .NET unload

### DIFF
--- a/core/hosting/src/NativeHost/nativehost.cpp
+++ b/core/hosting/src/NativeHost/nativehost.cpp
@@ -310,8 +310,7 @@ namespace
 
         // Load hostfxr and get desired exports
         // NOTE: The .NET Runtime does not support unloading any of its native libraries. Running
-        // dlclose/FreeLibrary on any .NET libraries produces undefined behavior. To unload managed assemblies,
-        // use an Unloadable AssemblyLoadContext.
+        // dlclose/FreeLibrary on any .NET libraries produces undefined behavior.
         void *lib = load_library(buffer);
         init_for_cmd_line_fptr = (hostfxr_initialize_for_dotnet_command_line_fn)get_export(lib, "hostfxr_initialize_for_dotnet_command_line");
         init_for_config_fptr = (hostfxr_initialize_for_runtime_config_fn)get_export(lib, "hostfxr_initialize_for_runtime_config");

--- a/core/hosting/src/NativeHost/nativehost.cpp
+++ b/core/hosting/src/NativeHost/nativehost.cpp
@@ -309,6 +309,9 @@ namespace
             return false;
 
         // Load hostfxr and get desired exports
+        // NOTE: The .NET Runtime does not support unloading any of its native libraries. Running
+        // dlclose/FreeLibrary on any .NET libraries produces undefined behavior. To unload managed assemblies,
+        // use an Unloadable AssemblyLoadContext.
         void *lib = load_library(buffer);
         init_for_cmd_line_fptr = (hostfxr_initialize_for_dotnet_command_line_fn)get_export(lib, "hostfxr_initialize_for_dotnet_command_line");
         init_for_config_fptr = (hostfxr_initialize_for_runtime_config_fn)get_export(lib, "hostfxr_initialize_for_runtime_config");

--- a/core/nativeaot/NativeLibrary/LoadLibrary.c
+++ b/core/nativeaot/NativeLibrary/LoadLibrary.c
@@ -68,8 +68,7 @@ int callSumFunc(char *path, char *funcName, int firstInt, int secondInt)
 
     int result = MyImport(firstInt, secondInt);
 
-    // CoreRT libraries do not support unloading
-    // See https://github.com/dotnet/corert/issues/7887
+    // NOTE: Native AOT libraries do not support unloading
     return result;
 }
 

--- a/core/nativeaot/NativeLibrary/README.md
+++ b/core/nativeaot/NativeLibrary/README.md
@@ -65,6 +65,8 @@ The last thing to do is to actually call the method we have imported.
 int result =  MyImport(5,3);
 ```
 
+Note that the .NET Runtime does not support unloading. Once a handle to the shared library is created, the library cannot be closed with `dlclose/FreeLibrary`.
+
 ## Exporting methods
 
 For a C# method in the native library to be consumable by external programs, it has to be explicitly exported using the `[UnmanagedCallersOnly]` attribute.


### PR DESCRIPTION
## Summary

Note in the .NET hosting docs that the runtime cannot be unloaded.