### PR TITLE
ComWrappersGeneration fix for PublishAOT with DNNE

### DIFF
--- a/core/interop/source-generation/ComWrappersGeneration/README.md
+++ b/core/interop/source-generation/ComWrappersGeneration/README.md
@@ -25,11 +25,11 @@ This sample supports NativeAOT and standard CoreCLR deployments. The native meth
 
 ### NativeAOT
 
-Build the Native AOT binaries by running `dotnet publish -r <RID>` where `<RID>` is the RuntimeIdentifier for your OS, for example `win-x64`. The projects will copy the binaries to the `OutputFiles\` directory. After publishing, use `regsvr32.exe` to register `Server.dll` with COM by running run `regsvr32.exe .\OutputFiles\Server\Server.dll`. Then, run the client application `.\OutputFiles\Client\Client.exe` and observe the output as it activates and uses a COM instance from `Server.dll`. When you are finished, unregister the server by running `regsvr32.exe .\OutputFiles\Server\Server.dll`.
+Build the Native AOT binaries by running `dotnet publish -r <RID>` where `<RID>` is the RuntimeIdentifier for your OS, for example `win-x64`. The projects will copy the binaries to the `OutputFiles\` directory. After publishing, use `regsvr32.exe` to register `Server.dll` with COM by running run `regsvr32.exe .\OutputFiles\Server\Server.dll`. Then, run the client application `.\OutputFiles\Client\Client.exe` and observe the output as it activates and uses a COM instance from `Server.dll`. When you are finished, unregister the server by running `regsvr32.exe /u .\OutputFiles\Server\Server.dll`.
 
 ### CoreCLR
 
-Build the projects by running `dotnet publish`. The projects will copy the binaries to the `OutputFiles\` directory. After publishing, use `regsvr32.exe` to register the native binary produced by DNNE, `ServerNE.dll` by running `regsvr32.exe .\OutputFiles\Server\ServerNE.dll`. `ServerNE.dll` will start the .NET runtime and call the exported methods in the managed `Server.dll` which register the server with COM. Then, run the client application `.\OutputFiles\Client\Client.exe` and observe the output as it activates and uses a COM instance from `ServerNE.dll`. When you are finished, unregister the server by running `regsvr32.exe .\OutputFiles\Server\ServerNE.dll`.
+Build the projects by running `dotnet publish`. The projects will copy the binaries to the `OutputFiles\` directory. After publishing, use `regsvr32.exe` to register the native binary produced by DNNE, `ServerNE.dll`, by running `regsvr32.exe .\OutputFiles\Server\ServerNE.dll`. `ServerNE.dll` will start the .NET runtime and call the exported methods in the managed `Server.dll` which register the server with COM. Then, run the client application `.\OutputFiles\Client\Client.exe` and observe the output as it activates and uses a COM instance from `ServerNE.dll`. When you are finished, unregister the server by running `regsvr32.exe /u .\OutputFiles\Server\ServerNE.dll`.
 
 ## See also
 

--- a/core/interop/source-generation/ComWrappersGeneration/README.md
+++ b/core/interop/source-generation/ComWrappersGeneration/README.md
@@ -25,11 +25,11 @@ This sample supports NativeAOT and standard CoreCLR deployments. The native meth
 
 ### NativeAOT
 
-Build the Native AOT binaries by running `dotnet publish -r <RID>` where `<RID>` is the RuntimeIdentifier for your OS, for example `win-x64`. The projects will copy the binaries to the `OutputFiles\` directory. After publishing, use `regsvr32.exe` to register `Server.dll` with COM by running run `regsvr.exe .\OutputFiles\Server\Server.dll`. Then, run the client application `.\OutputFiles\Client\Client.exe` and observe the output as it activates and uses a COM instance from `Server.dll`.
+Build the Native AOT binaries by running `dotnet publish -r <RID>` where `<RID>` is the RuntimeIdentifier for your OS, for example `win-x64`. The projects will copy the binaries to the `OutputFiles\` directory. After publishing, use `regsvr32.exe` to register `Server.dll` with COM by running run `regsvr32.exe .\OutputFiles\Server\Server.dll`. Then, run the client application `.\OutputFiles\Client\Client.exe` and observe the output as it activates and uses a COM instance from `Server.dll`. When you are finished, unregister the server by running `regsvr32.exe .\OutputFiles\Server\Server.dll`.
 
 ### CoreCLR
 
-Build the projects by running `dotnet publish`. The projects will copy the binaries to the `OutputFiles\` directory. After publishing, use `regsvr32.exe` to register the native binary produced by DNNE, `ServerNE.dll` by running `regsvr.exe .\OutputFiles\Server\ServerNE.dll`. `ServerNE.dll` will start the .NET runtime and call the exported methods in the managed `Server.dll` which register the server with COM. Then, run the client application `.\OutputFiles\Client\Client.exe` and observe the output as it activates and uses a COM instance from `ServerNE.dll`.
+Build the projects by running `dotnet publish`. The projects will copy the binaries to the `OutputFiles\` directory. After publishing, use `regsvr32.exe` to register the native binary produced by DNNE, `ServerNE.dll` by running `regsvr32.exe .\OutputFiles\Server\ServerNE.dll`. `ServerNE.dll` will start the .NET runtime and call the exported methods in the managed `Server.dll` which register the server with COM. Then, run the client application `.\OutputFiles\Client\Client.exe` and observe the output as it activates and uses a COM instance from `ServerNE.dll`. When you are finished, unregister the server by running `regsvr32.exe .\OutputFiles\Server\ServerNE.dll`.
 
 ## See also
 

--- a/core/interop/source-generation/ComWrappersGeneration/Server/Server.csproj
+++ b/core/interop/source-generation/ComWrappersGeneration/Server/Server.csproj
@@ -17,8 +17,12 @@
     <DnneWindowsExportsDef>Server.def</DnneWindowsExportsDef>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(PublishAOT)' == 'true'">
+    <DnneBuildExports>false</DnneBuildExports>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="DNNE" Version="2.0.7" Condition="'$(PublishAOT)' != 'true'"/>
+    <PackageReference Include="DNNE" Version="2.0.7" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <!-- When publishing AOT, use our own .def file to export the COM methods as PRIVATE. The Windows native linker (Link.exe) warns when exported COM methods are not PRIVATE. -->
     <LinkerArg Include="/DEF:&quot;Server.def&quot;" Condition="'$(PublishAOT)' == 'true'"/>

--- a/core/interop/source-generation/ComWrappersGeneration/Server/Server.csproj
+++ b/core/interop/source-generation/ComWrappersGeneration/Server/Server.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <!-- Uncomment to publish as a native executable -->
+    <!-- Uncomment to publish the project as a single native .dll -->
     <!-- <PublishAOT>true</PublishAOT> -->
   </PropertyGroup>
 
@@ -15,9 +15,12 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <!-- Use our own .def file to export the COM methods as PRIVATE. The Windows native linker (Link.exe) warns when exported COM methods are not PRIVATE. -->
     <DnneWindowsExportsDef>Server.def</DnneWindowsExportsDef>
+    <!-- Copy DNNE .dll and header files to the output directory -->
+    <DnneAddGeneratedBinaryToProject>true</DnneAddGeneratedBinaryToProject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishAOT)' == 'true'">
+    <!-- Don't build the DNNE .dll when publishing a native .dll with Native AOT. -->
     <DnneBuildExports>false</DnneBuildExports>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Use DNNE package when publishing AOT, but don't build the native binary. Add instructions to unregister server after demo.

Fixes https://github.com/dotnet/samples/issues/7047
