### PR TITLE
Fix Orleans ChatRoom sample to match documentation

### DIFF
--- a/orleans/ChatRoom/ChatRoom.Client/Program.cs
+++ b/orleans/ChatRoom/ChatRoom.Client/Program.cs
@@ -238,8 +238,7 @@ static async Task<ClientContext> JoinChannel(
     await AnsiConsole.Status().StartAsync("Joining channel...", async ctx =>
     {
         var room = context.Client.GetGrain<IChannelGrain>(context.CurrentChannel);
-        await room.Join(context.UserName!);
-        var streamId = StreamId.Create("ChatRoom", context.CurrentChannel!);
+        var streamId = await room.Join(context.UserName!);
         var stream =
             context.Client
                 .GetStreamProvider("chat")
@@ -267,8 +266,7 @@ static async Task<ClientContext> LeaveChannel(ClientContext context)
     await AnsiConsole.Status().StartAsync("Leaving channel...", async ctx =>
     {
         var room = context.Client.GetGrain<IChannelGrain>(context.CurrentChannel);
-        await room.Leave(context.UserName!);
-        var streamId = StreamId.Create("ChatRoom", context.CurrentChannel!);
+        var streamId = await room.Leave(context.UserName!);
         var stream =
             context.Client
                 .GetStreamProvider("chat")


### PR DESCRIPTION
## Summary

Change the ChatRoom client sample to use the `streamId` returned by the `IChannelGrain.Join` and `Leave` methods

The [README.md](https://github.com/dotnet/samples/blob/4231a563d5fecdcfaebe8de6d43cef0af859ec90/orleans/ChatRoom/README.md?plain=1#L25) for the ChatRoom sample states that

> Clients connect to the `ChannelGrain` for a channel and then subscribe to the stream identified by the `Guid` returned from the `IChannelGrain.Join` call

The sample currently creates the streamId manually, instead of using the one returned by the Join and Leave methods.