### PR TITLE
Fix state inconsistency in Orleans Chirper account

### DIFF
--- a/orleans/Chirper/Chirper.Grains/ChirperAccount.cs
+++ b/orleans/Chirper/Chirper.Grains/ChirperAccount.cs
@@ -3,10 +3,11 @@ using Chirper.Grains.Models;
 using Microsoft.Extensions.Logging;
 using Orleans.Concurrency;
 using Orleans.Runtime;
+using Orleans.Serialization.Invocation;
 
 namespace Chirper.Grains;
 
-[Reentrant]
+[MayInterleave(nameof(WontFollowAndUnfollowSimultaneously))]
 public sealed class ChirperAccount : Grain, IChirperAccount
 {
     /// <summary>
@@ -47,6 +48,9 @@ public sealed class ChirperAccount : Grain, IChirperAccount
 
     private static string GrainType => nameof(ChirperAccount);
     private string GrainKey => this.GetPrimaryKeyString();
+
+    public static bool WontFollowAndUnfollowSimultaneously(IInvokable request) =>
+        request.GetMethodName() is not (nameof(FollowUserIdAsync) or nameof(UnfollowUserIdAsync));
 
     public override Task OnActivateAsync(CancellationToken _)
     {


### PR DESCRIPTION
## Summary

Disabled reentrancy/interleaving for `FollowUserIdAsync`‎ and `UnfollowUserIdAsync`. Interleaving can cause 2 problems if both methods get called with the same username on the same grain:
1. If a user gets followed, but between the remote and local update, he gets unfollowed, the local state says the user is followed, but the remote state says the user is not followed. Same vice versa.
2. The follow and unfollow commands may arrive on the other grain in reverse of sending order, causing the same inconsistencies.

Fixes #7124 