### PR TITLE
Upgrade GPS Tracker to dotnet 9 and add Aspire orchestration

### DIFF
--- a/orleans/GPSTracker/GPSTracker.AppHost/GPSTracker.AppHost.csproj
+++ b/orleans/GPSTracker/GPSTracker.AppHost/GPSTracker.AppHost.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>afde51c8-abcf-4e8d-97a3-fd9301b96ffd</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="9.0.0" />
+    <PackageReference Include="Aspire.Hosting.Orleans" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GPSTracker.FakeDeviceGateway\GPSTracker.FakeDeviceGateway.csproj" />
+    <ProjectReference Include="..\GPSTracker.Service\GPSTracker.Service.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/orleans/GPSTracker/GPSTracker.AppHost/Program.cs
+++ b/orleans/GPSTracker/GPSTracker.AppHost/Program.cs
@@ -1,0 +1,19 @@
+﻿var builder = DistributedApplication.CreateBuilder(args);
+
+// https://learn.microsoft.com/en-us/dotnet/aspire/frameworks/orleans?tabs=dotnet-cli
+var storage = builder.AddAzureStorage("storage")
+    .RunAsEmulator();
+var clusteringTable = storage.AddTables("clustering");
+var orleans = builder.AddOrleans("default")
+    .WithClustering(clusteringTable);
+
+var service = builder.AddProject<Projects.GPSTracker_Service>("gpstracker-service")
+    .WithReference(orleans)
+    .WithReplicas(3);
+
+var deviceGateway = builder.AddProject<Projects.GPSTracker_FakeDeviceGateway>("device-gateway")
+    .WithReference(orleans.AsClient())
+    .WithExternalHttpEndpoints()
+    .WaitFor(service);
+
+builder.Build().Run();

--- a/orleans/GPSTracker/GPSTracker.AppHost/Properties/launchSettings.json
+++ b/orleans/GPSTracker/GPSTracker.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17244;http://localhost:15133",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21285",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22279"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15133",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19294",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20112"
+      }
+    }
+  }
+}

--- a/orleans/GPSTracker/GPSTracker.AppHost/appsettings.Development.json
+++ b/orleans/GPSTracker/GPSTracker.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/orleans/GPSTracker/GPSTracker.AppHost/appsettings.json
+++ b/orleans/GPSTracker/GPSTracker.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/orleans/GPSTracker/GPSTracker.Common/GPSTracker.Common.csproj
+++ b/orleans/GPSTracker/GPSTracker.Common/GPSTracker.Common.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/orleans/GPSTracker/GPSTracker.Common/LoadDriver.cs
+++ b/orleans/GPSTracker/GPSTracker.Common/LoadDriver.cs
@@ -111,7 +111,7 @@ public static class LoadDriver
 
     public static double NextDouble(double min, double max) => Random.NextDouble() * (max - min) + min;
 
-    private class Model
+    private sealed class Model
     {
         public Stopwatch TimeSinceLastUpdate { get; } = Stopwatch.StartNew();
         public int DeviceId { get; set; }

--- a/orleans/GPSTracker/GPSTracker.FakeDeviceGateway/GPSTracker.FakeDeviceGateway.csproj
+++ b/orleans/GPSTracker/GPSTracker.FakeDeviceGateway/GPSTracker.FakeDeviceGateway.csproj
@@ -1,11 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\GPSTracker.Common\GPSTracker.Common.csproj" />
+    <ProjectReference Include="..\GPSTracker.ServiceDefaults\GPSTracker.ServiceDefaults.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Azure.Data.Tables" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/orleans/GPSTracker/GPSTracker.FakeDeviceGateway/Program.cs
+++ b/orleans/GPSTracker/GPSTracker.FakeDeviceGateway/Program.cs
@@ -2,11 +2,12 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-using IHost host = Host.CreateDefaultBuilder(args)
-    .UseOrleansClient((ctx, clientBuilder) => clientBuilder.UseLocalhostClustering())
-    .UseConsoleLifetime()
-    .Build();
+var builder = Host.CreateApplicationBuilder(args);
+builder.AddServiceDefaults();
+builder.AddKeyedAzureTableClient("clustering");
+builder.UseOrleansClient();
 
+using var host = builder.Build();
 await host.StartAsync();
 
 IHostApplicationLifetime lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();

--- a/orleans/GPSTracker/GPSTracker.Service/GPSTracker.Service.csproj
+++ b/orleans/GPSTracker/GPSTracker.Service/GPSTracker.Service.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GPSTracker.Common\GPSTracker.Common.csproj" />
+    <ProjectReference Include="..\GPSTracker.ServiceDefaults\GPSTracker.ServiceDefaults.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Server" Version="8.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
+    <PackageReference Include="Aspire.Azure.Data.Tables" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/orleans/GPSTracker/GPSTracker.Service/Grains/DeviceGrain.cs
+++ b/orleans/GPSTracker/GPSTracker.Service/Grains/DeviceGrain.cs
@@ -7,7 +7,7 @@ namespace GPSTracker.GrainImplementation;
 [Reentrant]
 public class DeviceGrain : Grain, IDeviceGrain
 {
-    private DeviceMessage _lastMessage = null!;
+    private DeviceMessage? _lastMessage;
 
     private readonly IPushNotifierGrain _pushNotifier;
 

--- a/orleans/GPSTracker/GPSTracker.Service/Grains/HubListGrain.cs
+++ b/orleans/GPSTracker/GPSTracker.Service/Grains/HubListGrain.cs
@@ -2,17 +2,11 @@
 
 namespace GPSTracker.GrainImplementation;
 
-public class HubListGrain : Grain, IHubListGrain
+public class HubListGrain(IClusterMembershipService clusterMembershipService) : Grain, IHubListGrain
 {
-    private readonly IClusterMembershipService _clusterMembership;
-    private readonly Dictionary<SiloAddress, IRemoteLocationHub> _hubs = new();
+    private readonly Dictionary<SiloAddress, IRemoteLocationHub> _hubs = [];
     private MembershipVersion _cacheMembershipVersion;
     private List<(SiloAddress Host, IRemoteLocationHub Hub)>? _cache;
-
-    public HubListGrain(IClusterMembershipService clusterMembershipService)
-    {
-        _clusterMembership = clusterMembershipService;
-    }
 
     public ValueTask AddHub(SiloAddress host, IRemoteLocationHub hubReference)
     {
@@ -29,7 +23,7 @@ public class HubListGrain : Grain, IHubListGrain
     private List<(SiloAddress Host, IRemoteLocationHub Hub)> GetCachedHubs()
     {
         // Returns a cached list of hubs if the cache is valid, otherwise builds a list of hubs.
-        ClusterMembershipSnapshot clusterMembers = _clusterMembership.CurrentSnapshot;
+        ClusterMembershipSnapshot clusterMembers = clusterMembershipService.CurrentSnapshot;
         if (_cache is { } && clusterMembers.Version == _cacheMembershipVersion)
         {
             return _cache;

--- a/orleans/GPSTracker/GPSTracker.Service/Grains/IHubListGrain.cs
+++ b/orleans/GPSTracker/GPSTracker.Service/Grains/IHubListGrain.cs
@@ -1,4 +1,4 @@
-using Orleans.Runtime;
+﻿using Orleans.Runtime;
 
 namespace GPSTracker.GrainImplementation;
 
@@ -8,5 +8,6 @@ namespace GPSTracker.GrainImplementation;
 public interface IHubListGrain : IGrainWithGuidKey
 {
     ValueTask AddHub(SiloAddress host, IRemoteLocationHub hubReference);
+
     ValueTask<List<(SiloAddress Host, IRemoteLocationHub Hub)>> GetHubs();
 }

--- a/orleans/GPSTracker/GPSTracker.Service/Grains/RemoteLocationHub.cs
+++ b/orleans/GPSTracker/GPSTracker.Service/Grains/RemoteLocationHub.cs
@@ -6,14 +6,10 @@ namespace GPSTracker;
 /// <summary>
 /// Broadcasts location messages to clients which are connected to the local SignalR hub.
 /// </summary>
-internal sealed class RemoteLocationHub : IRemoteLocationHub
+internal sealed class RemoteLocationHub(IHubContext<LocationHub> hub) : IRemoteLocationHub
 {
-    private readonly IHubContext<LocationHub> _hub;
-
-    public RemoteLocationHub(IHubContext<LocationHub> hub) => _hub = hub;
-
     // Send a message to every client which is connected to the hub
     public ValueTask BroadcastUpdates(VelocityBatch messages) =>
-        new(_hub.Clients.All.SendAsync(
+        new(hub.Clients.All.SendAsync(
             "locationUpdates", messages, CancellationToken.None));
 }

--- a/orleans/GPSTracker/GPSTracker.Service/Program.cs
+++ b/orleans/GPSTracker/GPSTracker.Service/Program.cs
@@ -4,61 +4,25 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using System.Net;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetry()
-    .WithMetrics(metrics =>
-    {
-        metrics
-            .AddPrometheusExporter()
-            .AddMeter("Microsoft.Orleans");
-    })
-    .WithTracing(tracing =>
-    {
-        // Set a service name
-        tracing.SetResourceBuilder(
-            ResourceBuilder.CreateDefault()
-                .AddService(serviceName: "GPSTracker", serviceVersion: "1.0"));
-
-        tracing.AddSource("Microsoft.Orleans.Runtime");
-        tracing.AddSource("Microsoft.Orleans.Application");
-
-        tracing.AddZipkinExporter(zipkin =>
-        {
-            zipkin.Endpoint = new Uri("http://localhost:9411/api/v2/spans");
-        });
-    });
-
-builder.Host.UseOrleans((ctx, siloBuilder) => {
-
-    // In order to support multiple hosts forming a cluster, they must listen on different ports.
-    // Use the --InstanceId X option to launch subsequent hosts.
-    int instanceId = ctx.Configuration.GetValue<int>("InstanceId");
-    siloBuilder.UseLocalhostClustering(
-        siloPort: 11111 + instanceId,
-        gatewayPort: 30000 + instanceId,
-        primarySiloEndpoint: new IPEndPoint(IPAddress.Loopback, 11111));
-
-    siloBuilder.AddActivityPropagation();
-});
-builder.WebHost.UseKestrel((ctx, kestrelOptions) =>
-{
-    // To avoid port conflicts, each Web server must listen on a different port.
-    int instanceId = ctx.Configuration.GetValue<int>("InstanceId");
-    kestrelOptions.ListenLocalhost(5001 + instanceId);
-});
+builder.AddServiceDefaults();
+builder.AddKeyedAzureTableClient("clustering");
+builder.UseOrleans();
 builder.Services.AddHostedService<HubListUpdater>();
 builder.Services.AddSignalR().AddJsonProtocol();
 
-WebApplication app = builder.Build();
+var app = builder.Build();
+
+
 if (app.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();
 }
+
 app.UseStaticFiles();
-app.UseDefaultFiles();
 app.UseRouting();
 app.UseAuthorization();
 app.MapHub<LocationHub>("/locationHub");
-app.MapPrometheusScrapingEndpoint();
-app.Run();
+app.MapDefaultEndpoints();
+await app.RunAsync();

--- a/orleans/GPSTracker/GPSTracker.ServiceDefaults/Extensions.cs
+++ b/orleans/GPSTracker/GPSTracker.ServiceDefaults/Extensions.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation()
+                    .AddMeter("Microsoft.Orleans");
+            })
+            .WithTracing(tracing =>
+            {
+                // Uncomment to see Orleans internal traces. Very noisy.
+                // tracing.AddSource("Microsoft.Orleans.Runtime");
+                tracing.AddSource("Microsoft.Orleans.Application");
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation()
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/orleans/GPSTracker/GPSTracker.ServiceDefaults/GPSTracker.ServiceDefaults.csproj
+++ b/orleans/GPSTracker/GPSTracker.ServiceDefaults/GPSTracker.ServiceDefaults.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
+  </ItemGroup>
+
+</Project>

--- a/orleans/GPSTracker/GPSTracker.sln
+++ b/orleans/GPSTracker/GPSTracker.sln
@@ -21,6 +21,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		screenshot.jpeg = screenshot.jpeg
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GPSTracker.AppHost", "GPSTracker.AppHost\GPSTracker.AppHost.csproj", "{63BE60F4-5F4A-43B9-AB32-E9075AB17437}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GPSTracker.ServiceDefaults", "GPSTracker.ServiceDefaults\GPSTracker.ServiceDefaults.csproj", "{6776EAA8-7997-4C09-8765-5E4DB0AA2BFE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +43,14 @@ Global
 		{B3ECE7C7-E076-4868-B6E1-9AFD16F8FA1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B3ECE7C7-E076-4868-B6E1-9AFD16F8FA1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B3ECE7C7-E076-4868-B6E1-9AFD16F8FA1F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63BE60F4-5F4A-43B9-AB32-E9075AB17437}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63BE60F4-5F4A-43B9-AB32-E9075AB17437}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63BE60F4-5F4A-43B9-AB32-E9075AB17437}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63BE60F4-5F4A-43B9-AB32-E9075AB17437}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6776EAA8-7997-4C09-8765-5E4DB0AA2BFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6776EAA8-7997-4C09-8765-5E4DB0AA2BFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6776EAA8-7997-4C09-8765-5E4DB0AA2BFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6776EAA8-7997-4C09-8765-5E4DB0AA2BFE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/orleans/GPSTracker/README.md
+++ b/orleans/GPSTracker/README.md
@@ -39,7 +39,7 @@ var notifier = GrainFactory.GetGrain<IPushNotifierGrain>(0);
 
 ## Sample prerequisites
 
-This sample is written in C# and targets .NET 8.0. It requires the [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later.
+This sample is written in C# and targets .NET 9.0. It requires the [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) or later.
 
 ## Building the sample
 
@@ -54,42 +54,10 @@ To download and run the sample, follow these steps:
    1. Navigate to the folder that holds the unzipped sample code.
    2. At the command line, type [`dotnet run`](https://docs.microsoft.com/dotnet/core/tools/dotnet-run).
 
-Open three terminal windows. In the first terminal window, run the following at the command prompt:
+## Run the solution
 
-```dotnetcli
-dotnet run --project GPSTracker.Service
+Start the `GPSTracker.AppHost` project in Visual Studio or from the command line:
+
 ```
-
-In the second terminal, launch another instance of the host, specifying that it's the second host by passing an `InstanceId` value as follows:
-
-```dotnetcli
-dotnet run --project GPSTracker.Service -- --InstanceId 1
-```
-
-Now open a web browser to `http://localhost:5001/index.html`. At this point, there will be no points moving around the map.
-
-In the third terminal window, run the following at the command prompt to begin simulating devices:
-
-```dotnetcli
-dotnet run --project GPSTracker.FakeDeviceGateway
-```
-
-Dots will appear on the map in the Web browser and begin moving randomly around the area.
-
-## Orleans observability
-
-If you're interested in observability, this sample includes some optional logging, metrics, and distributed tracing.
-
-```docker
-docker run -p 9090:9090 -v ..\dotnet\samples\GPSTracker\prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus
-```
-
-```docker
-docker run -d --name jaeger -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14268:14268 -p 14250:14250 -p 9411:9411 jaegertracing/all-in-one:1.22
-```
-
-OR zipkin:
-
-```docker
-docker run -p 9411:9411 openzipkin/zipkin
+dotnet run --project GPSTracker.AppHost
 ```


### PR DESCRIPTION
This upgrades the sample to dotnet 9 and adds Aspire orchestration. 

However, we may want to use something else than the Aspire dashboard to view the telemetry, as it runs into problems due to the amount of telemetry being produced.

Currently crashes with this error:

```
fail: Aspire.Hosting.Dashboard.Grpc.AspNetCore.Server.ServerCallHandler[6]
      Error when executing service method 'Export'.
      Google.Protobuf.InvalidProtocolBufferException: While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length.
         at Google.Protobuf.SegmentedBufferHelper.RefillFromReadOnlySequence(ReadOnlySpan`1& buffer, ParserInternalState& state, Boolean mustSucceed)
         at Google.Protobuf.ParsingPrimitives.ParseRawVarint32SlowPath(ReadOnlySpan`1& buffer, ParserInternalState& state)
         at OpenTelemetry.Proto.Trace.V1.Status.pb::Google.Protobuf.IBufferMessage.InternalMergeFrom(ParseContext& input) in /_/artifacts/obj/Aspire.Dashboard/win-x64/Release/net8.0/win-x64/opentelemetry/proto/trace/v1/Trace.cs:line 2612
         at Google.Protobuf.ParsingPrimitivesMessages.ReadMessage(ParseContext& ctx, IMessage message)
         at OpenTelemetry.Proto.Trace.V1.Span.pb::Google.Protobuf.IBufferMessage.InternalMergeFrom(ParseContext& input) in /_/artifacts/obj/Aspire.Dashboard/win-x64/Release/net8.0/win-x64/opentelemetry/proto/trace/v1/Trace.cs:line 1642
         at Google.Protobuf.ParsingPrimitivesMessages.ReadMessage(ParseContext& ctx, IMessage message)
         at Google.Protobuf.Collections.RepeatedField`1.AddEntriesFrom(ParseContext& ctx, FieldCodec`1 codec)
         at OpenTelemetry.Proto.Trace.V1.ScopeSpans.pb::Google.Protobuf.IBufferMessage.InternalMergeFrom(ParseContext& input) in /_/artifacts/obj/Aspire.Dashboard/win-x64/Release/net8.0/win-x64/opentelemetry/proto/trace/v1/Trace.cs:line 844
         at Google.Protobuf.ParsingPrimitivesMessages.ReadMessage(ParseContext& ctx, IMessage message)
         at Google.Protobuf.Collections.RepeatedField`1.AddEntriesFrom(ParseContext& ctx, FieldCodec`1 codec)
         at OpenTelemetry.Proto.Trace.V1.ResourceSpans.pb::Google.Protobuf.IBufferMessage.InternalMergeFrom(ParseContext& input) in /_/artifacts/obj/Aspire.Dashboard/win-x64/Release/net8.0/win-x64/opentelemetry/proto/trace/v1/Trace.cs:line 560
         at Google.Protobuf.ParsingPrimitivesMessages.ReadMessage(ParseContext& ctx, IMessage message)
         at Google.Protobuf.Collections.RepeatedField`1.AddEntriesFrom(ParseContext& ctx, FieldCodec`1 codec)
         at OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.pb::Google.Protobuf.IBufferMessage.InternalMergeFrom(ParseContext& input) in /_/artifacts/obj/Aspire.Dashboard/win-x64/Release/net8.0/win-x64/opentelemetry/proto/collector/trace/v1/TraceService.cs:line 241
         at Google.Protobuf.MessageExtensions.MergeFrom(IMessage message, ReadOnlySequence`1 data, Boolean discardUnknownFields, ExtensionRegistry registry)
         at Google.Protobuf.MessageParser`1.ParseFrom(ReadOnlySequence`1 data)
         at OpenTelemetry.Proto.Collector.Trace.V1.TraceService.__Helper_DeserializeMessage[T](DeserializationContext context, MessageParser`1 parser) in /_/artifacts/obj/Aspire.Dashboard/win-x64/Release/net8.0/win-x64/opentelemetry/proto/collector/trace/v1/TraceServiceGrpc.cs:line 62
         at OpenTelemetry.Proto.Collector.Trace.V1.TraceService.<>c.<.cctor>b__13_0(DeserializationContext context) in /_/artifacts/obj/Aspire.Dashboard/win-x64/Release/net8.0/win-x64/opentelemetry/proto/collector/trace/v1/TraceServiceGrpc.cs:line 69
         at Grpc.AspNetCore.Server.Internal.PipeExtensions.ReadSingleMessageAsync[T](PipeReader input, HttpContextServerCallContext serverCallContext, Func`2 deserializer)
         at Grpc.AspNetCore.Server.Internal.CallHandlers.UnaryServerCallHandler`3.HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext)
         at Grpc.AspNetCore.Server.Internal.CallHandlers.ServerCallHandlerBase`3.<HandleCallAsync>g__AwaitHandleCall|8_0(HttpContextServerCallContext serverCallContext, Method`2 method, Task handleCall)
```

Granted, I may have made a mistake in the upgrade, but I cannot see where. @IEvangelist can you figure out what is going on here.
