### PR TITLE
Update Orleans Adventure sample to .net 9

### DIFF
--- a/orleans/Adventure/AdventureGrainInterfaces/IMonsterGrain.cs
+++ b/orleans/Adventure/AdventureGrainInterfaces/IMonsterGrain.cs
@@ -1,13 +1,15 @@
-namespace AdventureGrainInterfaces;
+﻿namespace AdventureGrainInterfaces;
 
 public interface IMonsterGrain : IGrainWithIntegerKey
 {
     // Even monsters have a name
     Task<string?> Name();
+    
     Task SetInfo(MonsterInfo info);
 
     // Monsters are located in exactly one room
     Task SetRoomGrain(IRoomGrain room);
+
     Task<IRoomGrain> RoomGrain();
 
     Task<string> Kill(IRoomGrain room);

--- a/orleans/Adventure/AdventureGrainInterfaces/IPlayerGrain.cs
+++ b/orleans/Adventure/AdventureGrainInterfaces/IPlayerGrain.cs
@@ -1,4 +1,4 @@
-namespace AdventureGrainInterfaces;
+﻿namespace AdventureGrainInterfaces;
 
 /// <summary>
 /// A player is, well, there's really no other good name...
@@ -7,10 +7,12 @@ public interface IPlayerGrain : IGrainWithGuidKey
 {
     // Players have names
     Task<string?> Name();
+
     Task SetName(string name);
 
     // Each player is located in exactly one room
     Task SetRoomGrain(IRoomGrain room);
+    
     Task<IRoomGrain> RoomGrain();
 
     // Until Death comes knocking

--- a/orleans/Adventure/AdventureGrainInterfaces/IRoomGrain.cs
+++ b/orleans/Adventure/AdventureGrainInterfaces/IRoomGrain.cs
@@ -1,4 +1,4 @@
-namespace AdventureGrainInterfaces;
+﻿namespace AdventureGrainInterfaces;
 
 /// <summary>
 /// A room is any location in a game, including outdoor locations and
@@ -8,24 +8,30 @@ public interface IRoomGrain : IGrainWithIntegerKey
 {
     // Rooms have a textual description
     Task<string> Description(PlayerInfo whoisAsking);
+
     Task SetInfo(RoomInfo info);
 
     Task<IRoomGrain?> ExitTo(string direction);
 
     // Players can enter or exit a room
     Task Enter(PlayerInfo player);
+    
     Task Exit(PlayerInfo player);
 
     // Monsters can enter or exit a room
     Task Enter(MonsterInfo monster);
+    
     Task Exit(MonsterInfo monster);
 
     // Things can be dropped or taken from a room
     Task Drop(Thing thing);
+    
     Task Take(Thing thing);
+    
     Task<Thing?> FindThing(string name);
 
     // Players and monsters can be killed, if you have the right weapon.
     Task<PlayerInfo?> FindPlayer(string name);
+
     Task<MonsterInfo?> FindMonster(string name);
 }

--- a/orleans/Adventure/AdventureGrains/MonsterGrain.cs
+++ b/orleans/Adventure/AdventureGrains/MonsterGrain.cs
@@ -61,7 +61,6 @@ public class MonsterGrain : Grain, IMonsterGrain
         }
     }
 
-
     Task<string> IMonsterGrain.Kill(IRoomGrain room)
     {
         if (_roomGrain is not null)

--- a/orleans/Adventure/AdventureGrains/MonsterGrain.cs
+++ b/orleans/Adventure/AdventureGrains/MonsterGrain.cs
@@ -1,24 +1,26 @@
-using AdventureGrainInterfaces;
+﻿using AdventureGrainInterfaces;
 
 namespace AdventureGrains;
 
-public class MonsterGrain : Grain, IMonsterGrain
+public class MonsterGrain : Grain, IMonsterGrain, IDisposable
 {
     private MonsterInfo _monsterInfo = new();
+    private IGrainTimer? _timer;
     private IRoomGrain? _roomGrain; // Current room
 
     public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
         _monsterInfo = _monsterInfo with { Id = this.GetPrimaryKeyLong() };
 
-        RegisterTimer(
+        _timer = this.RegisterGrainTimer(
             _ => Move(),
-            null!,
             TimeSpan.FromSeconds(150),
             TimeSpan.FromMinutes(150));
 
         return base.OnActivateAsync(cancellationToken);
     }
+
+    public void Dispose() => _timer?.Dispose();
 
     Task IMonsterGrain.SetInfo(MonsterInfo info)
     {

--- a/orleans/Adventure/AdventureGrains/PlayerGrain.cs
+++ b/orleans/Adventure/AdventureGrains/PlayerGrain.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Threading;
 using AdventureGrainInterfaces;
 
@@ -6,9 +6,8 @@ namespace AdventureGrains;
 
 public class PlayerGrain : Grain, IPlayerGrain
 {
+    private readonly List<Thing> _things = []; // Things that the player is carrying
     private IRoomGrain? _roomGrain; // Current room
-    private readonly List<Thing> _things = new(); // Things that the player is carrying
-
     private bool _killed = false;
     private PlayerInfo _myInfo = null!;
 
@@ -22,11 +21,10 @@ public class PlayerGrain : Grain, IPlayerGrain
 
     Task<IRoomGrain> IPlayerGrain.RoomGrain() => Task.FromResult(_roomGrain!);
 
-
     async Task IPlayerGrain.Die()
     {
         // Drop everything
-        var dropTasks = new List<Task<string?>>();        
+        var dropTasks = new List<Task<string?>>();
         foreach (var thing in _things.ToArray() /* New collection */)
         {
             dropTasks.Add(Drop(thing));

--- a/orleans/Adventure/AdventureGrains/RoomGrain.cs
+++ b/orleans/Adventure/AdventureGrains/RoomGrain.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using AdventureGrainInterfaces;
 
 namespace AdventureGrains;
@@ -8,14 +8,11 @@ namespace AdventureGrains;
 /// </summary>
 public class RoomGrain : Grain, IRoomGrain
 {
-    // TODO: replace placeholder grain interface with actual grain
-    // communication interface(s).
-
+    private readonly List<PlayerInfo> _players = [];
+    private readonly List<MonsterInfo> _monsters = [];
+    private readonly List<Thing> _things = [];
+    private readonly Dictionary<string, IRoomGrain> _exits = [];
     private string? _description;
-    private readonly List<PlayerInfo> _players = new();
-    private readonly List<MonsterInfo> _monsters = new();
-    private readonly List<Thing> _things = new();
-    private readonly Dictionary<string, IRoomGrain> _exits = new();
 
     Task IRoomGrain.Enter(PlayerInfo player)
     {
@@ -106,15 +103,19 @@ public class RoomGrain : Grain, IRoomGrain
         {
             builder.AppendLine("Beware! These guys are in the room with you:");
             if (others.Length > 0)
+            {
                 foreach (var player in others)
                 {
                     builder.Append("  ").AppendLine(player.Name);
                 }
+            }
             if (_monsters.Count > 0)
+            {
                 foreach (var monster in _monsters)
                 {
                     builder.Append("  ").AppendLine(monster.Name);
                 }
+            }
         }
 
         return Task.FromResult(builder.ToString());

--- a/orleans/Adventure/AdventureServer/Program.cs
+++ b/orleans/Adventure/AdventureServer/Program.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using AdventureSetup;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/orleans/Adventure/Directory.Build.props
+++ b/orleans/Adventure/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/orleans/Adventure/Directory.Packages.props
+++ b/orleans/Adventure/Directory.Packages.props
@@ -4,11 +4,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Orleans.Client" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Orleans.Server" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Client" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/orleans/Adventure/README.md
+++ b/orleans/Adventure/README.md
@@ -34,7 +34,7 @@ This is a simple game and there are only a few verbs which the game understands:
 
 ## Sample prerequisites
 
-This sample is written in C# and targets .NET 7.0. It requires the [.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet/7.0) or later.
+This sample is written in C# and targets .NET 9.0. It requires the [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) or later.
 
 ## Building the sample
 


### PR DESCRIPTION
- Upgrades sample to use .NET 9
- Use RegisterGrainTimer instead of obsolete RegisterTimer
- Normalize whitespace usage