### PR TITLE
Fix race condition in Orleans shopping cart inventory

### DIFF
--- a/orleans/ShoppingCart/Grains/InventoryGrain.cs
+++ b/orleans/ShoppingCart/Grains/InventoryGrain.cs
@@ -40,7 +40,7 @@ public sealed class InventoryGrain(
             return;
         }
 
-        object lockObject = new();
+        Lock lockObject = new();
         await Parallel.ForEachAsync(
             state.State,
             async (id, _) =>

--- a/orleans/ShoppingCart/Grains/InventoryGrain.cs
+++ b/orleans/ShoppingCart/Grains/InventoryGrain.cs
@@ -40,12 +40,17 @@ public sealed class InventoryGrain(
             return;
         }
 
+        object lockObject = new();
         await Parallel.ForEachAsync(
             state.State,
             async (id, _) =>
             {
                 var productGrain = GrainFactory.GetGrain<IProductGrain>(id);
-                _productCache[id] = await productGrain.GetProductDetailsAsync();
+                var productDetails = await productGrain.GetProductDetailsAsync();
+                lock (lockObject)
+                {
+                    _productCache[id] = productDetails;
+                }
             });
     }
 }


### PR DESCRIPTION
## Summary

A dictionary gets filled in a parallel for loop without protection, so I added locking.

Fixes #7121
