### PR TITLE
Adjust the samples code so that it matches the refactored tutorial

### DIFF
--- a/csharp/getting-started/console-webapiclient/Program.cs
+++ b/csharp/getting-started/console-webapiclient/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Headers;
-using System.Text.Json;
+using System.Net.Http.Json;
 
 using HttpClient client = new();
 client.DefaultRequestHeaders.Accept.Clear();
@@ -22,9 +22,6 @@ foreach (var repo in repositories)
 
 static async Task<List<Repository>> ProcessRepositoriesAsync(HttpClient client)
 {
-    await using Stream stream =
-        await client.GetStreamAsync("https://api.github.com/orgs/dotnet/repos");
-    var repositories =
-        await JsonSerializer.DeserializeAsync<List<Repository>>(stream);
-    return repositories ?? new();
+    var repositories = await client.GetFromJsonAsync<List<Repository>>("https://api.github.com/orgs/dotnet/repos");
+    return repositories ?? new List<Repository>();
 }

--- a/csharp/getting-started/console-webapiclient/Repository.cs
+++ b/csharp/getting-started/console-webapiclient/Repository.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Text.Json.Serialization;
-
-public sealed record class Repository(
-    [property: JsonPropertyName("name")] string Name,
-    [property: JsonPropertyName("description")] string Description,
-    [property: JsonPropertyName("html_url")] Uri GitHubHomeUrl,
-    [property: JsonPropertyName("homepage")] Uri Homepage,
-    [property: JsonPropertyName("watchers")] int Watchers,
-    [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc)
+﻿public record class Repository(
+    string Name,
+    string Description,
+    Uri GitHubHomeUrl,
+    Uri Homepage,
+    int Watchers,
+    DateTime LastPushUtc
+)
 {
     public DateTime LastPush => LastPushUtc.ToLocalTime();
 }

--- a/csharp/getting-started/console-webapiclient/webapiclient.csproj
+++ b/csharp/getting-started/console-webapiclient/webapiclient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
This pull request is the follow-up to the https://github.com/dotnet/docs/pull/48202 PR that makes the project now use `GetFromJsonAsync` instead of `DeserializeAsync`.
To keep the code up-to-date this PR also makes sure that the new version of .NET is used instead of old v6.

For more info please check the mentioned PR to docs repository.