### PR TITLE
Adjust sample code to match fixed tutorial

### DIFF
--- a/csharp/getting-started/console-webapiclient/Repository.cs
+++ b/csharp/getting-started/console-webapiclient/Repository.cs
@@ -1,10 +1,12 @@
-﻿public record class Repository(
+﻿using System.Text.Json.Serialization;
+
+public record class Repository(
     string Name,
     string Description,
-    Uri GitHubHomeUrl,
+    [property: JsonPropertyName("html_url")] Uri GitHubHomeUrl,
     Uri Homepage,
     int Watchers,
-    DateTime LastPushUtc
+    [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc
 )
 {
     public DateTime LastPush => LastPushUtc.ToLocalTime();


### PR DESCRIPTION
## Summary

- This PR adjusts the finished sample code of the C# `REST Client` tutorial to match the fix in dotnet/docs#49442.

Fixes dotnet/docs#49387
