### PR TITLE
Fix minor issue with NativeLibrary README

### DIFF
--- a/core/nativeaot/NativeLibrary/README.md
+++ b/core/nativeaot/NativeLibrary/README.md
@@ -26,7 +26,7 @@ The first thing you'll have to do in order to have a proper "loader" that loads 
 ```c
 #ifdef _WIN32
 #include "windows.h"
-#define symLoad GetProcAddress GetProcAddress
+#define symLoad GetProcAddress
 #else
 #include "dlfcn.h"
 #define symLoad dlsym


### PR DESCRIPTION
## Summary

The `symLoad` macro should not expand to 2 `GetProcAddress`.
