### PR TITLE
Add NUnit testing samples

### DIFF
--- a/test/nunit/microsoft-testing-platform/CalculatorTests.cs
+++ b/test/nunit/microsoft-testing-platform/CalculatorTests.cs
@@ -1,0 +1,12 @@
+﻿namespace NUnitMTP;
+
+public sealed class CalculatorTests
+{
+    [Test]
+    public void Add_TwoNumbers_ReturnsExpectedSum()
+    {
+        int result = 2 + 3;
+
+        Assert.That(result, Is.EqualTo(5));
+    }
+}

--- a/test/nunit/microsoft-testing-platform/NUnitMTP.csproj
+++ b/test/nunit/microsoft-testing-platform/NUnitMTP.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/test/nunit/vstest/CalculatorTests.cs
+++ b/test/nunit/vstest/CalculatorTests.cs
@@ -1,0 +1,12 @@
+﻿namespace NUnitVSTest;
+
+public sealed class CalculatorTests
+{
+    [Test]
+    public void Add_TwoNumbers_ReturnsExpectedSum()
+    {
+        int result = 2 + 3;
+
+        Assert.That(result, Is.EqualTo(5));
+    }
+}

--- a/test/nunit/vstest/NUnitVSTest.csproj
+++ b/test/nunit/vstest/NUnitVSTest.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds NUnit testing samples for issue #7079.

This PR includes two minimal NUnit examples:

- NUnit with VSTest
- NUnit with Microsoft.Testing.Platform

Both samples use the same test so that the configuration differences between the two test platforms are easy to compare.

## Included samples

- `test/nunit/vstest`
- `test/nunit/microsoft-testing-platform`

## Validation

The VSTest sample was tested with:

```bash
dotnet test test/nunit/vstest/NUnitVSTest.csproj
```

The Microsoft.Testing.Platform sample was tested with:

```bash
dotnet test test/nunit/microsoft-testing-platform/NUnitMTP.csproj
dotnet run --project test/nunit/microsoft-testing-platform/NUnitMTP.csproj
```

All tests pass successfully.

This is the second part of #7079. xUnit.net samples can follow in a separate pull request.

Related to #7079