### PR TITLE
Upgrade bank account sample

### DIFF
--- a/orleans/BankAccount/AccountTransfer.Grains/AccountGrain.cs
+++ b/orleans/BankAccount/AccountTransfer.Grains/AccountGrain.cs
@@ -1,14 +1,13 @@
-using AccountTransfer.Interfaces;
+﻿using AccountTransfer.Interfaces;
 using Orleans.Concurrency;
 using Orleans.Transactions.Abstractions;
 
 namespace AccountTransfer.Grains;
 
-[GenerateSerializer]
+[GenerateSerializer, Immutable]
 public record class Balance
 {
-    [Id(0)]
-    public int Value { get; set; } = 1_000;
+    public int Value { get; init; } = 1_000;
 }
 
 [Reentrant]
@@ -22,7 +21,7 @@ public sealed class AccountGrain : Grain, IAccountGrain
 
     public Task Deposit(int amount) =>
         _balance.PerformUpdate(
-            balance => balance.Value += amount);
+            balance => balance with { Value = balance.Value + amount });
 
     public Task Withdraw(int amount) =>
         _balance.PerformUpdate(balance =>
@@ -35,7 +34,7 @@ public sealed class AccountGrain : Grain, IAccountGrain
                     $" This account has {balance.Value} credits.");
             }
 
-            balance.Value -= amount;
+            return balance with { Value = balance.Value + amount };
         });
 
     public Task<int> GetBalance() =>

--- a/orleans/BankAccount/Directory.Build.props
+++ b/orleans/BankAccount/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/orleans/BankAccount/Directory.Packages.props
+++ b/orleans/BankAccount/Directory.Packages.props
@@ -4,12 +4,12 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Orleans.Client" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Orleans.Server" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Orleans.Transactions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Client" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Transactions" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/orleans/BankAccount/README.md
+++ b/orleans/BankAccount/README.md
@@ -89,7 +89,7 @@ public Task Withdraw(uint amount) => _balance.PerformUpdate(x =>
 
 ## Sample prerequisites
 
-This sample is written in C# and targets .NET 7.0. It requires the [.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet/7.0) or later.
+This sample is written in C# and targets .NET 7.0. It requires the [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) or later.
 
 ## Building the sample
 

--- a/orleans/BankAccount/README.md
+++ b/orleans/BankAccount/README.md
@@ -89,7 +89,7 @@ public Task Withdraw(uint amount) => _balance.PerformUpdate(x =>
 
 ## Sample prerequisites
 
-This sample is written in C# and targets .NET 7.0. It requires the [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) or later.
+This sample is written in C# and targets .NET 9.0. It requires the [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) or later.
 
 ## Building the sample
 


### PR DESCRIPTION
Upgrades sample to .NET 9 and shows how to use immutable records instead of mutable ones, which as far as I can tell, is generally recommended.